### PR TITLE
Raise an error if the mailgun config is missing :domain or :api_key

### DIFF
--- a/lib/swoosh/adapter.ex
+++ b/lib/swoosh/adapter.ex
@@ -10,6 +10,11 @@ defmodule Swoosh.Adapter do
   @typep config :: Keyword.t
 
   @doc """
+  Validates the config passed to the adapter.
+  """
+  @callback validate_config(config) :: {:ok} | {:error, term}
+
+  @doc """
   Delivers an email with the given config.
   """
   @callback deliver(email, config) :: {:ok, term} | {:error, term}

--- a/lib/swoosh/adapters/local.ex
+++ b/lib/swoosh/adapters/local.ex
@@ -21,6 +21,8 @@ defmodule Swoosh.Adapters.Local do
 
   @behaviour Swoosh.Adapter
 
+  def validate_config(_config), do: {:ok}
+
   def deliver(%Swoosh.Email{} = email, config) do
     driver = storage_driver(config)
     %Swoosh.Email{headers: %{"Message-ID" => id}} = driver.push(email)

--- a/lib/swoosh/adapters/logger.ex
+++ b/lib/swoosh/adapters/logger.ex
@@ -26,6 +26,8 @@ defmodule Swoosh.Adapters.Logger do
 
   @behaviour Swoosh.Adapter
 
+  def validate_config(_config), do: {:ok}
+
   def deliver(%Swoosh.Email{} = email, config) do
     rendered_email = render(config[:log_full_email] || false, email)
     Logger.log(config[:level] || :info, rendered_email)

--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -26,6 +26,16 @@ defmodule Swoosh.Adapters.Mailgun do
   @base_url     "https://api.mailgun.net/v3"
   @api_endpoint "/messages"
 
+  def validate_config(config) do
+    config_keys = Keyword.keys(config) |> Enum.sort
+    case config_keys do
+      [:api_key, :base_url, :domain] -> {:ok}
+      [:api_key, :domain] -> {:ok}
+      [:api_key] -> {:error, "Missing :domain from Mailgun config"}
+      [:domain] -> {:error, "Missing :api_key from Mailgun config"}
+    end
+  end
+
   def deliver(%Email{} = email, config \\ []) do
     headers = prepare_headers(email, config)
     params = email |> prepare_body |> Plug.Conn.Query.encode

--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -26,6 +26,8 @@ defmodule Swoosh.Adapters.Mandrill do
   @api_endpoint "/messages/send.json"
   @headers      [{"Content-Type", "application/json"}]
 
+  def validate_config(_config), do: {:ok}
+
   def deliver(%Email{} = email, config \\ []) do
     body = email |> prepare_body(config) |> Poison.encode!
 

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -25,6 +25,8 @@ defmodule Swoosh.Adapters.Postmark do
   @base_url     "https://api.postmarkapp.com"
   @api_endpoint "/email"
 
+  def validate_config(_config), do: {:ok}
+
   def deliver(%Email{} = email, config \\ []) do
     headers = prepare_headers(config)
     params = email |> prepare_body |> Poison.encode!

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -25,6 +25,8 @@ defmodule Swoosh.Adapters.Sendgrid do
   @base_url "https://api.sendgrid.com/api"
   @api_endpoint "/mail.send.json"
 
+  def validate_config(_config), do: {:ok}
+
   def deliver(%Email{} = email, config \\ []) do
     headers = [{"Content-Type", "application/x-www-form-urlencoded"},
                {"User-Agent", "swoosh/#{Swoosh.version}"},

--- a/lib/swoosh/adapters/sendmail.ex
+++ b/lib/swoosh/adapters/sendmail.ex
@@ -22,6 +22,8 @@ defmodule Swoosh.Adapters.Sendmail do
 
   @behaviour Swoosh.Adapter
 
+  def validate_config(_config), do: {:ok}
+
   def deliver(%Email{} = email, config) do
     body = SMTP.encode_message(email, config)
     port = Port.open({:spawn, cmd(email, config)}, [:binary])

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -30,6 +30,18 @@ defmodule Swoosh.Adapters.SMTP do
 
   @behaviour Swoosh.Adapter
 
+  def validate_config(config) do
+    required = MapSet.new [:relay, :password, :username]
+    actual   = MapSet.new(Keyword.keys(config))
+
+    case MapSet.difference(required, actual) do
+      [] -> {:ok}
+      missing ->
+        {:error, "Swoosh.Adapters.SMTP is missing " +
+                 "config keys: #{Enum.join(missing, ", ")}"}
+    end
+  end
+
   def deliver(%Email{} = email, config) do
     mail_from = mail_from(email)
     recipients = all_recipients(email)

--- a/lib/swoosh/adapters/test.ex
+++ b/lib/swoosh/adapters/test.ex
@@ -19,6 +19,8 @@ defmodule Swoosh.Adapters.Test do
 
   @behaviour Swoosh.Adapter
 
+  def validate_config(_config), do: {:ok}
+
   def deliver(email, _config) do
     send(self(), {:email, email})
     {:ok, %{}}

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -89,7 +89,11 @@ defmodule Swoosh.Mailer do
           @config
           |> Keyword.merge(config)
           |> Swoosh.Mailer.parse_runtime_config()
-        @adapter.deliver(email, config)
+
+        case @adapter.validate_config(config) do
+          {:ok} -> @adapter.deliver(email, config)
+          {:error, message} -> {:error, message}
+        end
       end
       def deliver(email, _config) do
         raise ArgumentError, "expected %Swoosh.Email{}, got #{inspect email}"
@@ -126,3 +130,4 @@ defmodule Swoosh.Mailer do
     end
   end
 end
+

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -14,6 +14,7 @@ defmodule Swoosh.Adapters.MailgunTest do
   setup_all do
     bypass = Bypass.open
     config = [base_url: "http://localhost:#{bypass.port}",
+              api_key: "fake",
               domain: "avengers.com"]
 
     valid_email =
@@ -94,5 +95,9 @@ defmodule Swoosh.Adapters.MailgunTest do
     end
 
     assert Mailgun.deliver(email, config) == {:error, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}
+  end
+
+  test "validate_config/1", %{config: config} do
+    assert Mailgun.validate_config(config) == {:ok}
   end
 end

--- a/test/swoosh/mailer_test.exs
+++ b/test/swoosh/mailer_test.exs
@@ -6,6 +6,7 @@ defmodule Swoosh.MailerTest do
     domain: "avengers.com")
 
   defmodule FakeAdapter do
+    def validate_config(_config), do: {:ok}
     def deliver(email, config), do: {email, config}
   end
 
@@ -87,5 +88,18 @@ defmodule Swoosh.MailerTest do
   test "merge config passed to deliver/2 into Mailer's config", %{valid_email: email} do
     assert FakeMailer.deliver(email, domain: "jarvis.com") ==
       {email, [api_key: "api-key", domain: "jarvis.com"]}
+  end
+
+  test "validate config passed to deliver/2", %{valid_email: email} do
+    defmodule NoConfigAdapter do
+      def deliver(_email, _config), do: :nothing
+      def validate_config(_config), do: {:error, "Missing"}
+    end
+
+    defmodule NoConfigMailer do
+      use Swoosh.Mailer, otp_app: :swoosh, adapter: NoConfigAdapter
+    end
+
+    assert NoConfigMailer.deliver(email, domain: "jarvis.com") == {:error, "Missing"}
   end
 end


### PR DESCRIPTION
References: https://github.com/swoosh/swoosh/issues/76

Let me know if you have any comments. Thanks.