### PR TITLE
Handle 401 response from Mailgun

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -33,6 +33,8 @@ defmodule Swoosh.Adapters.Mailgun do
     case HTTPoison.post(base_url(config) <> "/" <> config[:domain] <> @api_endpoint, params, headers) do
       {:ok, %Response{status_code: code, body: body}} when code >= 200 and code <= 299 ->
         {:ok, %{id: Poison.decode!(body)["id"]}}
+      {:ok, %Response{status_code: code, body: body}} when code == 401 ->
+        {:error, body}
       {:ok, %Response{status_code: code, body: body}} when code >= 400 and code <= 499 ->
         {:error, Poison.decode!(body)}
       {:ok, %Response{status_code: code, body: body}} when code >= 500 and code <= 599 ->

--- a/test/integration/adapters/mailgun_test.exs
+++ b/test/integration/adapters/mailgun_test.exs
@@ -25,4 +25,17 @@ defmodule Swoosh.Integration.Adapters.MailgunTest do
 
     assert {:ok, _response} = Swoosh.Adapters.Mailgun.deliver(email, config)
   end
+
+  test ":error with wrong api key", %{config: config} do
+    config = Keyword.put(config, :api_key, "bad_key")
+
+    email =
+      new
+      |> from({"Swoosh Mailgun", "swoosh@#{config[:domain]}"})
+      |> to("swoosh+to@elixirhq.com")
+      |> subject("Swoosh - Mailgun integration test")
+      |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")
+
+    assert {:error, "Forbidden"} = Swoosh.Adapters.Mailgun.deliver(email, config)
+  end
 end

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -83,10 +83,10 @@ defmodule Swoosh.Adapters.MailgunTest do
 
   test "delivery/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 401, "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}")
+      Plug.Conn.resp(conn, 401, "Forbidden")
     end
 
-    assert Mailgun.deliver(email, config) == {:error, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}
+    assert Mailgun.deliver(email, config) == {:error, "Forbidden"}
   end
 
   test "deliver/1 with 5xx response", %{bypass: bypass, valid_email: email, config: config} do


### PR DESCRIPTION
The Mailgun adapter expects a JSON response from the API when the response is a 401 (`:api_key` is invalid). Mailgun returns the string "Forbidden" instead, which causes a exception.

```
test wrong api key (Swoosh.Integration.Adapters.MailgunTest)
     test/integration/adapters/mailgun_test.exs:29
     ** (Poison.SyntaxError) Unexpected token: F
     stacktrace:
       lib/poison/parser.ex:56: Poison.Parser.parse!/2
       lib/poison.ex:83: Poison.decode!/2
       (swoosh) lib/swoosh/adapters/mailgun.ex:37: Swoosh.Adapters.Mailgun.deliver/2
       test/integration/adapters/mailgun_test.exs:39
```

Here is a proposed solution. I didn't actually check that the other status codes also return a string, but I think that's safe to assume that's the case. The docs https://documentation.mailgun.com/api-intro.html#errors are silent.
