### PR TITLE
Extracted required field checks into `Mailer`

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -48,11 +48,8 @@ defmodule Swoosh.Adapters.Mailgun do
     |> prepare_bcc(email)
   end
 
-  defp prepare_from(_body, %Email{from: nil}), do: raise ArgumentError, message: "`from` can't be nil"
-  defp prepare_from(_body, %Email{from: {_name, nil}}), do: raise ArgumentError, message: "`from` can't be nil"
   defp prepare_from(body, %Email{from: from}), do: Map.put(body, :from, prepare_recipient(from))
 
-  defp prepare_to(_body, %Email{to: []}), do: raise ArgumentError, message: "`to` can't be nil"
   defp prepare_to(body, %Email{to: to}), do: Map.put(body, :to, prepare_recipients(to))
 
   defp prepare_cc(body, %Email{cc: []}), do: body
@@ -70,18 +67,11 @@ defmodule Swoosh.Adapters.Mailgun do
   defp prepare_recipient({"", email}), do: email
   defp prepare_recipient({name, email}), do: name <> "<#{email}>"
 
-  defp prepare_subject(_body, %Email{subject: nil}), do: raise ArgumentError, message: "`subject` can't be nil"
   defp prepare_subject(body, %Email{subject: subject}), do: Map.put(body, :subject, subject)
 
-  defp prepare_text(_body, %{text_body: nil, html_body: nil}) do
-    raise ArgumentError, message: "`html_body` and `text_body` cannot both be nil"
-  end
   defp prepare_text(body, %{text_body: nil}), do: body
   defp prepare_text(body, %{text_body: text_body}), do: Map.put(body, :text, text_body)
 
-  defp prepare_html(_body, %{html_body: nil, text_body: nil}) do
-    raise ArgumentError, message: "`html_body` and `text_body` cannot both be nil"
-  end
   defp prepare_html(body, %{html_body: nil}), do: body
   defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, :html, html_body)
 end

--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -51,8 +51,6 @@ defmodule Swoosh.Adapters.Mandrill do
   def set_async(body, %Email{private: %{async: true}}), do: Map.put(body, :async, true)
   def set_async(body, _email), do: body
 
-  defp prepare_from(_body, %Email{from: nil}), do: raise ArgumentError, message: "`from` can't be nil"
-  defp prepare_from(_body, %Email{from: {_name, nil}}), do: raise ArgumentError, message: "`from` can't be nil"
   defp prepare_from(body, %Email{from: {nil, address}}), do: Map.put(body, :from_email, address)
   defp prepare_from(body, %Email{from: {name, address}}) do
     body
@@ -60,7 +58,6 @@ defmodule Swoosh.Adapters.Mandrill do
     |> Map.put(:from_email, address)
   end
 
-  defp prepare_to(_body, %Email{to: []}), do: raise ArgumentError, message: "`to` can't be nil"
   defp prepare_to(body, %Email{to: to}), do: prepare_recipients(body, to)
 
   defp prepare_cc(body, %Email{cc: []}), do: body
@@ -81,18 +78,11 @@ defmodule Swoosh.Adapters.Mandrill do
   defp prepare_recipient({"", email}, type), do: %{email: email, type: type}
   defp prepare_recipient({name, email}, type), do: %{email: email, name: name, type: type}
 
-  defp prepare_subject(_body, %Email{subject: nil}), do: raise ArgumentError, message: "`subject` can't be nil"
   defp prepare_subject(body, %Email{subject: subject}), do: Map.put(body, :subject, subject)
 
-  defp prepare_text(_body, %{text_body: nil, html_body: nil}) do
-    raise ArgumentError, message: "`html_body` and `text_body` cannot both be nil"
-  end
   defp prepare_text(body, %{text_body: nil}), do: body
   defp prepare_text(body, %{text_body: text_body}), do: Map.put(body, :text, text_body)
 
-  defp prepare_html(_body, %{html_body: nil, text_body: nil}) do
-    raise ArgumentError, message: "`html_body` and `text_body` cannot both be nil"
-  end
   defp prepare_html(body, %{html_body: nil}), do: body
   defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, :html, html_body)
 end

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -39,8 +39,6 @@ defmodule Swoosh.Adapters.Sendgrid do
     |> prepare_reply_to(email)
   end
 
-  def prepare_from(_body, %Email{from: nil}), do: raise ArgumentError, message: "`from` can't be nil"
-  def prepare_from(_body, %Email{from: {_name, nil}}), do: raise ArgumentError, message: "`from` address can't be nil"
   def prepare_from(body, %Email{from: {name, address}}) when is_nil(name) or name == "" do
     Map.put(body, :from, address)
   end
@@ -50,7 +48,6 @@ defmodule Swoosh.Adapters.Sendgrid do
     |> Map.put(:fromname, name)
   end
 
-  def prepare_to(_body, %Email{to: []}), do: raise ArgumentError, message: "`to` can't be empty"
   def prepare_to(body, %Email{to: to}) do
     {names, addresses} = Enum.unzip(to)
     body
@@ -74,7 +71,6 @@ defmodule Swoosh.Adapters.Sendgrid do
     |> prepare_names(:bcc, names)
   end
 
-  def prepare_subject(_body, %Email{subject: nil}), do: raise ArgumentError, message: "`subject` can't be nil"
   def prepare_subject(body, %Email{subject: subject}) do
     Map.put(body, :subject, subject)
   end

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -36,14 +36,10 @@ defmodule Swoosh.Adapters.SMTP do
     |> prepare_from(email)
   end
 
-  defp prepare_subject(_headers, %Email{subject: nil}), do: raise ArgumentError, message: "`subject` can't be nil"
   defp prepare_subject(headers, %Email{subject: subject}), do: [{"Subject", subject} | headers]
 
-  defp prepare_from(_headers, %Email{from: nil}), do: raise ArgumentError, message: "`from` can't be nil"
-  defp prepare_from(_headers, %Email{from: {_name, nil}}), do: raise ArgumentError, message: "`from` address can't be nil"
   defp prepare_from(headers, %Email{from: from}), do: [{"From", prepare_recipient(from)} | headers]
 
-  defp prepare_to(_headers, %Email{to: []}), do: raise ArgumentError, message: "`to` can't be empty"
   defp prepare_to(headers, %Email{to: to}), do: [{"To", "#{prepare_recipients(to)}"} | headers]
 
   defp prepare_cc(headers, %Email{cc: []}), do: headers

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -8,21 +8,16 @@ defmodule Swoosh.Mailer do
 
       def __adapter__, do: @adapter
 
-      def deliver(%Swoosh.Email{from: nil}) do
-        raise ArgumentError, "expected \"from\" to be set"
-      end
-      def deliver(%Swoosh.Email{to: nil}) do
-        raise ArgumentError, "expected \"to\" to be set"
-      end
+      def deliver(%Swoosh.Email{from: nil}), do: raise ArgumentError, "expected \"from\" to be set"
+      def deliver(%Swoosh.Email{from: {_name, nil}}), do: raise ArgumentError, "expected \"from\" address to be set"
+      def deliver(%Swoosh.Email{to: nil}), do: raise ArgumentError, "expected \"to\" to be set"
+      def deliver(%Swoosh.Email{to: []}), do: raise ArgumentError, "expected \"to\" not to be empty"
+      def deliver(%Swoosh.Email{subject: nil}), do: raise ArgumentError, "expected \"subject\" to be set"
       def deliver(%Swoosh.Email{html_body: nil, text_body: nil}) do
         raise ArgumentError, "expected \"html_body\" or \"text_body\" to be set"
       end
-      def deliver(%Swoosh.Email{} = email) do
-        @adapter.deliver(email, @config)
-      end
-      def deliver(email) do
-        raise ArgumentError, "expected %Swoosh.Email{}, got #{inspect email}"
-      end
+      def deliver(%Swoosh.Email{} = email), do: @adapter.deliver(email, @config)
+      def deliver(email), do: raise ArgumentError, "expected %Swoosh.Email{}, got #{inspect email}"
     end
   end
 

--- a/test/swoosh/mailer_test.exs
+++ b/test/swoosh/mailer_test.exs
@@ -29,9 +29,19 @@ defmodule Swoosh.MailerTest do
     assert_raise ArgumentError, "expected \"from\" to be set", fn ->
       Map.put(valid_email, :from, nil) |> FakeMailer.deliver()
     end
+    assert_raise ArgumentError, "expected \"from\" address to be set", fn ->
+      Map.put(valid_email, :from, {"Name", nil}) |> FakeMailer.deliver()
+    end
 
     assert_raise ArgumentError, "expected \"to\" to be set", fn ->
       Map.put(valid_email, :to, nil) |> FakeMailer.deliver()
+    end
+    assert_raise ArgumentError, "expected \"to\" not to be empty", fn ->
+      Map.put(valid_email, :to, []) |> FakeMailer.deliver()
+    end
+
+    assert_raise ArgumentError, "expected \"subject\" to be set", fn ->
+      Map.put(valid_email, :subject, nil) |> FakeMailer.deliver()
     end
 
     assert_raise ArgumentError, "expected \"html_body\" or \"text_body\" to be set", fn ->
@@ -41,4 +51,5 @@ defmodule Swoosh.MailerTest do
       |> FakeMailer.deliver()
     end
   end
+
 end


### PR DESCRIPTION
We were doing checks for required data in the adapters as well as in the `Mailer` module itself, made sense to extract this out and tidy it up separately from the rest of the tests I am adding.

@stevedomin :eyes: please
