### PR TITLE
Updates README.md `assert_email_sent` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ defmodule Sample.UserTest do
   import Swoosh.TestAssertions
 
   test "send email on user signup" do
+    # Assuming `create_user` creates a new user then sends out a `Sample.UserEmail.welcome` email
     user = create_user(%{username: "ironman", email: "tony@stark.com"})
-    assert_email_sent %Swoosh.Email{to: "tony@stark.com", subject: "Hello, ironman!"}
+    assert_email_sent Sample.UserEmail.welcome(user)
   end
 end
 ```


### PR DESCRIPTION
I believe this example is clearer than the previous one. The previous example actually fails if you don't construct the exact expected struct.