### PR TITLE
Mailgun provider_option handling custom variables

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -66,7 +66,19 @@ defmodule Swoosh.Adapters.Mailgun do
     |> prepare_cc(email)
     |> prepare_bcc(email)
     |> prepare_reply_to(email)
+    |> prepare_custom_vars(email)
   end
+
+  # example custom_vars
+  # 
+  # %{"my_var" => %{"my_message_id": 123}, 
+  #   "my_other_var" => %{"my_other_id": 1, "stuff": 2}}
+  defp prepare_custom_vars(body, %Email{provider_options: %{custom_vars: my_vars}}) do
+    my_vars 
+    |> Enum.reduce(body, fn({k, v}, body_acc) -> Map.put(body_acc, "v:#{k}", Poison.encode!(v)) end)
+  end   
+  defp prepare_custom_vars(body, _email), do: body
+
 
   defp prepare_from(body, %Email{from: from}), do: Map.put(body, :from, prepare_recipient(from))
 


### PR DESCRIPTION
I wrote a small method + test that handles custom variables to send with the Mailgun posts. The format expects a map with key the variable name and value the json object. I also tested by sending actual mail and works well. Let me know if there are issues with style or anything!