### PR TITLE
Change format on preview Plug to be user-friendly

### DIFF
--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -64,5 +64,13 @@ if Code.ensure_loaded?(Plug) do
     defp to_absolute_url(conn, path) do
       URI.parse("#{conn.assigns.base_path}/#{path}").path
     end
+
+    defp format_recipient(nil), do: "n/a"
+    defp format_recipient({nil, address}), do: address
+    defp format_recipient({"", address}), do: address
+    defp format_recipient({name, address}), do: "#{name} &lt;#{address}&gt;"
+
+    defp format_recipient_list([]), do: "n/a"
+    defp format_recipient_list(list), do: Enum.map(list, &format_recipient/1) |> Enum.join(", ")
   end
 end

--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -102,8 +102,8 @@
                 <% id = email.headers["Message-ID"] %>
                 <a href="<%= to_absolute_url(@conn, id) %>"
                    class="list-group-item<%= if @email && @email.headers["Message-ID"] == id, do: " active" %>">
-                  <h6 class="list-group-item-heading"><%= inspect(email.from) %></h6>
-                  <p class="list-group-item-text"><%= inspect(email.subject) %></p>
+		  <h6 class="list-group-item-heading"><%= format_recipient(email.from) %></h6>
+		  <p class="list-group-item-text"><%= email.subject %></p>
                 </a>
               <% end %>
             <% end %>
@@ -116,26 +116,26 @@
               <div class="header-content">
                 <dl class="dl-horizontal headers">
                   <dt class="col-sm-2">Subject</dt>
-                  <dd class="col-sm-10"><%= inspect(@email.subject) %></dd>
+		  <dd class="col-sm-10"><%= @email.subject %></dd>
 
                   <dt class="col-sm-2">From</dt>
-                  <dd class="col-sm-10"><%= inspect(@email.from) %></dd>
+		  <dd class="col-sm-10"><%= format_recipient(@email.from) %></dd>
 
                   <dt class="col-sm-2">To</dt>
-                  <dd class="col-sm-10"><%= inspect(@email.to) %></dd>
+		  <dd class="col-sm-10"><%= format_recipient_list(@email.to) %></dd>
 
                   <dt class="col-sm-2">Cc</dt>
-                  <dd class="col-sm-10"><%= inspect(@email.cc) %></dd>
+		  <dd class="col-sm-10"><%= format_recipient_list(@email.cc) %></dd>
 
                   <dt class="col-sm-2">Bcc</dt>
-                  <dd class="col-sm-10"><%= inspect(@email.bcc) %></dd>
+		  <dd class="col-sm-10"><%= format_recipient_list(@email.bcc) %></dd>
 
                   <dt class="col-sm-2">Reply-to</dt>
-                  <dd class="col-sm-10"><%= inspect(@email.reply_to) %></dd>
+		  <dd class="col-sm-10"><%= format_recipient(@email.reply_to) %></dd>
 
                   <%= for {name, value} <- @email.headers do %>
                     <dt class="col-sm-2"><%= name %></dt>
-                    <dd class="col-sm-10"><%= inspect(value) %></dd>
+		    <dd class="col-sm-10"><%= value %></dd>
                   <% end %>
                 </dl>
               </div>


### PR DESCRIPTION
We had some feedback that the formatting on the `Swoosh.Preview.Plug` can be confusing sometimes as we are using the `Inspect` protocol to display the fields in their Elixir native data format.

@lau fyi

<img width="1440" alt="screen shot 2016-04-16 at 13 45 12" src="https://cloud.githubusercontent.com/assets/512246/14581073/13d7336c-03da-11e6-9461-44fb40ab05c9.png">