### PR TITLE
Process `reply_to` header for Mandrill and Mailgun.

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -46,11 +46,15 @@ defmodule Swoosh.Adapters.Mailgun do
     |> prepare_text(email)
     |> prepare_cc(email)
     |> prepare_bcc(email)
+    |> prepare_reply_to(email)
   end
 
   defp prepare_from(body, %Email{from: {_name, address}}), do: Map.put(body, :from, address)
 
   defp prepare_to(body, %Email{to: to}), do: Map.put(body, :to, prepare_recipients(to))
+
+  defp prepare_reply_to(body, %Email{reply_to: nil}), do: body
+  defp prepare_reply_to(body, %Email{reply_to: {_name, address}}), do: Map.put(body, "h:Reply-To", address)
 
   defp prepare_cc(body, %Email{cc: []}), do: body
   defp prepare_cc(body, %Email{cc: cc}), do: Map.put(body, :cc, prepare_recipients(cc))

--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -44,12 +44,13 @@ defmodule Swoosh.Adapters.Mandrill do
     |> prepare_text(email)
     |> prepare_cc(email)
     |> prepare_bcc(email)
+    |> prepare_reply_to(email)
   end
 
-  def set_api_key(body, config), do: Map.put(body, :key, config[:api_key])
+  defp set_api_key(body, config), do: Map.put(body, :key, config[:api_key])
 
-  def set_async(body, %Email{provider_options: %{async: true}}), do: Map.put(body, :async, true)
-  def set_async(body, _email), do: body
+  defp set_async(body, %Email{provider_options: %{async: true}}), do: Map.put(body, :async, true)
+  defp set_async(body, _email), do: body
 
   defp prepare_from(body, %Email{from: {nil, address}}), do: Map.put(body, :from_email, address)
   defp prepare_from(body, %Email{from: {name, address}}) do
@@ -59,6 +60,11 @@ defmodule Swoosh.Adapters.Mandrill do
   end
 
   defp prepare_to(body, %Email{to: to}), do: prepare_recipients(body, to)
+
+  defp prepare_reply_to(body, %Email{reply_to: nil}), do: body
+  defp prepare_reply_to(body, %Email{reply_to: {_name, address}}) do
+    Map.put(body, :headers, %{"Reply-To" => address})
+  end
 
   defp prepare_cc(body, %Email{cc: []}), do: body
   defp prepare_cc(body, %Email{cc: cc}), do: prepare_recipients(body, cc, "cc")

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -42,6 +42,7 @@ defmodule Swoosh.Adapters.MailgunTest do
       |> from({"T Stark", "tony@stark.com"})
       |> to({"Steve Rogers", "steve@rogers.com"})
       |> to("wasp@avengers.com")
+      |> reply_to("office@avengers.com")
       |> cc({"Bruce Banner", "hulk@smash.com"})
       |> cc("thor@odinson.com")
       |> bcc({"Clinton Francis Barton", "hawk@eye.com"})
@@ -57,6 +58,7 @@ defmodule Swoosh.Adapters.MailgunTest do
                       "to" => "wasp@avengers.com,Steve Rogers <steve@rogers.com>",
                       "bcc" => "beast@avengers.com,Clinton Francis Barton <hawk@eye.com>",
                       "cc" => "thor@odinson.com,Bruce Banner <hulk@smash.com>",
+                      "h:Reply-To" => "office@avengers.com",
                       "from" => "tony@stark.com",
                       "text" => "Hello",
                       "html" => "<h1>Hello</h1>"}

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -48,6 +48,7 @@ defmodule Swoosh.Adapters.MandrillTest do
       |> from({"T Stark", "tony@stark.com"})
       |> to({"Steve Rogers", "steve@rogers.com"})
       |> to("wasp@avengers.com")
+      |> reply_to("office@avengers.com")
       |> cc({"Bruce Banner", "hulk@smash.com"})
       |> cc("thor@odinson.com")
       |> bcc({"Clinton Francis Barton", "hawk@eye.com"})
@@ -61,6 +62,7 @@ defmodule Swoosh.Adapters.MandrillTest do
       body_params = %{"key" => "jarvis",
                       "message" => %{
                         "subject" => "Hello, Avengers!",
+                        "headers" => %{"Reply-To" => "office@avengers.com"},
                         "to" => [%{"type" => "bcc", "email" => "beast@avengers.com"},
                                  %{"type" => "bcc", "email" => "hawk@eye.com", "name" => "Clinton Francis Barton"},
                                  %{"type" => "cc", "email" => "thor@odinson.com"},


### PR DESCRIPTION
Adds `reply_to` header for Mandrill and Mailgun adapters.
