### PR TITLE
Add Null adapter

### DIFF
--- a/lib/swoosh/adapters/null.ex
+++ b/lib/swoosh/adapters/null.ex
@@ -1,0 +1,25 @@
+defmodule Swoosh.Adapters.Null do
+  @moduledoc ~S"""
+  An adapter that does nothing at all.
+
+  Useful for e.g. staging servers where you do not want emails to be sent,
+  but still want a valid return from `deliver`
+
+  ## Example
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.Null
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample
+      end
+  """
+
+  @behaviour Swoosh.Adapter
+
+  def deliver(%Swoosh.Email{} = email, _config) do
+    {:ok, :null}
+  end
+end

--- a/test/swoosh/adapters/null_test.exs
+++ b/test/swoosh/adapters/null_test.exs
@@ -1,0 +1,16 @@
+defmodule Swoosh.Adapters.NullTest do
+  use ExUnit.Case, async: true
+
+  defmodule NullMailer do
+    use Swoosh.Mailer, otp_app: :swoosh, adapter: Swoosh.Adapters.Null
+  end
+
+  test "deliver/1" do
+    email = Swoosh.Email.new(from: "tony@stark.com",
+                             to: "steve@rogers.com",
+                             subject: "Hello, Avengers!",
+                             text_body: "Hello!")
+
+    assert {:ok, :null} = NullMailer.deliver(email)
+  end
+end


### PR DESCRIPTION
An adapter that does nothing at all.

Useful for e.g. staging servers where you do not want emails to be sent,
but still want a valid return from `deliver`

The use-case that led to writing this adapter was that I have a long-running staging server, from which I don't want emails to be sent, and where using the `Local` adapter will lead to growing memory usage over the long term, if it's not purged periodically. Rather that setting up this purging, this adapter simply says that it sent an email, but does nothing.