### PR TITLE
Add dkim support to smtp adapter

### DIFF
--- a/lib/swoosh/adapters/sendmail.ex
+++ b/lib/swoosh/adapters/sendmail.ex
@@ -23,8 +23,7 @@ defmodule Swoosh.Adapters.Sendmail do
   @behaviour Swoosh.Adapter
 
   def deliver(%Email{} = email, config) do
-    {type, subtype, headers, parts} = SMTP.prepare_message(email)
-    body = :mimemail.encode({type, subtype, headers, [], parts})
+    body = SMTP.encode_message(email, config)
     port = Port.open({:spawn, cmd(email, config)}, [:binary])
     Port.command(port, body)
     Port.close(port)

--- a/test/swoosh/adapters/smtp_test.exs
+++ b/test/swoosh/adapters/smtp_test.exs
@@ -13,7 +13,16 @@ defmodule Swoosh.Adapters.SMTPTest do
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
 
-    {:ok, valid_email: valid_email}
+    valid_config = [
+      adapter: Swoosh.Adapters.SMTP,
+      relay: "localhost",
+      dkim: [s: "default", d: "example.com",
+      private_key: {:pem_plain,                                                                                                                                                                                                                 "-----BEGIN RSA PRIVATE KEY-----
+      #{String.duplicate("abcdefghijklmnopqrstuvwxyz\n", 13)}
+      -----END RSA PRIVATE KEY-----\n"}]
+    ]
+
+    {:ok, valid_email: valid_email, valid_config: valid_config}
   end
 
   test "simple email", %{valid_email: email} do
@@ -119,4 +128,13 @@ defmodule Swoosh.Adapters.SMTPTest do
           {"disposition-params", []}],
         "<h1>Hello</h1>"}]}
   end
+
+  test "no dkim in config", %{} do
+    assert SMTP.prepare_options([]) == []
+  end
+
+  test "dkim in config", %{valid_config: config} do
+    assert SMTP.prepare_options(config) == [{:dkim, config[:dkim]}]
+  end
+
 end


### PR DESCRIPTION
dkim config can be added to config or email.provider_options or both, dkim config in email.provider_options overrides the one in the config.