### PR TITLE
Make config specific to a mailer

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,10 +1,2 @@
 use Mix.Config
 
-config :swoosh, :sendgrid,
-  api_key: "SG.x.x.x"
-
-config :swoosh, :mailgun,
-  api_key: "key-90210"
-
-config :swoosh, :mandrill,
-  api_key: "jarvis"

--- a/lib/swoosh/adapter.ex
+++ b/lib/swoosh/adapter.ex
@@ -1,3 +1,5 @@
 defmodule Swoosh.Adapter do
-  @callback deliver(%Swoosh.Email{}) :: any
+  @typep config :: Keyword.t
+
+  @callback deliver(%Swoosh.Email{}, config) :: :ok | {:ok, term} | {:error, term}
 end

--- a/lib/swoosh/adapters/local.ex
+++ b/lib/swoosh/adapters/local.ex
@@ -1,7 +1,7 @@
 defmodule Swoosh.Adapters.Local do
   @behaviour Swoosh.Adapter
 
-  def deliver(%Swoosh.Email{} = email) do
+  def deliver(%Swoosh.Email{} = email, _config) do
     :ok = Swoosh.InMemoryMailbox.push(email)
   end
 end

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -4,21 +4,18 @@ defmodule Swoosh.Adapters.Sendgrid do
 
   @behaviour Swoosh.Adapter
 
-  @base_url "https://api.sendgrid.com/api/"
-  @api_key Application.get_env(:swoosh, :sendgrid)[:api_key]
-  @api_endpoint "mail.send.json"
+  @base_url "https://api.sendgrid.com/api"
+  @api_endpoint "/mail.send.json"
 
-  def base_url() do
-    Application.get_env(:swoosh, :sendgrid)[:base_url] || @base_url
-  end
+  def base_url(config \\ []), do: config[:base_url] || @base_url
 
-  def deliver(%Email{} = email) do
+  def deliver(%Email{} = email, config \\ []) do
     headers = [{"Content-Type", "application/x-www-form-urlencoded"},
                {"User-Agent", "swoosh/#{Swoosh.version}"},
-               {"Authorization", "Bearer #{@api_key}"}]
+               {"Authorization", "Bearer #{config[:api_key]}"}]
     body = prepare_body(email) |> Plug.Conn.Query.encode
 
-    case HTTPoison.post(base_url() <> @api_endpoint, body, headers) do
+    case HTTPoison.post(base_url(config) <> @api_endpoint, body, headers) do
       {:ok, %Response{status_code: code}} when code >= 200 and code <= 299 ->
         :ok
       {:ok, %Response{status_code: code, body: body}} when code >= 400 and code <= 499 ->

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -18,7 +18,7 @@ defmodule Swoosh.Mailer do
         raise ArgumentError, "expected \"html_body\" or \"text_body\" to be set"
       end
       def deliver(%Swoosh.Email{} = email) do
-        @adapter.deliver(email)
+        @adapter.deliver(email, @config)
       end
       def deliver(email) do
         raise ArgumentError, "expected %Swoosh.Email{}, got #{inspect email}"

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -6,7 +6,8 @@ defmodule Swoosh.Adapters.MailgunTest do
 
   setup_all do
     bypass = Bypass.open
-    Application.put_env(:swoosh, :mailgun, %{base_url: "http://localhost:#{bypass.port}"})
+    config = [base_url: "http://localhost:#{bypass.port}",
+              domain: "/avengers.com"]
 
     valid_email =
       %Swoosh.Email{}
@@ -15,12 +16,10 @@ defmodule Swoosh.Adapters.MailgunTest do
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
 
-    config = [domain: "/sandboxac405b2c12824f69b7cea45fb8cb6e10.mailgun.org"]
-
     {:ok, bypass: bypass, valid_email: valid_email, config: config}
   end
 
-  test "a sent email results in :ok", %{bypass: bypass, valid_email: email, config: config} do
+  test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
       expected_path = config[:domain] <> "/messages"
@@ -37,7 +36,7 @@ defmodule Swoosh.Adapters.MailgunTest do
     assert Mailgun.deliver(email, config) == :ok
   end
 
-  test "delivery/1 with 4xx response", %{bypass: bypass, valid_email: email, config: config} do
+  test "delivery/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       Plug.Conn.resp(conn, 401, "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}")
     end

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -6,11 +6,8 @@ defmodule Swoosh.Adapters.MandrillTest do
 
   setup_all do
     bypass = Bypass.open
-
-    env =
-      Application.get_env(:swoosh, :mandrill)
-      |> Keyword.put(:base_url, "http://localhost:#{bypass.port}")
-    Application.put_env(:swoosh, :mandrill, env)
+    config = [base_url: "http://localhost:#{bypass.port}",
+              api_key: "jarvis"]
 
     valid_email =
       %Swoosh.Email{}
@@ -20,23 +17,20 @@ defmodule Swoosh.Adapters.MandrillTest do
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
 
-    {:ok, bypass: bypass, valid_email: valid_email}
+    {:ok, bypass: bypass, config: config, valid_email: valid_email}
   end
 
-  test "a sent email results in :ok", %{bypass: bypass, valid_email: email} do
+  test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
-      cc = %{"type" => "cc", "email" => "hulk@smash.com", "name" => "Bruce Banner"}
       body_params = %{"key" => "jarvis",
                       "message" => %{
                         "subject" => "Hello, Avengers!",
-                        "to" => [
-                          %{"type" => "cc", "email" => "hulk@smash.com", "name" => "Bruce Banner"},
-                          %{"type" => "to", "email" => "steve@rogers.com"}],
+                        "to" => [%{"type" => "cc", "email" => "hulk@smash.com", "name" => "Bruce Banner"},
+                                 %{"type" => "to", "email" => "steve@rogers.com"}],
                         "from_name" => "T Stark",
                         "from_email" => "tony@stark.com",
                         "html" => "<h1>Hello</h1>"}}
-
       assert body_params == conn.body_params
       assert "/messages/send.json" == conn.request_path
       assert "POST" == conn.method
@@ -44,10 +38,10 @@ defmodule Swoosh.Adapters.MandrillTest do
                     "[{\"email\":\"steve@rogers.com\",\"status\":\"sent\",\"_id\":\"968791b9f084486f9f65a4a6f93474ad\",\"reject_reason\":null}]")
     end
 
-    assert Mandrill.deliver(email) == :ok
+    assert Mandrill.deliver(email, config) == :ok
   end
 
-  test "a queued email results in :ok", %{bypass: bypass, valid_email: email} do
+  test "a queued email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
     email = put_private(email, :async, true)
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
@@ -57,22 +51,22 @@ defmodule Swoosh.Adapters.MandrillTest do
                     "[{\"email\":\"steve@rogers.com\",\"status\":\"queued\",\"_id\":\"968791b9f084486f9f65a4a6f93474ad\",\"reject_reason\":null}]")
     end
 
-    assert Mandrill.deliver(email) == :ok
+    assert Mandrill.deliver(email, config) == :ok
   end
 
-  test "deliver/1 with 2xx response containing errors", %{bypass: bypass, valid_email: email} do
+  test "deliver/1 with 2xx response containing errors", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       Plug.Conn.resp(conn, 200, "[{\"email\":\"leafybasil@gmail.com\",\"status\":\"rejected\",\"_id\":\"e1f1f16d3c6e47c5955ad2b4c3207986\",\"reject_reason\":\"unsigned\"}]")
     end
 
-    assert Mandrill.deliver(email) == {:error, %{"_id" => "e1f1f16d3c6e47c5955ad2b4c3207986", "email" => "leafybasil@gmail.com", "reject_reason" => "unsigned", "status" => "rejected"}}
+    assert Mandrill.deliver(email, config) == {:error, %{"_id" => "e1f1f16d3c6e47c5955ad2b4c3207986", "email" => "leafybasil@gmail.com", "reject_reason" => "unsigned", "status" => "rejected"}}
   end
 
-  test "deliver/1 with non 2xx response", %{bypass: bypass, valid_email: email} do
+  test "deliver/1 with non 2xx response", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       Plug.Conn.resp(conn, 500, "{\"status\":\"error\",\"code\":-1,\"name\":\"Invalid_Key\",\"message\":\"Invalid API key\"}")
     end
 
-    assert Mandrill.deliver(email) == {:error, %{"code" => -1, "message" => "Invalid API key", "name" => "Invalid_Key", "status" => "error"}}
+    assert Mandrill.deliver(email, config) == {:error, %{"code" => -1, "message" => "Invalid API key", "name" => "Invalid_Key", "status" => "error"}}
   end
 end


### PR DESCRIPTION
We want to support multiple mailers powered by the same adapter but
using different configuration (api keys, etc.).

This is the simplest option but also the most "costly" as we have to
pass the config down to the adapter whenever we call `deliver`.

Fixes #15 
