### PR TITLE
Raise on missing config

### DIFF
--- a/lib/swoosh/adapter.ex
+++ b/lib/swoosh/adapter.ex
@@ -3,16 +3,33 @@ defmodule Swoosh.Adapter do
   Specification of the email delivery adapter.
   """
 
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts] do
+      @required_config opts[:required_config] || []
+
+      @behaviour Swoosh.Adapter
+
+      def validate_config(config) do
+        missing_keys = Enum.reduce(@required_config, [], fn(key, missing_keys) ->
+          if config[key] in [nil, ""], do: [key | missing_keys], else: missing_keys
+        end)
+        raise_on_missing_config(missing_keys, config)
+      end
+
+      def raise_on_missing_config([], _config), do: :ok
+      def raise_on_missing_config(key, config) do
+        raise ArgumentError, """
+        expected #{inspect key} to be set, got: #{inspect config}
+        """
+      end
+    end
+  end
+
   @type t :: module
 
   @type email :: Email.t
 
   @typep config :: Keyword.t
-
-  @doc """
-  Validates the config passed to the adapter.
-  """
-  @callback validate_config(config) :: {:ok} | {:error, term}
 
   @doc """
   Delivers an email with the given config.

--- a/lib/swoosh/adapters/local.ex
+++ b/lib/swoosh/adapters/local.ex
@@ -19,9 +19,7 @@ defmodule Swoosh.Adapters.Local do
       end
   """
 
-  @behaviour Swoosh.Adapter
-
-  def validate_config(_config), do: {:ok}
+  use Swoosh.Adapter
 
   def deliver(%Swoosh.Email{} = email, config) do
     driver = storage_driver(config)

--- a/lib/swoosh/adapters/logger.ex
+++ b/lib/swoosh/adapters/logger.ex
@@ -12,21 +12,19 @@ defmodule Swoosh.Adapters.Logger do
 
       # config/config.exs
       config :sample, Sample.Mailer,
-	adapter: Swoosh.Adapters.Logger,
-	level: :debug
+        adapter: Swoosh.Adapters.Logger,
+        level: :debug
 
       # lib/sample/mailer.ex
       defmodule Sample.Mailer do
-	use Swoosh.Mailer, otp_app: :sample
+        use Swoosh.Mailer, otp_app: :sample
       end
   """
 
+  use Swoosh.Adapter
+
   require Logger
   import Swoosh.Email.Format
-
-  @behaviour Swoosh.Adapter
-
-  def validate_config(_config), do: {:ok}
 
   def deliver(%Swoosh.Email{} = email, config) do
     rendered_email = render(config[:log_full_email] || false, email)

--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -18,23 +18,13 @@ defmodule Swoosh.Adapters.Mailgun do
       end
   """
 
+  use Swoosh.Adapter, required_config: [:api_key, :domain]
+
   alias HTTPoison.Response
   alias Swoosh.Email
 
-  @behaviour Swoosh.Adapter
-
   @base_url     "https://api.mailgun.net/v3"
   @api_endpoint "/messages"
-
-  def validate_config(config) do
-    config_keys = Keyword.keys(config) |> Enum.sort
-    case config_keys do
-      [:api_key, :base_url, :domain] -> {:ok}
-      [:api_key, :domain] -> {:ok}
-      [:api_key] -> {:error, "Missing :domain from Mailgun config"}
-      [:domain] -> {:error, "Missing :api_key from Mailgun config"}
-    end
-  end
 
   def deliver(%Email{} = email, config \\ []) do
     headers = prepare_headers(email, config)

--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -17,16 +17,14 @@ defmodule Swoosh.Adapters.Mandrill do
       end
   """
 
+  use Swoosh.Adapter, required_config: [:api_key]
+
   alias HTTPoison.Response
   alias Swoosh.Email
-
-  @behaviour Swoosh.Adapter
 
   @base_url     "https://mandrillapp.com/api/1.0"
   @api_endpoint "/messages/send.json"
   @headers      [{"Content-Type", "application/json"}]
-
-  def validate_config(_config), do: {:ok}
 
   def deliver(%Email{} = email, config \\ []) do
     body = email |> prepare_body(config) |> Poison.encode!

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -17,15 +17,13 @@ defmodule Swoosh.Adapters.Postmark do
       end
   """
 
+  use Swoosh.Adapter, required_config: [:api_key]
+
   alias HTTPoison.Response
   alias Swoosh.Email
 
-  @behaviour Swoosh.Adapter
-
   @base_url     "https://api.postmarkapp.com"
   @api_endpoint "/email"
-
-  def validate_config(_config), do: {:ok}
 
   def deliver(%Email{} = email, config \\ []) do
     headers = prepare_headers(config)

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -17,15 +17,13 @@ defmodule Swoosh.Adapters.Sendgrid do
       end
   """
 
+  use Swoosh.Adapter, required_config: [:api_key]
+
   alias HTTPoison.Response
   alias Swoosh.Email
 
-  @behaviour Swoosh.Adapter
-
   @base_url "https://api.sendgrid.com/api"
   @api_endpoint "/mail.send.json"
-
-  def validate_config(_config), do: {:ok}
 
   def deliver(%Email{} = email, config \\ []) do
     headers = [{"Content-Type", "application/x-www-form-urlencoded"},

--- a/lib/swoosh/adapters/sendmail.ex
+++ b/lib/swoosh/adapters/sendmail.ex
@@ -17,12 +17,10 @@ defmodule Swoosh.Adapters.Sendmail do
       end
   """
 
+  use Swoosh.Adapter
+
   alias Swoosh.Email
   alias Swoosh.Adapters.SMTP
-
-  @behaviour Swoosh.Adapter
-
-  def validate_config(_config), do: {:ok}
 
   def deliver(%Email{} = email, config) do
     body = SMTP.encode_message(email, config)
@@ -59,5 +57,4 @@ defmodule Swoosh.Adapters.Sendmail do
   def shell_escape(s) do
     "'" <> String.replace(s, "'", "'\\''") <> "'"
   end
-
 end

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -26,21 +26,9 @@ defmodule Swoosh.Adapters.SMTP do
       end
   """
 
+  use Swoosh.Adapter, required_config: [:relay]
+
   alias Swoosh.Email
-
-  @behaviour Swoosh.Adapter
-
-  def validate_config(config) do
-    required = MapSet.new [:relay, :password, :username]
-    actual   = MapSet.new(Keyword.keys(config))
-
-    case MapSet.difference(required, actual) do
-      [] -> {:ok}
-      missing ->
-        {:error, "Swoosh.Adapters.SMTP is missing " +
-                 "config keys: #{Enum.join(missing, ", ")}"}
-    end
-  end
 
   def deliver(%Email{} = email, config) do
     mail_from = mail_from(email)

--- a/lib/swoosh/adapters/test.ex
+++ b/lib/swoosh/adapters/test.ex
@@ -17,9 +17,7 @@ defmodule Swoosh.Adapters.Test do
       end
   """
 
-  @behaviour Swoosh.Adapter
-
-  def validate_config(_config), do: {:ok}
+  use Swoosh.Adapter
 
   def deliver(email, _config) do
     send(self(), {:email, email})

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -93,10 +93,8 @@ defmodule Swoosh.Mailer do
   def deliver(adapter, %Swoosh.Email{} = email, config) do
     config = config |> Swoosh.Mailer.parse_runtime_config()
 
-    case adapter.validate_config(config) do
-      {:ok} -> adapter.deliver(email, config)
-      {:error, message} -> {:error, message}
-    end
+    :ok = adapter.validate_config(config)
+    adapter.deliver(email, config)
   end
   def deliver(_adapter, email, _config) do
     raise ArgumentError, "expected %Swoosh.Email{}, got #{inspect email}"

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -97,7 +97,15 @@ defmodule Swoosh.Adapters.MailgunTest do
     assert Mailgun.deliver(email, config) == {:error, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}
   end
 
-  test "validate_config/1", %{config: config} do
-    assert Mailgun.validate_config(config) == {:ok}
+  test "validate_config/1 with valid config", %{config: config} do
+    assert Mailgun.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise ArgumentError, """
+    expected [:domain, :api_key] to be set, got: []
+    """, fn ->
+      Mailgun.validate_config([])
+    end
   end
 end

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -132,4 +132,16 @@ defmodule Swoosh.Adapters.MandrillTest do
 
     assert Mandrill.deliver(email, config) == {:error, %{"code" => -1, "message" => "Invalid API key", "name" => "Invalid_Key", "status" => "error"}}
   end
+
+  test "validate_config/1 with valid config", %{config: config} do
+    assert Mandrill.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise ArgumentError, """
+    expected [:api_key] to be set, got: []
+    """, fn ->
+      Mandrill.validate_config([])
+    end
+  end
 end

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -17,7 +17,6 @@ defmodule Swoosh.Adapters.PostmarkTest do
   setup_all do
     bypass = Bypass.open
     config = [base_url: "http://localhost:#{bypass.port}",
-              domain: "/avengers.com",
               api_key: "jarvis"]
 
     valid_email =
@@ -98,5 +97,17 @@ defmodule Swoosh.Adapters.PostmarkTest do
     end
 
     assert Postmark.deliver(email, config) == {:error, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}
+  end
+
+  test "validate_config/1 with valid config", %{config: config} do
+    assert Postmark.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise ArgumentError, """
+    expected [:api_key] to be set, got: []
+    """, fn ->
+      Postmark.validate_config([])
+    end
   end
 end

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -13,7 +13,7 @@ defmodule Swoosh.Adapters.SendgridTest do
 
   setup_all do
     bypass = Bypass.open
-    config = [base_url: "http://localhost:#{bypass.port}"]
+    config = [api_key: "123", base_url: "http://localhost:#{bypass.port}"]
 
     valid_email =
       new
@@ -96,5 +96,18 @@ defmodule Swoosh.Adapters.SendgridTest do
     end
     assert Sendgrid.deliver(email, config) ==
            {:error, %{"errors" => ["Internal server error"], "message" => "error"}}
+  end
+
+
+  test "validate_config/1 with valid config", %{config: config} do
+    assert Sendgrid.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise ArgumentError, """
+    expected [:api_key] to be set, got: []
+    """, fn ->
+      Sendgrid.validate_config([])
+    end
   end
 end

--- a/test/swoosh/adapters/sendmail_test.exs
+++ b/test/swoosh/adapters/sendmail_test.exs
@@ -44,5 +44,4 @@ defmodule Swoosh.Adapters.SendmailTest do
     cmd = "#{config[:cmd_path]} -f'tony@stark.com' -oi -t #{config[:cmd_args]}"
     assert Sendmail.cmd(email, config) == cmd
   end
-
 end

--- a/test/swoosh/adapters/smtp_test.exs
+++ b/test/swoosh/adapters/smtp_test.exs
@@ -14,7 +14,6 @@ defmodule Swoosh.Adapters.SMTPTest do
       |> text_body("Hello")
 
     valid_config = [
-      adapter: Swoosh.Adapters.SMTP,
       relay: "localhost",
       dkim: [s: "default", d: "example.com",
       private_key: {:pem_plain,                                                                                                                                                                                                                 "-----BEGIN RSA PRIVATE KEY-----
@@ -137,4 +136,15 @@ defmodule Swoosh.Adapters.SMTPTest do
     assert SMTP.prepare_options(config) == [{:dkim, config[:dkim]}]
   end
 
+  test "validate_config/1 with valid config", %{valid_config: config} do
+    assert SMTP.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise ArgumentError, """
+    expected [:relay] to be set, got: []
+    """, fn ->
+      SMTP.validate_config([])
+    end
+  end
 end

--- a/test/swoosh/mailer_test.exs
+++ b/test/swoosh/mailer_test.exs
@@ -6,7 +6,8 @@ defmodule Swoosh.MailerTest do
     domain: "avengers.com")
 
   defmodule FakeAdapter do
-    def validate_config(_config), do: {:ok}
+    use Swoosh.Adapter
+
     def deliver(email, config), do: {email, config}
   end
 
@@ -92,14 +93,18 @@ defmodule Swoosh.MailerTest do
 
   test "validate config passed to deliver/2", %{valid_email: email} do
     defmodule NoConfigAdapter do
+      use Swoosh.Adapter, required_config: [:api_key]
       def deliver(_email, _config), do: :nothing
-      def validate_config(_config), do: {:error, "Missing"}
     end
 
     defmodule NoConfigMailer do
       use Swoosh.Mailer, otp_app: :swoosh, adapter: NoConfigAdapter
     end
 
-    assert NoConfigMailer.deliver(email, domain: "jarvis.com") == {:error, "Missing"}
+    assert_raise ArgumentError, """
+    expected [:api_key] to be set, got: [domain: "jarvis.com"]
+    """, fn ->
+      NoConfigMailer.deliver(email, domain: "jarvis.com")
+    end
   end
 end


### PR DESCRIPTION
Currently we only return a {:error, reason} tuple if the adapter config
fails the validation. This decision was made in
https://github.com/swoosh/swoosh/pull/80 but is not ideal as users of
the library can't do much in that case and end up raising in their
application.