### PR TITLE
Add Swoosh.Mailer.deliver!/2

### DIFF
--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -100,10 +100,9 @@
             <% else %>
               <%= for email <- @emails do %>
                 <% id = email.headers["Message-ID"] %>
-                <a href="<%= to_absolute_url(@conn, id) %>"
-                   class="list-group-item<%= if @email && @email.headers["Message-ID"] == id, do: " active" %>">
-		  <h6 class="list-group-item-heading"><%= format_recipient(email.from) %></h6>
-		  <p class="list-group-item-text"><%= email.subject %></p>
+                <a href="<%= to_absolute_url(@conn, id) %>" class="list-group-item<%= if @email && @email.headers["Message-ID"] == id, do: " active" %>">
+                  <h6 class="list-group-item-heading"><%= format_recipient(email.from) %></h6>
+                  <p class="list-group-item-text"><%= email.subject %></p>
                 </a>
               <% end %>
             <% end %>
@@ -116,26 +115,26 @@
               <div class="header-content">
                 <dl class="dl-horizontal headers">
                   <dt class="col-sm-2">Subject</dt>
-		  <dd class="col-sm-10"><%= @email.subject %></dd>
+                  <dd class="col-sm-10"><%= @email.subject %></dd>
 
                   <dt class="col-sm-2">From</dt>
-		  <dd class="col-sm-10"><%= format_recipient(@email.from) %></dd>
+                  <dd class="col-sm-10"><%= format_recipient(@email.from) %></dd>
 
                   <dt class="col-sm-2">To</dt>
-		  <dd class="col-sm-10"><%= format_recipient(@email.to) %></dd>
+                  <dd class="col-sm-10"><%= format_recipient(@email.to) %></dd>
 
                   <dt class="col-sm-2">Cc</dt>
-		  <dd class="col-sm-10"><%= format_recipient(@email.cc) %></dd>
+                  <dd class="col-sm-10"><%= format_recipient(@email.cc) %></dd>
 
                   <dt class="col-sm-2">Bcc</dt>
-		  <dd class="col-sm-10"><%= format_recipient(@email.bcc) %></dd>
+                  <dd class="col-sm-10"><%= format_recipient(@email.bcc) %></dd>
 
                   <dt class="col-sm-2">Reply-to</dt>
-		  <dd class="col-sm-10"><%= format_recipient(@email.reply_to) %></dd>
+                  <dd class="col-sm-10"><%= format_recipient(@email.reply_to) %></dd>
 
                   <%= for {name, value} <- @email.headers do %>
                     <dt class="col-sm-2"><%= name %></dt>
-		    <dd class="col-sm-10"><%= value %></dd>
+                    <dd class="col-sm-10"><%= value %></dd>
                   <% end %>
                 </dl>
               </div>

--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -32,8 +32,8 @@ defmodule Swoosh.Adapters.Mandrill do
     case HTTPoison.post(base_url(config) <> @api_endpoint, body, @headers) do
       {:ok, %Response{status_code: 200, body: body}} ->
         interpret_response(body)
-      {:ok, %Response{status_code: code, body: body}} when code != 200 ->
-        {:error, Poison.decode!(body)}
+      {:ok, %Response{status_code: code, body: body}} when code > 399 ->
+        {:error, {code, Poison.decode!(body)}}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, reason}
     end

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -32,10 +32,8 @@ defmodule Swoosh.Adapters.Postmark do
     case HTTPoison.post(base_url(config) <> @api_endpoint, params, headers) do
       {:ok, %Response{status_code: 200, body: body}} ->
         {:ok, %{id: Poison.decode!(body)["MessageID"]}}
-      {:ok, %Response{status_code: code, body: body}} when code >= 400 and code <= 499 ->
-        {:error, Poison.decode!(body)}
-      {:ok, %Response{status_code: code, body: body}} when code >= 500 and code <= 599 ->
-        {:error, Poison.decode!(body)}
+      {:ok, %Response{status_code: code, body: body}} when code > 399 ->
+        {:error, {code, Poison.decode!(body)}}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, reason}
     end

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -32,12 +32,10 @@ defmodule Swoosh.Adapters.Sendgrid do
     body = email |> prepare_body() |> Plug.Conn.Query.encode
 
     case HTTPoison.post(base_url(config) <> @api_endpoint, body, headers) do
-      {:ok, %Response{status_code: code}} when code >= 200 and code <= 299 ->
+      {:ok, %Response{status_code: code}} when code >= 200 and code <= 399 ->
         {:ok, %{}}
-      {:ok, %Response{status_code: code, body: body}} when code >= 400 and code <= 499 ->
-        {:error, Poison.decode!(body)}
-      {:ok, %Response{status_code: code, body: body}} when code >= 500 and code <= 599 ->
-        {:error, Poison.decode!(body)}
+      {:ok, %Response{status_code: code, body: body}} when code > 399 ->
+        {:error, {code, Poison.decode!(body)}}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, reason}
     end

--- a/lib/swoosh/delivery_error.ex
+++ b/lib/swoosh/delivery_error.ex
@@ -1,0 +1,14 @@
+defmodule Swoosh.DeliveryError do
+  defexception [reason: nil, payload: nil]
+
+  def message(exception) do
+    formatted = format_error(exception.reason, exception.payload)
+    "delivery error: #{formatted}"
+  end
+
+  defp format_error(:from_not_set, _), do: "expected \"from\" to be set"
+  defp format_error(:invalid_email, _), do: "expected %Swoosh.Email{}"
+  defp format_error(:api_error, {code, body}), do: "api error - response code: #{code}. body: #{body}"
+  defp format_error(:smtp_error, {type, message}), do: "smtp error - type: #{type}. message: #{message}"
+  defp format_error(reason, _), do: "#{inspect reason}"
+end

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -40,28 +40,29 @@ defmodule Swoosh.TestAssertions do
       Enum.each params, fn param -> assert_equal(email, param) end
     rescue
       error ->
-	stacktrace = System.stacktrace
-	name = error.__struct__
-	field =
-	  case elem(error.expr, 0) do
-	    :== ->
-	      {_, _, [{{_, _, [_, field]}, _, _},_]} = error.expr
-	      field
-	    :in ->
-	      {_, _, [{_, _, _}, {{_, _, [_, field]}, _, _}]} = error.expr
-	      field
-	  end
+        stacktrace = System.stacktrace
+        name = error.__struct__
+        field =
+          case elem(error.expr, 0) do
+            :== ->
+              {_, _, [{{_, _, [_, field]}, _, _},_]} = error.expr
+              field
+            :in ->
+              {_, _, [{_, _, _}, {{_, _, [_, field]}, _, _}]} = error.expr
+              field
+          end
 
-	cond do
-	  name == ExUnit.AssertionError ->
-	    message = "Email `#{to_string(field)}` does not match\n" <>
-		      "email: #{inspect email}\n" <>
-		      "lhs: #{inspect error.left}\n" <>
-		      "rhs: #{inspect error.right}"
-	    reraise ExUnit.AssertionError, [message: message], stacktrace
-	  true ->
-	    reraise(error, stacktrace)
-	end
+        cond do
+          name == ExUnit.AssertionError ->
+            message =
+              "Email `#{to_string(field)}` does not match\n" <>
+              "email: #{inspect email}\n" <>
+              "lhs: #{inspect error.left}\n" <>
+              "rhs: #{inspect error.right}"
+            reraise ExUnit.AssertionError, [message: message], stacktrace
+          true ->
+            reraise(error, stacktrace)
+        end
     end
   end
 

--- a/test/integration/adapters/mailgun_test.exs
+++ b/test/integration/adapters/mailgun_test.exs
@@ -6,8 +6,10 @@ defmodule Swoosh.Integration.Adapters.MailgunTest do
   @moduletag integration: true
 
   setup_all do
-    config = [domain: System.get_env("MAILGUN_DOMAIN"),
-	      api_key: System.get_env("MAILGUN_API_KEY")]
+    config = [
+      domain: System.get_env("MAILGUN_DOMAIN"),
+      api_key: System.get_env("MAILGUN_API_KEY")
+    ]
     {:ok, config: config}
   end
 
@@ -36,6 +38,6 @@ defmodule Swoosh.Integration.Adapters.MailgunTest do
       |> subject("Swoosh - Mailgun integration test")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")
 
-    assert {:error, "Forbidden"} = Swoosh.Adapters.Mailgun.deliver(email, config)
+    assert {:error, {401, "Forbidden"}} = Swoosh.Adapters.Mailgun.deliver(email, config)
   end
 end

--- a/test/integration/adapters/smtp_test.exs
+++ b/test/integration/adapters/smtp_test.exs
@@ -6,11 +6,13 @@ defmodule Swoosh.Integration.Adapters.SMTPTest do
   @moduletag integration: true
 
   setup_all do
-    config = [relay: System.get_env("SMTP_RELAY"),
-	      username: System.get_env("SMTP_USERNAME"),
-	      password: System.get_env("SMTP_PASSWORD"),
-	      tls: :always,
-	      auth: :always]
+    config = [
+      relay: System.get_env("SMTP_RELAY"),
+      username: System.get_env("SMTP_USERNAME"),
+      password: System.get_env("SMTP_PASSWORD"),
+      tls: :always,
+      auth: :always
+    ]
     {:ok, config: config}
   end
 

--- a/test/swoosh/adapters/logger_test.exs
+++ b/test/swoosh/adapters/logger_test.exs
@@ -8,10 +8,12 @@ defmodule Swoosh.Adapters.LoggerTest do
   end
 
   setup_all do
-    email = Swoosh.Email.new(from: "tony@stark.com",
-			     to: "steve@rogers.com",
-			     subject: "Hello, Avengers!",
-			     text_body: "Hello!")
+    email = Swoosh.Email.new(
+      from: "tony@stark.com",
+      to: "steve@rogers.com",
+      subject: "Hello, Avengers!",
+      text_body: "Hello!"
+    )
     {:ok, email: email}
   end
 

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -86,7 +86,7 @@ defmodule Swoosh.Adapters.MailgunTest do
       Plug.Conn.resp(conn, 401, "Forbidden")
     end
 
-    assert Mailgun.deliver(email, config) == {:error, "Forbidden"}
+    assert Mailgun.deliver(email, config) == {:error, {401, "Forbidden"}}
   end
 
   test "deliver/1 with 5xx response", %{bypass: bypass, valid_email: email, config: config} do
@@ -94,7 +94,7 @@ defmodule Swoosh.Adapters.MailgunTest do
       Plug.Conn.resp(conn, 500, "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}")
     end
 
-    assert Mailgun.deliver(email, config) == {:error, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}
+    assert Mailgun.deliver(email, config) == {:error, {500, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}}
   end
 
   test "validate_config/1 with valid config", %{config: config} do

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -130,7 +130,7 @@ defmodule Swoosh.Adapters.MandrillTest do
       Plug.Conn.resp(conn, 500, "{\"status\":\"error\",\"code\":-1,\"name\":\"Invalid_Key\",\"message\":\"Invalid API key\"}")
     end
 
-    assert Mandrill.deliver(email, config) == {:error, %{"code" => -1, "message" => "Invalid API key", "name" => "Invalid_Key", "status" => "error"}}
+    assert Mandrill.deliver(email, config) == {:error, {500, %{"code" => -1, "message" => "Invalid API key", "name" => "Invalid_Key", "status" => "error"}}}
   end
 
   test "validate_config/1 with valid config", %{config: config} do

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -88,7 +88,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
       Plug.Conn.resp(conn, 422, "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}")
     end
 
-    assert Postmark.deliver(email, config) == {:error, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}
+    assert Postmark.deliver(email, config) == {:error, {422, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}}
   end
 
   test "deliver/1 with 5xx response", %{bypass: bypass, valid_email: email, config: config} do
@@ -96,7 +96,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
       Plug.Conn.resp(conn, 500, "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}")
     end
 
-    assert Postmark.deliver(email, config) == {:error, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}
+    assert Postmark.deliver(email, config) == {:error, {500, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}}
   end
 
   test "validate_config/1 with valid config", %{config: config} do

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -31,11 +31,10 @@ defmodule Swoosh.TestAssertionsTest do
       assert_email_sent [subject: "Hello, X-Men!"]
     rescue
       error in [ExUnit.AssertionError] ->
-	"Email `subject` does not match\n" <>
-	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-	"lhs: \"Hello, Avengers!\"\n" <>
-	"rhs: \"Hello, X-Men!\""
-	= error.message
+        "Email `subject` does not match\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+        "lhs: \"Hello, Avengers!\"\n" <>
+        "rhs: \"Hello, X-Men!\"" = error.message
     end
   end
 
@@ -44,11 +43,10 @@ defmodule Swoosh.TestAssertionsTest do
       assert_email_sent [from: "thor@odinson.com"]
     rescue
       error in [ExUnit.AssertionError] ->
-	"Email `from` does not match\n" <>
-	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-	"lhs: {\"\", \"tony@stark.com\"}\n" <>
-	"rhs: {\"\", \"thor@odinson.com\"}"
-	= error.message
+        "Email `from` does not match\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+        "lhs: {\"\", \"tony@stark.com\"}\n" <>
+        "rhs: {\"\", \"thor@odinson.com\"}" = error.message
     end
   end
 
@@ -57,11 +55,10 @@ defmodule Swoosh.TestAssertionsTest do
       assert_email_sent [to: "bruce@banner.com"]
     rescue
       error in [ExUnit.AssertionError] ->
-	"Email `to` does not match\n" <>
-	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-	"lhs: {\"\", \"bruce@banner.com\"}\n" <>
-	"rhs: [{\"\", \"steve@rogers.com\"}]"
-	= error.message
+        "Email `to` does not match\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+        "lhs: {\"\", \"bruce@banner.com\"}\n" <>
+        "rhs: [{\"\", \"steve@rogers.com\"}]" = error.message
     end
   end
 
@@ -70,11 +67,10 @@ defmodule Swoosh.TestAssertionsTest do
       assert_email_sent [to: ["bruce@banner.com"]]
     rescue
       error in [ExUnit.AssertionError] ->
-	"Email `to` does not match\n" <>
-	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-	"lhs: [{\"\", \"steve@rogers.com\"}]\n" <>
-	"rhs: [{\"\", \"bruce@banner.com\"}]"
-	= error.message
+        "Email `to` does not match\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+        "lhs: [{\"\", \"steve@rogers.com\"}]\n" <>
+        "rhs: [{\"\", \"bruce@banner.com\"}]" = error.message
     end
   end
 
@@ -83,11 +79,10 @@ defmodule Swoosh.TestAssertionsTest do
       assert_email_sent [cc: "bruce@banner.com"]
     rescue
       error in [ExUnit.AssertionError] ->
-	"Email `cc` does not match\n" <>
-	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-	"lhs: {\"\", \"bruce@banner.com\"}\n" <>
-	"rhs: []"
-	= error.message
+        "Email `cc` does not match\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+        "lhs: {\"\", \"bruce@banner.com\"}\n" <>
+        "rhs: []" = error.message
     end
   end
 
@@ -96,11 +91,10 @@ defmodule Swoosh.TestAssertionsTest do
       assert_email_sent [bcc: "bruce@banner.com"]
     rescue
       error in [ExUnit.AssertionError] ->
-	"Email `bcc` does not match\n" <>
-	"email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-	"lhs: {\"\", \"bruce@banner.com\"}\n" <>
-	"rhs: []"
-	= error.message
+        "Email `bcc` does not match\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+        "lhs: {\"\", \"bruce@banner.com\"}\n" <>
+        "rhs: []" = error.message
     end
   end
 


### PR DESCRIPTION
Sometimes we want to raise when the delivery is unsuccessful. This PR introduces a new `deliver!/2` function that will raise if there is an API or SMTP error, or if the email validation failed (we will now only check that the `from` address is set, according to the RFC).

This PR introduces a couple of breaking changes:

* The API-based adapters now return a slightly different error payload: a `{status_code, body}` tuple instead of just the body.
* The `deliver/2` function will no longer raise if the email validation failed.
* We only validate that the `from` address is preset. We no longer check that there is a recipient (to, cc, bcc), that the subject is set, or that one of html_body or text_body is set.

