### PR TITLE
Update mix.exs to add Poison and gen_smtp to applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Swoosh.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison],
+    [applications: [:logger, :httpoison, :poison, :gen_smtp],
      mod: {Swoosh.Application, []}]
   end
 


### PR DESCRIPTION
In an exrm release, poison and gen_smtp will not be included because they are missing from Swoosh's applications list.