### PR TITLE
Introduce `provider_options` to `%Swoosh.Email`

### DIFF
--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -48,7 +48,7 @@ defmodule Swoosh.Adapters.Mandrill do
 
   def set_api_key(body, config), do: Map.put(body, :key, config[:api_key])
 
-  def set_async(body, %Email{private: %{async: true}}), do: Map.put(body, :async, true)
+  def set_async(body, %Email{provider_options: %{async: true}}), do: Map.put(body, :async, true)
   def set_async(body, _email), do: body
 
   defp prepare_from(body, %Email{from: {nil, address}}), do: Map.put(body, :from_email, address)

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -16,7 +16,7 @@ defmodule Swoosh.Email do
 
   defstruct subject: "", from: nil, to: [], cc: [], bcc: [], text_body: nil,
             html_body: nil, attachments: nil, reply_to: nil, headers: %{},
-            private: %{}, assigns: %{}
+            private: %{}, assigns: %{}, provider_options: %{}
 
   @doc """
   Sets the `from` header.
@@ -109,6 +109,15 @@ defmodule Swoosh.Email do
   """
   def put_private(%__MODULE__{private: private} = email, key, value) when is_atom(key) do
     %{email | private: Map.put(private, key, value)}
+  end
+
+  @doc """
+  Assigns a new **provider_option** key and value in the email.
+
+  This storage is meant to be used by adapters for provider-specific functionality.
+  """
+  def put_provider_option(%__MODULE__{provider_options: provider_options} = email, key, value) when is_atom(key) do
+    %{email | provider_options: Map.put(provider_options, key, value)}
   end
 
   defp format_recipient({name, address} = recipient) when is_binary(name) and is_binary(address) and recipient != "" do

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -83,7 +83,7 @@ defmodule Swoosh.Adapters.MandrillTest do
   end
 
   test "a queued email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
-    email = put_private(email, :async, true)
+    email = put_provider_option(email, :async, true)
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
       assert true == conn.body_params["async"]


### PR DESCRIPTION
Also moved mandrill `async` option to `provider_options`.
