### PR TITLE
Allow to assert on email params

### DIFF
--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -52,6 +52,8 @@ defmodule Swoosh.Email do
       email = new(from: "tony@stark.com", to: "steve@rogers.com", subject: "Hello, Avengers!")
   """
 
+  import Swoosh.EmailHelpers
+
   defstruct subject: "", from: nil, to: [], cc: [], bcc: [], text_body: nil,
             html_body: nil, attachments: nil, reply_to: nil, headers: %{},
             private: %{}, assigns: %{}, provider_options: %{}
@@ -464,22 +466,5 @@ defmodule Swoosh.Email do
   @spec assign(t, atom, any) :: t
   def assign(%__MODULE__{assigns: assigns} = email, key, value) when is_atom(key) do
     %{email | assigns: Map.put(assigns, key, value)}
-  end
-
-  defp format_recipient({name, address} = recipient) when is_binary(name) and is_binary(address) and recipient != "" do
-    recipient
-  end
-  defp format_recipient(recipient) when is_binary(recipient) and recipient != "" do
-    {"", recipient}
-  end
-  defp format_recipient(invalid) do
-    raise ArgumentError, message:
-    """
-    The recipient `#{inspect invalid}` is invalid.
-
-    Recipients must be a string representing an email address like
-    `foo@bar.com` or a two-element tuple `{name, address}`, where
-    name and address are strings.
-    """
   end
 end

--- a/lib/swoosh/email_helpers.ex
+++ b/lib/swoosh/email_helpers.ex
@@ -1,0 +1,18 @@
+defmodule Swoosh.EmailHelpers do
+  def format_recipient({name, address} = recipient) when is_binary(name) and is_binary(address) and recipient != "" do
+    recipient
+  end
+  def format_recipient(recipient) when is_binary(recipient) and recipient != "" do
+    {"", recipient}
+  end
+  def format_recipient(invalid) do
+    raise ArgumentError, message:
+    """
+    The recipient `#{inspect invalid}` is invalid.
+
+    Recipients must be a string representing an email address like
+    `foo@bar.com` or a two-element tuple `{name, address}`, where
+    name and address are strings.
+    """
+  end
+end

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -8,13 +8,74 @@ defmodule Swoosh.TestAssertions do
   """
 
   import ExUnit.Assertions
+  import Swoosh.EmailHelpers
+
+  alias Swoosh.Email
 
   @doc ~S"""
   Asserts `email` was sent.
+
+  You pass a keyword list to match on specific params.
+
+  ## Examples
+
+      iex> alias Swoosh.Email
+      iex> import Swoosh.TestAssertions
+
+      iex> email = Email.new(subject: "Hello, Avengers!")
+      iex> Swoosh.Adapters.Test.deliver(email, [])
+
+      # assert a specific email was sent
+      iex> assert_email_sent email
+
+      # assert an email with specific field(s) was sent
+      iex> assert_email_sent subject: "Hello, Avengers!"
   """
-  def assert_email_sent(email) do
+  def assert_email_sent(%Email{} = email) do
     assert_received {:email, ^email}
   end
+  def assert_email_sent(params) when is_list(params) do
+    assert_received {:email, email}
+    try do
+      Enum.each params, fn param -> assert_equal(email, param) end
+    rescue
+      error ->
+	stacktrace = System.stacktrace
+	name = error.__struct__
+	field =
+	  case elem(error.expr, 0) do
+	    :== ->
+	      {_, _, [{{_, _, [_, field]}, _, _},_]} = error.expr
+	      field
+	    :in ->
+	      {_, _, [{_, _, _}, {{_, _, [_, field]}, _, _}]} = error.expr
+	      field
+	  end
+
+	cond do
+	  name == ExUnit.AssertionError ->
+	    message = "Email `#{to_string(field)}` does not match\n" <>
+		      "email: #{inspect email}\n" <>
+		      "lhs: #{inspect error.left}\n" <>
+		      "rhs: #{inspect error.right}"
+	    reraise ExUnit.AssertionError, [message: message], stacktrace
+	  true ->
+	    reraise(error, stacktrace)
+	end
+    end
+  end
+
+  def assert_equal(email, {:subject, value}), do: assert email.subject == value
+  def assert_equal(email, {:from, value}), do: assert email.from == format_recipient(value)
+  def assert_equal(email, {:reply_to, value}), do: assert email.reply_to == format_recipient(value)
+  def assert_equal(email, {:to, value}) when is_list(value), do: assert email.to == Enum.map(value, &format_recipient/1)
+  def assert_equal(email, {:to, value}), do: assert format_recipient(value) in email.to
+  def assert_equal(email, {:cc, value}) when is_list(value), do: assert email.cc == Enum.map(value, &format_recipient/1)
+  def assert_equal(email, {:cc, value}), do: assert format_recipient(value) in email.cc
+  def assert_equal(email, {:bcc, value}) when is_list(value), do: assert email.bcc == Enum.map(value, &format_recipient/1)
+  def assert_equal(email, {:bcc, value}), do: assert format_recipient(value) in email.bcc
+  def assert_equal(email, {:text_body, value}), do: assert email.text_body == value
+  def assert_equal(email, {:html_body, value}), do: assert email.html_body == value
 
   @doc ~S"""
   Asserts `email` was not sent.

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -18,6 +18,92 @@ defmodule Swoosh.TestAssertionsTest do
     assert_email_sent email
   end
 
+  test "assert email sent with specific params" do
+    assert_email_sent [subject: "Hello, Avengers!", to: "steve@rogers.com"]
+  end
+
+  test "assert email sent with specific to (list)" do
+    assert_email_sent [to: ["steve@rogers.com"]]
+  end
+
+  test "assert email sent with wrong subject" do
+    try do
+      assert_email_sent [subject: "Hello, X-Men!"]
+    rescue
+      error in [ExUnit.AssertionError] ->
+	"Email `subject` does not match\n" <>
+	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+	"lhs: \"Hello, Avengers!\"\n" <>
+	"rhs: \"Hello, X-Men!\""
+	= error.message
+    end
+  end
+
+  test "assert email sent with wrong from" do
+    try do
+      assert_email_sent [from: "thor@odinson.com"]
+    rescue
+      error in [ExUnit.AssertionError] ->
+	"Email `from` does not match\n" <>
+	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+	"lhs: {\"\", \"tony@stark.com\"}\n" <>
+	"rhs: {\"\", \"thor@odinson.com\"}"
+	= error.message
+    end
+  end
+
+  test "assert email sent with wrong to" do
+    try do
+      assert_email_sent [to: "bruce@banner.com"]
+    rescue
+      error in [ExUnit.AssertionError] ->
+	"Email `to` does not match\n" <>
+	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+	"lhs: {\"\", \"bruce@banner.com\"}\n" <>
+	"rhs: [{\"\", \"steve@rogers.com\"}]"
+	= error.message
+    end
+  end
+
+  test "assert email sent with wrong to (list)" do
+    try do
+      assert_email_sent [to: ["bruce@banner.com"]]
+    rescue
+      error in [ExUnit.AssertionError] ->
+	"Email `to` does not match\n" <>
+	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+	"lhs: [{\"\", \"steve@rogers.com\"}]\n" <>
+	"rhs: [{\"\", \"bruce@banner.com\"}]"
+	= error.message
+    end
+  end
+
+  test "assert email sent with wrong cc" do
+    try do
+      assert_email_sent [cc: "bruce@banner.com"]
+    rescue
+      error in [ExUnit.AssertionError] ->
+	"Email `cc` does not match\n" <>
+	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+	"lhs: {\"\", \"bruce@banner.com\"}\n" <>
+	"rhs: []"
+	= error.message
+    end
+  end
+
+  test "assert email sent with wrong bcc" do
+    try do
+      assert_email_sent [bcc: "bruce@banner.com"]
+    rescue
+      error in [ExUnit.AssertionError] ->
+	"Email `bcc` does not match\n" <>
+	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+	"lhs: {\"\", \"bruce@banner.com\"}\n" <>
+	"rhs: []"
+	= error.message
+    end
+  end
+
   test "assert email sent with wrong email" do
     try do
       wrong_email = new |> subject("Wrong, Avengers!")


### PR DESCRIPTION
This adds some code to make it possible to use assert_email_sent with certain fields rather than the whole email.

