### PR TITLE
Add Logger adapter.

### DIFF
--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -22,7 +22,8 @@ if Code.ensure_loaded?(Plug) do
     use Plug.Router
     use Plug.ErrorHandler
 
-    alias Swoosh.InMemoryMailbox
+    alias Swoosh.Email.Format
+    alias InMemoryMailbox
 
     require EEx
     EEx.function_from_file :defp, :template, "lib/plug/templates/mailbox_viewer/index.html.eex", [:assigns]
@@ -65,12 +66,11 @@ if Code.ensure_loaded?(Plug) do
       URI.parse("#{conn.assigns.base_path}/#{path}").path
     end
 
-    defp format_recipient(nil), do: "n/a"
-    defp format_recipient({nil, address}), do: address
-    defp format_recipient({"", address}), do: address
-    defp format_recipient({name, address}), do: "#{name} &lt;#{address}&gt;"
-
-    defp format_recipient_list([]), do: "n/a"
-    defp format_recipient_list(list), do: Enum.map(list, &format_recipient/1) |> Enum.join(", ")
+    defp format_recipient(recipient) do
+      case Format.format_recipient(recipient) do
+	"" -> "n/a"
+	recipient -> Plug.HTML.html_escape(recipient)
+      end
+    end
   end
 end

--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -122,13 +122,13 @@
 		  <dd class="col-sm-10"><%= format_recipient(@email.from) %></dd>
 
                   <dt class="col-sm-2">To</dt>
-		  <dd class="col-sm-10"><%= format_recipient_list(@email.to) %></dd>
+		  <dd class="col-sm-10"><%= format_recipient(@email.to) %></dd>
 
                   <dt class="col-sm-2">Cc</dt>
-		  <dd class="col-sm-10"><%= format_recipient_list(@email.cc) %></dd>
+		  <dd class="col-sm-10"><%= format_recipient(@email.cc) %></dd>
 
                   <dt class="col-sm-2">Bcc</dt>
-		  <dd class="col-sm-10"><%= format_recipient_list(@email.bcc) %></dd>
+		  <dd class="col-sm-10"><%= format_recipient(@email.bcc) %></dd>
 
                   <dt class="col-sm-2">Reply-to</dt>
 		  <dd class="col-sm-10"><%= format_recipient(@email.reply_to) %></dd>

--- a/lib/swoosh/adapters/logger.ex
+++ b/lib/swoosh/adapters/logger.ex
@@ -1,0 +1,81 @@
+defmodule Swoosh.Adapters.Logger do
+  @moduledoc ~S"""
+  An adapter that only logs email using Logger.
+
+  It can be useful in environment where you do not necessarily want to send real
+  emails (eg. staging environments) or in development.
+
+  By default it only prints the recipient of the email but you can print the full
+  email by using `log_full_email: true` in the adapter configuration.
+
+  ## Example
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+	adapter: Swoosh.Adapters.Logger,
+	level: :debug
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+	use Swoosh.Mailer, otp_app: :sample
+      end
+  """
+
+  require Logger
+  import Swoosh.Email.Format
+
+  @behaviour Swoosh.Adapter
+
+  def deliver(%Swoosh.Email{} = email, config) do
+    rendered_email = render(config[:log_full_email] || false, email)
+    Logger.log(config[:level] || :info, rendered_email)
+    {:ok, %{}}
+  end
+
+  defp render(false, email) do
+    "New email delivered to #{format_recipient(email.to)}"
+  end
+
+  defp render(true, email) do
+    recipients = render_recipients(email)
+    subject = render_subject(email)
+    headers = render_headers(email)
+    bodies = render_bodies(email)
+
+    message =
+      [recipients, subject, headers, bodies]
+      |> Enum.filter(fn text -> text != "" end)
+      |> Enum.join("\n")
+
+    "New email delivered\n#{message}"
+  end
+
+  defp render_subject(email), do: "Subject: #{email.subject}"
+
+  defp render_recipients(email) do
+    [:from, :reply_to, :to, :cc, :bcc]
+    |> Enum.map(fn key -> {to_string(key), Map.get(email, key)} end)
+    |> Enum.filter(fn
+      {_key, value} when is_list(value) -> !Enum.empty?(value)
+      {_key, value} -> value
+    end)
+    |> Enum.map(fn {key, value} -> String.capitalize(key) <> ": " <> format_recipient(value) end)
+    |> Enum.join("\n")
+  end
+
+  defp render_headers(email) do
+    Enum.map(email.headers, fn {key, value} -> "#{key}: #{value}" end)
+    |> Enum.join("\n")
+  end
+
+  defp render_bodies(email) do
+    """
+
+    Text body:
+    #{email.text_body}
+
+    HTML body:
+    #{email.html_body}
+    """
+  end
+end

--- a/lib/swoosh/email/format.ex
+++ b/lib/swoosh/email/format.ex
@@ -1,0 +1,11 @@
+defmodule Swoosh.Email.Format do
+  def format_recipient(nil), do: ""
+  def format_recipient({nil, address}), do: address
+  def format_recipient({"", address}), do: address
+  def format_recipient({name, address}), do: "#{name} <#{address}>"
+  def format_recipient([]), do: ""
+  def format_recipient(list) when is_list(list) do
+    Enum.map(list, &format_recipient/1)
+    |> Enum.join(", ")
+  end
+end

--- a/test/swoosh/adapters/logger_test.exs
+++ b/test/swoosh/adapters/logger_test.exs
@@ -1,0 +1,31 @@
+defmodule Swoosh.Adapters.LoggerTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  defmodule LoggerMailer do
+    use Swoosh.Mailer, otp_app: :swoosh, adapter: Swoosh.Adapters.Logger
+  end
+
+  setup_all do
+    email = Swoosh.Email.new(from: "tony@stark.com",
+			     to: "steve@rogers.com",
+			     subject: "Hello, Avengers!",
+			     text_body: "Hello!")
+    {:ok, email: email}
+  end
+
+  test "deliver/1", %{email: email} do
+    assert capture_log(fn ->
+      {status, _} = LoggerMailer.deliver(email)
+      assert status == :ok
+    end) =~ "New email delivered to steve@rogers.com"
+  end
+
+  test "deliver/1, log full email", %{email: email} do
+    assert capture_log(fn ->
+      {status, _} = LoggerMailer.deliver(email, log_full_email: true)
+      assert status == :ok
+    end) =~ "New email delivered\nFrom: tony@stark.com"
+  end
+end


### PR DESCRIPTION
This can be useful when you don't want to send real emails but still
want the Mailer to return successfully.

This was triggered by https://github.com/swoosh/swoosh/pull/72/