### PR TITLE
[Proposal] Default `base_url` when not explicitly overidden.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,8 +1,5 @@
 use Mix.Config
 
-config :swoosh, :sendgrid,
-  base_url: "https://api.sendgrid.com/api/"
-
 if Mix.env == :test do
   import_config "test.exs"
 end

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -6,9 +6,10 @@ defmodule Swoosh.Adapters.Sendgrid do
 
   @api_key Application.get_env(:swoosh, :sendgrid)[:api_key]
   @api_endpoint "mail.send.json"
+  @base_url "https://api.sendgrid.com/api/"
 
   def base_url() do
-    Application.get_env(:swoosh, :sendgrid)[:base_url]
+    Application.get_env(:swoosh, :sendgrid)[:base_url] || @base_url
   end
 
   def deliver(%Swoosh.Email{} = email) do


### PR DESCRIPTION
It strikes me that the `base_url` for APIs is very unlikely to change, and if it does, it probably does rarely and along with potential breaking changes.  To that end it seems sensible not to bother asking users to define/set it, but to allow it to be overridden.

Thoughts?
