### PR TITLE
Introduce Email.new/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ defmodule Sample.UserEmail do
   import Swoosh.Email
 
   def welcome(user) do
-    %Swoosh.Email{}
+    new
     |> to({user.name, user.email})
     |> from({"Dr B Banner", "hulk@smash.com"})
     |> subject("Hello, Avengers!")
@@ -125,7 +125,7 @@ defmodule Sample.UserEmail do
   use Phoenix.Swoosh, view: Sample.EmailView, layout: {Sample.LayoutView, :email}
 
   def welcome(user) do
-    %Swoosh.Email{}
+    new
     |> to({user.name, user.email})
     |> from({"Dr B Banner", "hulk@smash.com"})
     |> subject("Hello, Avengers!")

--- a/lib/swoosh/in_memory_mailbox.ex
+++ b/lib/swoosh/in_memory_mailbox.ex
@@ -31,7 +31,7 @@ defmodule Swoosh.InMemoryMailbox do
 
   ## Examples
 
-      iex> email = %Swoosh.Email{} |> from("tony@stark.com")
+      iex> email = new |> from("tony@stark.com")
       %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
       iex> InMemoryMailbox.push(email)
       %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "A1B2C3"}, [...]}
@@ -45,7 +45,7 @@ defmodule Swoosh.InMemoryMailbox do
 
   ## Examples
 
-      iex> email = %Swoosh.Email{} |> from("tony@stark.com")
+      iex> email = new |> from("tony@stark.com")
       %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
       iex> InMemoryMailbox.push(email)
       %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "A1B2C3"}, [...]}
@@ -65,7 +65,7 @@ defmodule Swoosh.InMemoryMailbox do
 
   ## Examples
 
-      iex> email = %Swoosh.Email{} |> from("tony@stark.com")
+      iex> email = new |> from("tony@stark.com")
       %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
       iex> InMemoryMailbox.push(email)
       %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "A1B2C3"}, [...]}
@@ -81,7 +81,7 @@ defmodule Swoosh.InMemoryMailbox do
 
   ## Examples
 
-      iex> email = %Swoosh.Email{} |> from("tony@stark.com")
+      iex> email = new |> from("tony@stark.com")
       %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
       iex> InMemoryMailbox.push(email)
       %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "A1B2C3"}, [...]}
@@ -97,7 +97,7 @@ defmodule Swoosh.InMemoryMailbox do
 
   ## Examples
 
-      iex> email = %Swoosh.Email{} |> from("tony@stark.com")
+      iex> email = new |> from("tony@stark.com")
       %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
       iex> InMemoryMailbox.push(email)
       %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "A1B2C3"}, [...]}

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -41,7 +41,7 @@ defmodule Swoosh.Mailer do
   Once configured you can use your mailer like this:
 
       # in an IEx console
-      iex> email = %Swoosh.Email{} |> from("tony@stark.com") |> to("steve@rogers.com")
+      iex> email = new |> from("tony@stark.com") |> to("steve@rogers.com")
       %Swoosh.Email{from: {"", "tony@stark.com"}, ...}
       iex> Mailer.deliver(email)
       :ok
@@ -50,7 +50,7 @@ defmodule Swoosh.Mailer do
   with your Mailer's config:
 
       # in an IEx console
-      iex> email = %Swoosh.Email{} |> from("tony@stark.com") |> to("steve@rogers.com")
+      iex> email = new |> from("tony@stark.com") |> to("steve@rogers.com")
       %Swoosh.Email{from: {"", "tony@stark.com"}, ...}
       iex> Mailer.deliver(email, domain: "jarvis.com")
       :ok

--- a/test/swoosh/adapters/local_test.exs
+++ b/test/swoosh/adapters/local_test.exs
@@ -6,12 +6,11 @@ defmodule Swoosh.Adapters.LocalTest do
   end
 
   test "deliver/1" do
-    {status, _} = LocalMailer.deliver(%Swoosh.Email{
-      from: "tony@stark.com",
-      to: "steve@rogers.com",
-      subject: "Hello, Avengers!",
-      text_body: "Hello!"
-    })
+    email = Swoosh.Email.new(from: "tony@stark.com",
+                             to: "steve@rogers.com",
+                             subject: "Hello, Avengers!",
+                             text_body: "Hello!")
+    {status, _} = LocalMailer.deliver(email)
 
     assert status == :ok
   end

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -17,7 +17,7 @@ defmodule Swoosh.Adapters.MailgunTest do
               domain: "/avengers.com"]
 
     valid_email =
-      %Swoosh.Email{}
+      new
       |> from("tony@stark.com")
       |> to("steve@rogers.com")
       |> subject("Hello, Avengers!")
@@ -46,7 +46,7 @@ defmodule Swoosh.Adapters.MailgunTest do
 
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
-      %Swoosh.Email{}
+      new
       |> from({"T Stark", "tony@stark.com"})
       |> to({"Steve Rogers", "steve@rogers.com"})
       |> to("wasp@avengers.com")

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -32,7 +32,7 @@ defmodule Swoosh.Adapters.MandrillTest do
               api_key: "jarvis"]
 
     valid_email =
-      %Swoosh.Email{}
+      new
       |> from({"T Stark", "tony@stark.com"})
       |> to("steve@rogers.com")
       |> cc({"Bruce Banner", "hulk@smash.com"})
@@ -65,7 +65,7 @@ defmodule Swoosh.Adapters.MandrillTest do
 
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
-      %Swoosh.Email{}
+      new
       |> from({"T Stark", "tony@stark.com"})
       |> to({"Steve Rogers", "steve@rogers.com"})
       |> to("wasp@avengers.com")

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -21,7 +21,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
               api_key: "jarvis"]
 
     valid_email =
-      %Swoosh.Email{}
+      new
       |> from("steve@rogers.com")
       |> to("tony@stark.com")
       |> subject("Hello, Avengers!")
@@ -49,7 +49,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
 
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
-      %Swoosh.Email{}
+      new
       |> from({"T Stark", "tony@stark.com"})
       |> to("wasp@avengers.com")
       |> to({"Steve Rogers", "steve@rogers.com"})

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -16,7 +16,7 @@ defmodule Swoosh.Adapters.SendgridTest do
     config = [base_url: "http://localhost:#{bypass.port}"]
 
     valid_email =
-      %Swoosh.Email{}
+      new
       |> from("tony@stark.com")
       |> to("steve@rogers.com")
       |> subject("Hello, Avengers!")
@@ -44,7 +44,7 @@ defmodule Swoosh.Adapters.SendgridTest do
 
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
-      %Swoosh.Email{}
+      new
       |> from({"T Stark", "tony@stark.com"})
       |> to({"Steve Rogers", "steve@rogers.com"})
       |> reply_to("hulk@smash.com")
@@ -98,4 +98,3 @@ defmodule Swoosh.Adapters.SendgridTest do
            {:error, %{"errors" => ["Internal server error"], "message" => "error"}}
   end
 end
-

--- a/test/swoosh/adapters/smtp_test.exs
+++ b/test/swoosh/adapters/smtp_test.exs
@@ -6,12 +6,12 @@ defmodule Swoosh.Adapters.SMTPTest do
 
   setup_all do
     valid_email =
-    %Swoosh.Email{}
-    |> from("tony@stark.com")
-    |> to("steve@rogers.com")
-    |> subject("Hello, Avengers!")
-    |> html_body("<h1>Hello</h1>")
-    |> text_body("Hello")
+      new
+      |> from("tony@stark.com")
+      |> to("steve@rogers.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
 
     {:ok, valid_email: valid_email}
   end

--- a/test/swoosh/email_test.exs
+++ b/test/swoosh/email_test.exs
@@ -5,12 +5,23 @@ defmodule Swoosh.EmailTest do
   alias Swoosh.Email
   import Swoosh.Email
 
-  test "new/0 create an empty email" do
-    assert %Email{} == %Email{}
+  test "new without arguments create an empty email" do
+    assert %Email{} = new
+  end
+
+  test "new with arguments create an email with fiels populated" do
+    email = new(subject: "Hello, Avengers!")
+    assert email.subject == "Hello, Avengers!"
+  end
+
+  test "new raises if arguments contain unknown field" do
+    assert_raise ArgumentError, """
+    invalid field `:sbject` (value="Unknown") for Swoosh.Email.new/1.
+    """, fn -> new(sbject: "Unknown") end
   end
 
   test "from/2" do
-    email = %Email{} |> from("tony@stark.com")
+    email = new |> from("tony@stark.com")
     assert email == %Email{from: {"", "tony@stark.com"}}
 
     email = email |> from({"Steve Rogers", "steve@rogers.com"})
@@ -18,14 +29,14 @@ defmodule Swoosh.EmailTest do
   end
 
   test "from/2 should raise if from value is invalid" do
-    assert_raise ArgumentError, fn -> %Email{} |> from(nil) end
-    assert_raise ArgumentError, fn -> %Email{} |> from("") end
-    assert_raise ArgumentError, fn -> %Email{} |> from({nil, "tony@stark.com"}) end
-    assert_raise ArgumentError, fn -> %Email{} |> from({nil, ""}) end
+    assert_raise ArgumentError, fn -> new |> from(nil) end
+    assert_raise ArgumentError, fn -> new |> from("") end
+    assert_raise ArgumentError, fn -> new |> from({nil, "tony@stark.com"}) end
+    assert_raise ArgumentError, fn -> new |> from({nil, ""}) end
   end
 
   test "subject/2" do
-    email = %Email{} |> subject("Hello, Avengers!")
+    email = new |> subject("Hello, Avengers!")
     assert email == %Email{subject: "Hello, Avengers!"}
 
     email = email |> subject("Welcome, I am Jarvis")
@@ -33,7 +44,7 @@ defmodule Swoosh.EmailTest do
   end
 
   test "html_body/2" do
-    email = %Email{} |> html_body("<h1>Hello, Avengers!</h1>")
+    email = new |> html_body("<h1>Hello, Avengers!</h1>")
     assert email == %Email{html_body: "<h1>Hello, Avengers!</h1>"}
 
     email = email |> html_body("<h1>Welcome, I am Jarvis</h1>")
@@ -41,7 +52,7 @@ defmodule Swoosh.EmailTest do
   end
 
   test "text_body/2" do
-    email = %Email{} |> text_body("Hello, Avengers!")
+    email = new |> text_body("Hello, Avengers!")
     assert email == %Email{text_body: "Hello, Avengers!"}
 
     email = email |> text_body("Welcome, I am Jarvis")
@@ -49,7 +60,7 @@ defmodule Swoosh.EmailTest do
   end
 
   test "reply_to/2" do
-    email = %Email{} |> reply_to("welcome@avengers.com")
+    email = new |> reply_to("welcome@avengers.com")
     assert email == %Email{reply_to: {"", "welcome@avengers.com"}}
 
     email = email |> reply_to({"Jarvis Assist", "help@jarvis.com"})
@@ -57,7 +68,7 @@ defmodule Swoosh.EmailTest do
   end
 
   test "to/2 add new recipient(s) to \"to\"" do
-    email = %Email{} |> to("tony@stark.com")
+    email = new |> to("tony@stark.com")
     assert email == %Email{to: [{"", "tony@stark.com"}]}
 
     email = email |> to({"Steve Rogers", "steve@rogers.com"})
@@ -69,17 +80,17 @@ defmodule Swoosh.EmailTest do
   end
 
   test "to/2 should raise if recipient(s) are invalid" do
-    assert_raise ArgumentError, fn -> %Email{} |> to(nil) end
-    assert_raise ArgumentError, fn -> %Email{} |> to("") end
-    assert_raise ArgumentError, fn -> %Email{} |> to({nil, "tony@stark.com"}) end
-    assert_raise ArgumentError, fn -> %Email{} |> to([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> to(nil) end
+    assert_raise ArgumentError, fn -> new |> to("") end
+    assert_raise ArgumentError, fn -> new |> to({nil, "tony@stark.com"}) end
+    assert_raise ArgumentError, fn -> new |> to([nil, "thor@odinson.com"]) end
     assert_raise ArgumentError, fn ->
-      %Email{} |> to([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> to([{"Bruce Banner", nil}, "thor@odinson.com"])
     end
   end
 
   test "put_to/2 replace new recipient(s) in \"to\"" do
-    email = %Email{} |> to("foo@bar.com")
+    email = new |> to("foo@bar.com")
 
     email = email |> put_to("tony@stark.com")
     assert email == %Email{to: [{"", "tony@stark.com"}]}
@@ -92,17 +103,17 @@ defmodule Swoosh.EmailTest do
   end
 
   test "put_to/2 should raise if recipient(s) are invalid" do
-    assert_raise ArgumentError, fn -> %Email{} |> put_to(nil) end
-    assert_raise ArgumentError, fn -> %Email{} |> put_to("") end
-    assert_raise ArgumentError, fn -> %Email{} |> put_to({nil, "tony@stark.com"}) end
-    assert_raise ArgumentError, fn -> %Email{} |> put_to([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> put_to(nil) end
+    assert_raise ArgumentError, fn -> new |> put_to("") end
+    assert_raise ArgumentError, fn -> new |> put_to({nil, "tony@stark.com"}) end
+    assert_raise ArgumentError, fn -> new |> put_to([nil, "thor@odinson.com"]) end
     assert_raise ArgumentError, fn ->
-      %Email{} |> put_to([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> put_to([{"Bruce Banner", nil}, "thor@odinson.com"])
     end
   end
 
   test "cc/2 add new recipient(s) to \"cc\"" do
-    email = %Email{} |> cc("ccny@stark.com")
+    email = new |> cc("ccny@stark.com")
     assert email == %Email{cc: [{"", "ccny@stark.com"}]}
 
     email = email |> cc({"Steve Rogers", "steve@rogers.com"})
@@ -114,17 +125,17 @@ defmodule Swoosh.EmailTest do
   end
 
   test "cc/2 should raise if recipient(s) are invalid" do
-    assert_raise ArgumentError, fn -> %Email{} |> cc(nil) end
-    assert_raise ArgumentError, fn -> %Email{} |> cc("") end
-    assert_raise ArgumentError, fn -> %Email{} |> cc({nil, "ccny@stark.com"}) end
-    assert_raise ArgumentError, fn -> %Email{} |> cc([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> cc(nil) end
+    assert_raise ArgumentError, fn -> new |> cc("") end
+    assert_raise ArgumentError, fn -> new |> cc({nil, "ccny@stark.com"}) end
+    assert_raise ArgumentError, fn -> new |> cc([nil, "thor@odinson.com"]) end
     assert_raise ArgumentError, fn ->
-      %Email{} |> cc([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> cc([{"Bruce Banner", nil}, "thor@odinson.com"])
     end
   end
 
   test "put_cc/2 replace new recipient(s) in \"cc\"" do
-    email = %Email{} |> cc("foo@bar.com")
+    email = new |> cc("foo@bar.com")
 
     email = email |> put_cc("ccny@stark.com")
     assert email == %Email{cc: [{"", "ccny@stark.com"}]}
@@ -137,17 +148,17 @@ defmodule Swoosh.EmailTest do
   end
 
   test "put_cc/2 should raise if recipient(s) are invalid" do
-    assert_raise ArgumentError, fn -> %Email{} |> put_cc(nil) end
-    assert_raise ArgumentError, fn -> %Email{} |> put_cc("") end
-    assert_raise ArgumentError, fn -> %Email{} |> put_cc({nil, "ccny@stark.com"}) end
-    assert_raise ArgumentError, fn -> %Email{} |> put_cc([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> put_cc(nil) end
+    assert_raise ArgumentError, fn -> new |> put_cc("") end
+    assert_raise ArgumentError, fn -> new |> put_cc({nil, "ccny@stark.com"}) end
+    assert_raise ArgumentError, fn -> new |> put_cc([nil, "thor@odinson.com"]) end
     assert_raise ArgumentError, fn ->
-      %Email{} |> put_cc([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> put_cc([{"Bruce Banner", nil}, "thor@odinson.com"])
     end
   end
 
   test "bcc/2 add new recipient(s) to \"bcc\"" do
-    email = %Email{} |> bcc("bccny@stark.com")
+    email = new |> bcc("bccny@stark.com")
     assert email == %Email{bcc: [{"", "bccny@stark.com"}]}
 
     email = email |> bcc({"Steve Rogers", "steve@rogers.com"})
@@ -159,17 +170,17 @@ defmodule Swoosh.EmailTest do
   end
 
   test "bcc/2 should raise if recipient(s) are invalid" do
-    assert_raise ArgumentError, fn -> %Email{} |> bcc(nil) end
-    assert_raise ArgumentError, fn -> %Email{} |> bcc("") end
-    assert_raise ArgumentError, fn -> %Email{} |> bcc({nil, "bccny@stark.com"}) end
-    assert_raise ArgumentError, fn -> %Email{} |> bcc([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> bcc(nil) end
+    assert_raise ArgumentError, fn -> new |> bcc("") end
+    assert_raise ArgumentError, fn -> new |> bcc({nil, "bccny@stark.com"}) end
+    assert_raise ArgumentError, fn -> new |> bcc([nil, "thor@odinson.com"]) end
     assert_raise ArgumentError, fn ->
-      %Email{} |> bcc([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> bcc([{"Bruce Banner", nil}, "thor@odinson.com"])
     end
   end
 
   test "put_bcc/2 replace new recipient(s) in \"bcc\"" do
-    email = %Email{} |> bcc("foo@bar.com")
+    email = new |> bcc("foo@bar.com")
 
     email = email |> put_bcc("bccny@stark.com")
     assert email == %Email{bcc: [{"", "bccny@stark.com"}]}
@@ -182,17 +193,17 @@ defmodule Swoosh.EmailTest do
   end
 
   test "put_bcc/2 should raise if recipient(s) are invalid" do
-    assert_raise ArgumentError, fn -> %Email{} |> put_bcc(nil) end
-    assert_raise ArgumentError, fn -> %Email{} |> put_bcc("") end
-    assert_raise ArgumentError, fn -> %Email{} |> put_bcc({nil, "bccny@stark.com"}) end
-    assert_raise ArgumentError, fn -> %Email{} |> put_bcc([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> put_bcc(nil) end
+    assert_raise ArgumentError, fn -> new |> put_bcc("") end
+    assert_raise ArgumentError, fn -> new |> put_bcc({nil, "bccny@stark.com"}) end
+    assert_raise ArgumentError, fn -> new |> put_bcc([nil, "thor@odinson.com"]) end
     assert_raise ArgumentError, fn ->
-      %Email{} |> put_bcc([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> put_bcc([{"Bruce Banner", nil}, "thor@odinson.com"])
     end
   end
 
   test "header/3" do
-    email = %Email{} |> header("X-Accept-Language", "en")
+    email = new |> header("X-Accept-Language", "en")
     assert email == %Email{headers: %{"X-Accept-Language" => "en"}}
 
     email = email |> header("X-Mailer", "swoosh")
@@ -208,7 +219,7 @@ defmodule Swoosh.EmailTest do
       name: `"X-Accept-Language"`.
       value: `nil`.
     """, fn ->
-      %Email{} |> header("X-Accept-Language", nil)
+      new |> header("X-Accept-Language", nil)
     end
 
     assert_raise ArgumentError, """
@@ -218,12 +229,12 @@ defmodule Swoosh.EmailTest do
       name: `nil`.
       value: `"swoosh"`.
     """, fn ->
-      %Email{} |> header(nil, "swoosh")
+      new |> header(nil, "swoosh")
     end
   end
 
   test "put_private/3" do
-    email = %Email{} |> put_private(:phoenix_layout, false)
+    email = new |> put_private(:phoenix_layout, false)
     assert email == %Email{private: %{phoenix_layout: false}}
   end
 
@@ -236,7 +247,7 @@ defmodule Swoosh.EmailTest do
       `foo@bar.com` or a two-element tuple `{name, address}`, where
       name and address are strings.
       """, fn ->
-      %Email{} |> to(nil)
+      new |> to(nil)
     end
 
     assert_raise ArgumentError,
@@ -247,7 +258,7 @@ defmodule Swoosh.EmailTest do
       `foo@bar.com` or a two-element tuple `{name, address}`, where
       name and address are strings.
       """, fn ->
-      %Email{} |> to({nil, "tony@stark.com"})
+      new |> to({nil, "tony@stark.com"})
     end
 
     assert_raise ArgumentError,
@@ -258,7 +269,7 @@ defmodule Swoosh.EmailTest do
       `foo@bar.com` or a two-element tuple `{name, address}`, where
       name and address are strings.
       """, fn ->
-      %Email{} |> to([nil, "thor@odinson.com"])
+      new |> to([nil, "thor@odinson.com"])
     end
 
     assert_raise ArgumentError,
@@ -269,7 +280,7 @@ defmodule Swoosh.EmailTest do
       `foo@bar.com` or a two-element tuple `{name, address}`, where
       name and address are strings.
       """, fn ->
-      %Email{} |> to([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> to([{"Bruce Banner", nil}, "thor@odinson.com"])
     end
   end
 end

--- a/test/swoosh/mailer_test.exs
+++ b/test/swoosh/mailer_test.exs
@@ -14,11 +14,11 @@ defmodule Swoosh.MailerTest do
   end
 
   setup_all do
-    valid_email = %Swoosh.Email{from: {"", "tony@stark.com"},
-                                to: [{"", "steve@rogers.com"}],
-                                subject: "Hello, Avengers!",
-                                html_body: "<h1>Hello</h1>",
-                                text_body: "Hello"}
+    valid_email = Swoosh.Email.new(from: "tony@stark.com",
+                                   to: "steve@rogers.com",
+                                   subject: "Hello, Avengers!",
+                                   html_body: "<h1>Hello</h1>",
+                                   text_body: "Hello")
     {:ok, valid_email: valid_email}
   end
 

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -6,7 +6,7 @@ defmodule Swoosh.TestAssertionsTest do
 
   setup do
     email =
-      %Swoosh.Email{}
+      new
       |> from("tony@stark.com")
       |> to("steve@rogers.com")
       |> subject("Hello, Avengers!")
@@ -20,7 +20,7 @@ defmodule Swoosh.TestAssertionsTest do
 
   test "assert email sent with wrong email" do
     try do
-      wrong_email = %Swoosh.Email{} |> subject("Wrong, Avengers!")
+      wrong_email = new |> subject("Wrong, Avengers!")
       assert_email_sent wrong_email
     rescue
       error in [ExUnit.AssertionError] ->
@@ -34,7 +34,7 @@ defmodule Swoosh.TestAssertionsTest do
   end
 
   test "assert email not sent with unexpected email" do
-    unexpected_email = %Swoosh.Email{} |> subject("Testing Avenger")
+    unexpected_email = new |> subject("Testing Avenger")
     assert_email_not_sent unexpected_email
   end
 


### PR DESCRIPTION
Since `Swoosh.Email` is meant to be an opaque struct it makes sense
to provide a constructor for it.
We allow options to be passed to the function as it can be very
convenient at time (i.e testing).