### PR TITLE
Refactor adapter return values

### DIFF
--- a/lib/swoosh/adapter.ex
+++ b/lib/swoosh/adapter.ex
@@ -4,5 +4,5 @@ defmodule Swoosh.Adapter do
   """
   @typep config :: Keyword.t
 
-  @callback deliver(%Swoosh.Email{}, config) :: :ok | {:ok, term} | {:error, term}
+  @callback deliver(%Swoosh.Email{}, config) :: {:ok, term} | {:error, term}
 end

--- a/lib/swoosh/adapters/local.ex
+++ b/lib/swoosh/adapters/local.ex
@@ -22,6 +22,8 @@ defmodule Swoosh.Adapters.Local do
   @behaviour Swoosh.Adapter
 
   def deliver(%Swoosh.Email{} = email, _config) do
-    Swoosh.InMemoryMailbox.push(email)
+    %Swoosh.Email{headers: %{"Message-ID" => id}} = Swoosh.InMemoryMailbox.push(email)
+
+    {:ok, %{id: id}}
   end
 end

--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -31,8 +31,8 @@ defmodule Swoosh.Adapters.Mailgun do
     params = email |> prepare_body |> Plug.Conn.Query.encode
 
     case HTTPoison.post(base_url(config) <> config[:domain] <> @api_endpoint, params, headers) do
-      {:ok, %Response{status_code: code}} when code >= 200 and code <= 299 ->
-        :ok
+      {:ok, %Response{status_code: code, body: body}} when code >= 200 and code <= 299 ->
+        {:ok, %{id: Poison.decode!(body)["id"]}}
       {:ok, %Response{status_code: code, body: body}} when code >= 400 and code <= 499 ->
         {:error, Poison.decode!(body)}
       {:ok, %Response{status_code: code, body: body}} when code >= 500 and code <= 599 ->

--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -40,8 +40,8 @@ defmodule Swoosh.Adapters.Mandrill do
   end
 
   defp interpret_response(body) when is_binary(body), do: body |> Poison.decode! |> hd |> interpret_response
-  defp interpret_response(%{"status" => "sent"}), do: :ok
-  defp interpret_response(%{"status" => "queued"}), do: :ok
+  defp interpret_response(%{"status" => "sent"} = body), do: {:ok, %{id: body["_id"]}}
+  defp interpret_response(%{"status" => "queued"} = body), do: {:ok, %{id: body["_id"]}}
   defp interpret_response(%{"status" => "rejected"} = body), do: {:error, body}
   defp interpret_response(body), do: {:error, Poison.decode!(body)}
 

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -30,8 +30,8 @@ defmodule Swoosh.Adapters.Postmark do
     params = email |> prepare_body |> Poison.encode!
 
     case HTTPoison.post(base_url(config) <> @api_endpoint, params, headers) do
-      {:ok, %Response{status_code: 200}} ->
-        :ok
+      {:ok, %Response{status_code: 200, body: body}} ->
+        {:ok, %{id: Poison.decode!(body)["MessageID"]}}
       {:ok, %Response{status_code: code, body: body}} when code >= 400 and code <= 499 ->
         {:error, Poison.decode!(body)}
       {:ok, %Response{status_code: code, body: body}} when code >= 500 and code <= 599 ->

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -33,7 +33,7 @@ defmodule Swoosh.Adapters.Sendgrid do
 
     case HTTPoison.post(base_url(config) <> @api_endpoint, body, headers) do
       {:ok, %Response{status_code: code}} when code >= 200 and code <= 299 ->
-        :ok
+        {:ok, %{}}
       {:ok, %Response{status_code: code, body: body}} when code >= 400 and code <= 499 ->
         {:error, Poison.decode!(body)}
       {:ok, %Response{status_code: code, body: body}} when code >= 500 and code <= 599 ->

--- a/lib/swoosh/adapters/test.ex
+++ b/lib/swoosh/adapters/test.ex
@@ -21,5 +21,6 @@ defmodule Swoosh.Adapters.Test do
 
   def deliver(email, _config) do
     send(self(), {:email, email})
+    {:ok, %{}}
   end
 end

--- a/test/swoosh/adapters/local_test.exs
+++ b/test/swoosh/adapters/local_test.exs
@@ -6,13 +6,13 @@ defmodule Swoosh.Adapters.LocalTest do
   end
 
   test "deliver/1" do
-    email = LocalMailer.deliver(%Swoosh.Email{
+    {status, _} = LocalMailer.deliver(%Swoosh.Email{
       from: "tony@stark.com",
       to: "steve@rogers.com",
       subject: "Hello, Avengers!",
       text_body: "Hello!"
     })
 
-    assert email == Swoosh.InMemoryMailbox.pop()
+    assert status == :ok
   end
 end

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -4,6 +4,13 @@ defmodule Swoosh.Adapters.MailgunTest do
   import Swoosh.Email
   alias Swoosh.Adapters.Mailgun
 
+  @success_response """
+    {
+      "message": "Queued. Thank you.",
+      "id": "<20111114174239.25659.5817@samples.mailgun.org>"
+    }
+  """
+
   setup_all do
     bypass = Bypass.open
     config = [base_url: "http://localhost:#{bypass.port}",
@@ -30,10 +37,11 @@ defmodule Swoosh.Adapters.MailgunTest do
       assert body_params == conn.body_params
       assert expected_path == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "OK")
+
+      Plug.Conn.resp(conn, 200, @success_response)
     end
 
-    assert Mailgun.deliver(email, config) == :ok
+    assert Mailgun.deliver(email, config) == {:ok, %{id: "<20111114174239.25659.5817@samples.mailgun.org>"}}
   end
 
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
@@ -66,10 +74,10 @@ defmodule Swoosh.Adapters.MailgunTest do
       assert expected_path == conn.request_path
       assert "POST" == conn.method
 
-      Plug.Conn.resp(conn, 200, "OK")
+      Plug.Conn.resp(conn, 200, @success_response)
     end
 
-    assert Mailgun.deliver(email, config) == :ok
+    assert Mailgun.deliver(email, config) == {:ok, %{id: "<20111114174239.25659.5817@samples.mailgun.org>"}}
   end
 
   test "delivery/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -4,6 +4,16 @@ defmodule Swoosh.Adapters.PostmarkTest do
   import Swoosh.Email
   alias Swoosh.Adapters.Postmark
 
+  @success_response """
+    {
+      "ErrorCode": 0,
+      "Message": "OK",
+      "MessageID": "b7bc2f4a-e38e-4336-af7d-e6c392c2f817",
+      "SubmittedAt": "2010-11-26T12:01:05.1794748-05:00",
+      "To": "tony@stark.com"
+    }
+  """
+
   setup_all do
     bypass = Bypass.open
     config = [base_url: "http://localhost:#{bypass.port}",
@@ -30,10 +40,11 @@ defmodule Swoosh.Adapters.PostmarkTest do
       assert body_params == conn.body_params
       assert "/email" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "OK")
+
+      Plug.Conn.resp(conn, 200, @success_response)
     end
 
-    assert Postmark.deliver(email, config) == :ok
+    assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
   end
 
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
@@ -67,10 +78,10 @@ defmodule Swoosh.Adapters.PostmarkTest do
       assert "/email" == conn.request_path
       assert "POST" == conn.method
 
-      Plug.Conn.resp(conn, 200, "OK")
+      Plug.Conn.resp(conn, 200, @success_response)
     end
 
-    assert Postmark.deliver(email, config) == :ok
+    assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
   end
 
   test "delivery/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do


### PR DESCRIPTION
Most services return useful information, and it makes sense to normalise the return values for each adapter.  This PR would replace all `:ok` returns with `{:ok, map}` where map will usually hold an ID provided by the service.

It's something of a suggestion at the moment.  @stevedomin :eyes: please!