### PR TITLE
SMTP adapter

### DIFF
--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -1,6 +1,88 @@
 defmodule Swoosh.Adapters.SMTP do
+  alias Swoosh.Email
+
   @behaviour Swoosh.Adapter
 
-  def deliver(%Swoosh.Email{} = email) do
+  def deliver(%Swoosh.Email{} = email, config) do
+    {_from_name, from_address} = email.from
+    recipients = recipients(email)
+    {type, subtype, headers, parts} = prepare_message(email)
+    body = :mimemail.encode({type, subtype, headers, [], parts})
+    case :gen_smtp_client.send_blocking({from_address, recipients, body}, config) do
+      receipt when is_binary(receipt) -> {:ok, receipt}
+      {:error, type, message} -> {:error, {type, message}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp recipients(email) do
+    Enum.concat([email.to, email.cc, email.bcc])
+    |> Enum.map(fn {_name, address} -> address end)
+    |> Enum.uniq
+  end
+
+  @doc false
+  def prepare_message(email) do
+    prepare_headers(email)
+    |> prepare_parts(email)
+  end
+
+  defp prepare_headers(%Email{} = email) do
+    []
+    |> prepare_mime_version
+    |> prepare_subject(email)
+    |> prepare_cc(email)
+    |> prepare_to(email)
+    |> prepare_from(email)
+  end
+
+  defp prepare_subject(_headers, %Email{subject: nil}), do: raise ArgumentError, message: "`subject` can't be nil"
+  defp prepare_subject(headers, %Email{subject: subject}), do: [{"Subject", subject} | headers]
+
+  defp prepare_from(_headers, %Email{from: nil}), do: raise ArgumentError, message: "`from` can't be nil"
+  defp prepare_from(_headers, %Email{from: {_name, nil}}), do: raise ArgumentError, message: "`from` address can't be nil"
+  defp prepare_from(headers, %Email{from: from}), do: [{"From", prepare_recipient(from)} | headers]
+
+  defp prepare_to(_headers, %Email{to: []}), do: raise ArgumentError, message: "`to` can't be empty"
+  defp prepare_to(headers, %Email{to: to}), do: [{"To", "#{prepare_recipients(to)}"} | headers]
+
+  defp prepare_cc(headers, %Email{cc: []}), do: headers
+  defp prepare_cc(headers, %Email{cc: cc}), do: [{"Cc", "#{prepare_recipients(cc)}"} | headers]
+
+  defp prepare_mime_version(headers), do: [{"Mime-Version", "1.0"} | headers]
+
+  defp prepare_recipients(recipients) do
+    recipients
+    |> Enum.map(&prepare_recipient(&1))
+    |> Enum.join(", ")
+  end
+
+  defp prepare_recipient({nil, address}), do: address
+  defp prepare_recipient({"", address}), do: address
+  defp prepare_recipient({name, address}), do: "#{name} <#{address}>"
+
+  defp prepare_parts(headers, %Email{html_body: nil, text_body: text_body}) do
+    headers = [{"Content-Type", "text/plain; charset=\"utf-8\""} | headers]
+    {"text", "plain", headers, text_body}
+  end
+  defp prepare_parts(headers, %Email{html_body: html_body, text_body: nil}) do
+    headers = [{"Content-Type", "text/html; charset=\"utf-8\""} | headers]
+    {"text", "html", headers, html_body}
+  end
+  defp prepare_parts(headers, %Email{html_body: html_body, text_body: text_body}) do
+    parts = [prepare_part(:plain, text_body), prepare_part(:html, html_body)]
+    {"multipart", "alternative", headers, parts}
+  end
+
+  defp prepare_part(subtype, content) do
+    subtype_string = to_string(subtype)
+    {"text",
+     subtype_string,
+     [{"Content-Type", "text/#{subtype_string}; charset=\"utf-8\""},
+      {"Content-Transfer-Encoding", "quoted-printable"}],
+     [{"content-type-params", [{"charset", "utf-8"}]},
+      {"disposition", "inline"},
+      {"disposition-params",[]}],
+     content}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Swoosh.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison],
+    [applications: [:logger, :httpoison, :gen_smtp],
      mod: {Swoosh.Application, []}]
   end
 
@@ -28,6 +28,7 @@ defmodule Swoosh.Mixfile do
   defp deps do
     [{:httpoison, "~> 0.8"},
      {:poison, "~> 2.1"},
+     {:gen_smtp, "~> 0.9.0"},
      {:phoenix, "~> 1.1", only: [:test]},
      {:phoenix_html, "~> 2.2", only: [:test]},
      {:bypass, "~> 0.5", only: [:test]}]

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "certifi": {:hex, :certifi, "0.3.0"},
   "cowboy": {:hex, :cowboy, "1.0.4"},
   "cowlib": {:hex, :cowlib, "1.0.2"},
+  "gen_smtp": {:hex, :gen_smtp, "0.9.0"},
   "hackney": {:hex, :hackney, "1.4.10"},
   "httpoison": {:hex, :httpoison, "0.8.1"},
   "idna": {:hex, :idna, "1.1.0"},

--- a/test/swoosh/adapters/smtp_test.exs
+++ b/test/swoosh/adapters/smtp_test.exs
@@ -1,3 +1,95 @@
 defmodule Swoosh.Adapters.SMTPTest do
-  use ExUnit.Case, async: true
+  use AdapterCase, async: true
+
+  import Swoosh.Email
+  alias Swoosh.Adapters.SMTP
+
+  setup_all do
+    valid_email =
+    %Swoosh.Email{}
+    |> from("tony@stark.com")
+    |> to("steve@rogers.com")
+    |> subject("Hello, Avengers!")
+    |> html_body("<h1>Hello</h1>")
+    |> text_body("Hello")
+
+    {:ok, valid_email: valid_email}
+  end
+
+  test "simple email", %{valid_email: email} do
+    email = email |> html_body(nil)
+    assert SMTP.prepare_message(email) ==
+    {"text", "plain",
+      [{"Content-Type", "text/plain; charset=\"utf-8\""},
+        {"From", "tony@stark.com"},
+        {"To", "steve@rogers.com"},
+        {"Subject", "Hello, Avengers!"},
+        {"Mime-Version", "1.0"}],
+      "Hello"}
+  end
+
+  test "simple email with multiple recipients", %{valid_email: email} do
+    email = email |> html_body(nil) |> to({"Bruce Banner", "bruce@banner.com"})
+    assert SMTP.prepare_message(email) ==
+    {"text", "plain",
+      [{"Content-Type", "text/plain; charset=\"utf-8\""},
+        {"From", "tony@stark.com"},
+        {"To", "Bruce Banner <bruce@banner.com>, steve@rogers.com"},
+        {"Subject", "Hello, Avengers!"},
+        {"Mime-Version", "1.0"}],
+      "Hello"}
+  end
+
+  test "simple email with multiple cc recipients", %{valid_email: email} do
+    email =
+    email
+    |> html_body(nil)
+    |> to({"Bruce Banner", "bruce@banner.com"})
+    |> cc("thor@odinson.com")
+
+    assert SMTP.prepare_message(email) ==
+      {"text", "plain",
+       [{"Content-Type", "text/plain; charset=\"utf-8\""},
+        {"From", "tony@stark.com"},
+        {"To", "Bruce Banner <bruce@banner.com>, steve@rogers.com"},
+        {"Cc", "thor@odinson.com"},
+        {"Subject", "Hello, Avengers!"},
+        {"Mime-Version", "1.0"}],
+       "Hello"}
+  end
+
+  test "simple html email", %{valid_email: email} do
+    email = email |> text_body(nil)
+    assert SMTP.prepare_message(email) ==
+      {"text", "html",
+       [{"Content-Type", "text/html; charset=\"utf-8\""},
+        {"From", "tony@stark.com"},
+        {"To", "steve@rogers.com"},
+        {"Subject", "Hello, Avengers!"},
+        {"Mime-Version", "1.0"}],
+      "<h1>Hello</h1>"}
+  end
+
+  test "multipart/alternative email", %{valid_email: email} do
+    assert SMTP.prepare_message(email) ==
+      {"multipart", "alternative",
+       [{"From", "tony@stark.com"},
+        {"To", "steve@rogers.com"},
+        {"Subject", "Hello, Avengers!"},
+        {"Mime-Version", "1.0"}],
+       [{"text", "plain",
+         [{"Content-Type", "text/plain; charset=\"utf-8\""},
+          {"Content-Transfer-Encoding", "quoted-printable"}],
+         [{"content-type-params", [{"charset", "utf-8"}]},
+          {"disposition", "inline"},
+          {"disposition-params", []}],
+         "Hello"},
+        {"text", "html",
+         [{"Content-Type", "text/html; charset=\"utf-8\""},
+          {"Content-Transfer-Encoding", "quoted-printable"}],
+         [{"content-type-params", [{"charset", "utf-8"}]},
+          {"disposition", "inline"},
+          {"disposition-params", []}],
+        "<h1>Hello</h1>"}]}
+  end
 end


### PR DESCRIPTION
This is the first version of an SMTP adapter backed by gen_stmp.
It only supports text/plain, text/html, and multipart/alternative parts
with limited support for configuring the Content-Type,
Content-Transfer-Encoding of each individual parts.

There is also no support for attachments since Swoosh doesn't support it
yet.

The testing is not as good as I would like it to be, ideally I would
want to test whatever the mimemail modules returns (the string that will
be sent to the server), rather than the tuple I'm generating.

Fixes #9 
