### PR TITLE
Fix `prepare_message` function broken in `Credo` PR.

### DIFF
--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -25,8 +25,8 @@ defmodule Swoosh.Adapters.SMTP do
   @doc false
   def prepare_message(email) do
     email
-    |> prepare_headers(email)
-    |> prepare_parts()
+    |> prepare_headers()
+    |> prepare_parts(email)
   end
 
   defp prepare_headers(%Email{} = email) do


### PR DESCRIPTION
After running tests I noticed project wasn't compiling.  Was my fault, I should have eyeballed the change more closely.  Merging this in now as it's small and fixes the problem.
