### PR TITLE
Tests: make hardcoded domain configurable and use RFC-compliant @example.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ after_script:
   - MIX_ENV=docs mix inch.report
 notifications:
   recipients:
-    - steve@stevedomin.com 
+    - steve@stevedomin.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ after_script:
   - MIX_ENV=docs mix inch.report
 notifications:
   recipients:
-    - steve@stevedomin.com
+    - steve@stevedomin.com 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ defmodule Sample.UserEmail do
   def welcome(user) do
     new
     |> to({user.name, user.email})
-    |> from({"Dr B Banner", "hulk@smash.com"})
+    |> from({"Dr B Banner", "hulk.smash@example.com"})
     |> subject("Hello, Avengers!")
     |> html_body("<h1>Hello #{user.name}</h1>")
     |> text_body("Hello #{user.name}\n")
@@ -39,7 +39,7 @@ defmodule Sample.UserEmail do
 end
 
 # In an IEx session
-Sample.UserEmail.welcome(%{name: "Tony Stark", email: "tony@stark.com"}) |> Sample.Mailer.deliver
+Sample.UserEmail.welcome(%{name: "Tony Stark", email: "tony.stark@example.com"}) |> Sample.Mailer.deliver
 
 # Or in a Phoenix controller
 defmodule Sample.UserController do
@@ -134,7 +134,7 @@ defmodule Sample.UserEmail do
   def welcome(user) do
     new
     |> to({user.name, user.email})
-    |> from({"Dr B Banner", "hulk@smash.com"})
+    |> from({"Dr B Banner", "hulk.smash@example.com"})
     |> subject("Hello, Avengers!")
     |> render_body("welcome.html", %{username: user.username})
   end
@@ -156,7 +156,7 @@ defmodule Sample.UserTest do
 
   test "send email on user signup" do
     # Assuming `create_user` creates a new user then sends out a `Sample.UserEmail.welcome` email
-    user = create_user(%{username: "ironman", email: "tony@stark.com"})
+    user = create_user(%{username: "ironman", email: "tony.stark@example.com"})
     assert_email_sent Sample.UserEmail.welcome(user)
   end
 end

--- a/lib/swoosh/adapters/local/storage/memory.ex
+++ b/lib/swoosh/adapters/local/storage/memory.ex
@@ -31,10 +31,10 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
 
   ## Examples
 
-      iex> email = new |> from("tony@stark.com")
-      %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
+      iex> email = new |> from("tony.stark@example.com")
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, [...]}
       iex> Memory.push(email)
-      %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
   """
   def push(email) do
     GenServer.call(__MODULE__, {:push, email})
@@ -45,14 +45,14 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
 
   ## Examples
 
-      iex> email = new |> from("tony@stark.com")
-      %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
+      iex> email = new |> from("tony.stark@example.com")
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, [...]}
       iex> Memory.push(email)
-      %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
       iex> Memory.all() |> Enum.count()
       1
       iex> Memory.pop()
-      %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
       iex> Memory.all() |> Enun.count()
       0
   """
@@ -65,12 +65,12 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
 
   ## Examples
 
-      iex> email = new |> from("tony@stark.com")
-      %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
+      iex> email = new |> from("tony.stark@example.com")
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, [...]}
       iex> Memory.push(email)
-      %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
       iex> Memory.get("A1B2C3")
-      %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
   """
   def get(id) do
     GenServer.call(__MODULE__, {:get, id})
@@ -81,12 +81,12 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
 
   ## Examples
 
-      iex> email = new |> from("tony@stark.com")
-      %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
+      iex> email = new |> from("tony.stark@example.com")
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, [...]}
       iex> Memory.push(email)
-      %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
       iex> Memory.all()
-      [%Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}]
+      [%Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}]
   """
   def all() do
     GenServer.call(__MODULE__, :all)
@@ -97,10 +97,10 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
 
   ## Examples
 
-      iex> email = new |> from("tony@stark.com")
-      %Swoosh.Email{from: {"", "tony@stark.com"}, [...]}
+      iex> email = new |> from("tony.stark@example.com")
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, [...]}
       iex> Memory.push(email)
-      %Swoosh.Email{from: {"", "tony@stark.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
       iex> Memory.delete_all()
       :ok
       iex> Memory.list()

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -7,14 +7,14 @@ defmodule Swoosh.Email do
 
   ## Email fields
 
-  * `from` - the email address of the sender, example: `{"Tony Stark", "tony@stark.com"}`
-  * `to` - the email address for the recipient(s), example: `[{"Steve Rogers", "steve@rogers.com"}]`
+  * `from` - the email address of the sender, example: `{"Tony Stark", "tony.stark@example.com"}`
+  * `to` - the email address for the recipient(s), example: `[{"Steve Rogers", "steve.rogers@example.com"}]`
   * `subject` - the subject of the email, example: `"Hello, Avengers!"`
-  * `cc` - the intended carbon copy recipient(s) of the email, example: `[{"Bruce Banner", "hulk@smash.com"}]`
-  * `bcc` - the intended blind carbon copy recipient(s) of the email, example: `[{"Janet Pym", "wasp@avengers.com"}]`
+  * `cc` - the intended carbon copy recipient(s) of the email, example: `[{"Bruce Banner", "hulk.smash@example.com"}]`
+  * `bcc` - the intended blind carbon copy recipient(s) of the email, example: `[{"Janet Pym", "wasp.avengers@example.com"}]`
   * `text_body` - the content of the email in plaintext, example: `"Hello"`
   * `html_body` - the content of the email in HTML, example: `"<h1>Hello</h1>"`
-  * `reply_to` - the email address that should receive replies, example: `{"Clints Barton", "hawk@eye.com"}`
+  * `reply_to` - the email address that should receive replies, example: `{"Clints Barton", "hawk.eye@example.com"}`
   * `headers` - a map of headers that should be included in the email, example: `%{"X-Accept-Language" => "en-us, en"}`
   * `assigns` - a map of values that correspond with any template variables, example: `%{"first_name" => "Bruce"}`
 
@@ -34,22 +34,22 @@ defmodule Swoosh.Email do
 
       email =
         new
-        |> to("tony@stark.com")
-        |> from("bruce@banner.com")
+        |> to("tony.stark@example.com")
+        |> from("bruce.banner@example.com")
         |> text_body("Welcome to the Avengers")
 
   The composable nature makes it very easy to continue expanding upon a given Email.
 
       email =
         email
-        |> cc({"Steve Rogers", "steve@rogers.com"})
-        |> cc("wasp@avengers.com")
-        |> bcc(["thor@odinson.com", {"Henry McCoy", "beast@avengers.com"}])
+        |> cc({"Steve Rogers", "steve.rogers@example.com"})
+        |> cc("wasp.avengers@example.com")
+        |> bcc(["thor.odinson@example.com", {"Henry McCoy", "beast.avengers@example.com"}])
         |> html_body("<h1>Special Welcome</h1>")
 
   You can also directly pass arguments to the `new/1` function.
 
-      email = new(from: "tony@stark.com", to: "steve@rogers.com", subject: "Hello, Avengers!")
+      email = new(from: "tony.stark@example.com", to: "steve.rogers@example.com", subject: "Hello, Avengers!")
   """
 
   import Swoosh.EmailHelpers
@@ -92,31 +92,31 @@ defmodule Swoosh.Email do
       iex> new(subject: "Hello, Avengers!")
       %Swoosh.Email{subject: "Hello, Avengers!"}
 
-      iex> new(from: "tony@stark.com")
-      %Swoosh.Email{from: {"", "tony@stark.com"}}
-      iex> new(from: {"Tony Stark", "tony@stark.com"})
-      %Swoosh.Email{from: {"Tony Stark", "tony@stark.com"}}
+      iex> new(from: "tony.stark@example.com")
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}}
+      iex> new(from: {"Tony Stark", "tony.stark@example.com"})
+      %Swoosh.Email{from: {"Tony Stark", "tony.stark@example.com"}}
 
-      iex> new(to: "steve@rogers.com")
-      %Swoosh.Email{to: [{"", "steve@rogers.com"}]}
-      iex> new(to: {"Steve Rogers", "steve@rogers.com"})
-      %Swoosh.Email{to: [{"Steve Rogers", "steve@rogers.com"}]}
-      iex> new(to: [{"Bruce Banner", "bruce@banner.com"}, "thor@odinson.com"])
-      %Swoosh.Email{to: [{"Bruce Banner", "bruce@banner.com"}, {"", "thor@odinson.com"}]}
+      iex> new(to: "steve.rogers@example.com")
+      %Swoosh.Email{to: [{"", "steve.rogers@example.com"}]}
+      iex> new(to: {"Steve Rogers", "steve.rogers@example.com"})
+      %Swoosh.Email{to: [{"Steve Rogers", "steve.rogers@example.com"}]}
+      iex> new(to: [{"Bruce Banner", "bruce.banner@example.com"}, "thor.odinson@example.com"])
+      %Swoosh.Email{to: [{"Bruce Banner", "bruce.banner@example.com"}, {"", "thor.odinson@example.com"}]}
 
-      iex> new(cc: "steve@rogers.com")
-      %Swoosh.Email{cc: [{"", "steve@rogers.com"}]}
-      iex> new(cc: {"Steve Rogers", "steve@rogers.com"})
-      %Swoosh.Email{cc: [{"Steve Rogers", "steve@rogers.com"}]}
-      iex> new(cc: [{"Bruce Banner", "bruce@banner.com"}, "thor@odinson.com"])
-      %Swoosh.Email{cc: [{"Bruce Banner", "bruce@banner.com"}, {"", "thor@odinson.com"}]}
+      iex> new(cc: "steve.rogers@example.com")
+      %Swoosh.Email{cc: [{"", "steve.rogers@example.com"}]}
+      iex> new(cc: {"Steve Rogers", "steve.rogers@example.com"})
+      %Swoosh.Email{cc: [{"Steve Rogers", "steve.rogers@example.com"}]}
+      iex> new(cc: [{"Bruce Banner", "bruce.banner@example.com"}, "thor.odinson@example.com"])
+      %Swoosh.Email{cc: [{"Bruce Banner", "bruce.banner@example.com"}, {"", "thor.odinson@example.com"}]}
 
-      iex> new(bcc: "steve@rogers.com")
-      %Swoosh.Email{bcc: [{"", "steve@rogers.com"}]}
-      iex> new(bcc: {"Steve Rogers", "steve@rogers.com"})
-      %Swoosh.Email{bcc: [{"Steve Rogers", "steve@rogers.com"}]}
-      iex> new(bcc: [{"Bruce Banner", "bruce@banner.com"}, "thor@odinson.com"])
-      %Swoosh.Email{bcc: [{"Bruce Banner", "bruce@banner.com"}, {"", "thor@odinson.com"}]}
+      iex> new(bcc: "steve.rogers@example.com")
+      %Swoosh.Email{bcc: [{"", "steve.rogers@example.com"}]}
+      iex> new(bcc: {"Steve Rogers", "steve.rogers@example.com"})
+      %Swoosh.Email{bcc: [{"Steve Rogers", "steve.rogers@example.com"}]}
+      iex> new(bcc: [{"Bruce Banner", "bruce.banner@example.com"}, "thor.odinson@example.com"])
+      %Swoosh.Email{bcc: [{"Bruce Banner", "bruce.banner@example.com"}, {"", "thor.odinson@example.com"}]}
 
       iex> new(html_body: "<h1>Welcome, Avengers</h1>")
       %Swoosh.Email{html_body: "<h1>Welcome, Avengers</h1>"}
@@ -124,10 +124,10 @@ defmodule Swoosh.Email do
       iex> new(text_body: "Welcome, Avengers")
       %Swoosh.Email{text_body: "Welcome, Avengers"}
 
-      iex> new(reply_to: "edwin@jarvis.com")
-      %Swoosh.Email{reply_to: {"", "edwin@jarvis.com"}}
-      iex> new(reply_to: {"Edwin Jarvis", "edwin@jarvis.com"})
-      %Swoosh.Email{reply_to: {"Edwin Jarvis", "edwin@jarvis.com"}}
+      iex> new(reply_to: "edwin.jarvis@example.com")
+      %Swoosh.Email{reply_to: {"", "edwin.jarvis@example.com"}}
+      iex> new(reply_to: {"Edwin Jarvis", "edwin.jarvis@example.com"})
+      %Swoosh.Email{reply_to: {"Edwin Jarvis", "edwin.jarvis@example.com"}}
 
       iex> new(headers: %{"X-Accept-Language" => "en"})
       %Swoosh.Email{headers: %{"X-Accept-Language" => "en"}}
@@ -140,8 +140,8 @@ defmodule Swoosh.Email do
 
   You can obviously combine these arguments together:
 
-      iex> new(to: "steve@rogers.com", subject: "Hello, Avengers!")
-      %Swoosh.Email{to: [{"", "steve@rogers.com"}], subject: "Hello, Avengers!"}
+      iex> new(to: "steve.rogers@example.com", subject: "Hello, Avengers!")
+      %Swoosh.Email{to: [{"", "steve.rogers@example.com"}], subject: "Hello, Avengers!"}
   """
   @spec new(none | Enum.t) :: t
   def new(opts \\ []) do
@@ -171,13 +171,13 @@ defmodule Swoosh.Email do
 
   ## Examples
 
-      iex> new |> from({"Steve Rogers", "steve@rogers.com"})
-      %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {"Steve Rogers", "steve@rogers.com"},
+      iex> new |> from({"Steve Rogers", "steve.rogers@example.com"})
+      %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {"Steve Rogers", "steve.rogers@example.com"},
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: []}
 
-      iex> new |> from("steve@rogers.com")
-      %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {"", "steve@rogers.com"},
+      iex> new |> from("steve.rogers@example.com")
+      %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {"", "steve.rogers@example.com"},
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: []}
   """
@@ -195,15 +195,15 @@ defmodule Swoosh.Email do
 
   ## Examples
 
-      iex> new |> reply_to({"Steve Rogers", "steve@rogers.com"})
+      iex> new |> reply_to({"Steve Rogers", "steve.rogers@example.com"})
       %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
-       reply_to: {"Steve Rogers", "steve@rogers.com"}, subject: "", text_body: nil, to: []}
+       reply_to: {"Steve Rogers", "steve.rogers@example.com"}, subject: "", text_body: nil, to: []}
 
-      iex> new |> reply_to("steve@rogers.com")
+      iex> new |> reply_to("steve.rogers@example.com")
       %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
-       reply_to: {"", "steve@rogers.com"}, subject: "", text_body: nil, to: []}
+       reply_to: {"", "steve.rogers@example.com"}, subject: "", text_body: nil, to: []}
   """
   @spec reply_to(t, mailbox | address) :: t
   def reply_to(%__MODULE__{} = email, reply_to) do
@@ -265,8 +265,8 @@ defmodule Swoosh.Email do
   The recipient must be; a tuple specifying the name and address of the recipient; a string specifying the
   address of the recipient; or an array comprised of a combination of either.
 
-      iex> new |> bcc("steve@rogers.com")
-      %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [{"", "steve@rogers.com"}],
+      iex> new |> bcc("steve.rogers@example.com")
+      %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [{"", "steve.rogers@example.com"}],
        cc: [], from: nil, headers: %{}, html_body: nil,
        private: %{}, provider_options: %{}, reply_to: nil, subject: "",
        text_body: nil, to: []}
@@ -307,9 +307,9 @@ defmodule Swoosh.Email do
 
   ## Examples
 
-      iex> new |> cc("steve@rogers.com")
+      iex> new |> cc("steve.rogers@example.com")
       %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [],
-       cc: [{"", "steve@rogers.com"}], from: nil, headers: %{}, html_body: nil,
+       cc: [{"", "steve.rogers@example.com"}], from: nil, headers: %{}, html_body: nil,
        private: %{}, provider_options: %{}, reply_to: nil, subject: "",
        text_body: nil, to: []}
   """
@@ -349,11 +349,11 @@ defmodule Swoosh.Email do
 
   ## Examples
 
-      iex> new |> to("steve@rogers.com")
+      iex> new |> to("steve.rogers@example.com")
       %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [],
        cc: [], from: nil, headers: %{}, html_body: nil,
        private: %{}, provider_options: %{}, reply_to: nil, subject: "",
-       text_body: nil, to: [{"", "steve@rogers.com"}]}
+       text_body: nil, to: [{"", "steve.rogers@example.com"}]}
   """
   @spec to(t, mailbox | address | [mailbox|address]) :: t
   def to(%__MODULE__{to: to} = email, recipients) when is_list(recipients) do

--- a/lib/swoosh/email_helpers.ex
+++ b/lib/swoosh/email_helpers.ex
@@ -13,8 +13,10 @@ defmodule Swoosh.EmailHelpers do
     The recipient `#{inspect invalid}` is invalid.
 
     Recipients must be a string representing an email address like
-    `foo@bar.com` or a two-element tuple `{name, address}`, where
+    `foo.bar@example.com` or a two-element tuple `{name, address}`, where
     name and address are strings.
     """
   end
+
+
 end

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -41,8 +41,8 @@ defmodule Swoosh.Mailer do
   Once configured you can use your mailer like this:
 
       # in an IEx console
-      iex> email = new |> from("tony@stark.com") |> to("steve@rogers.com")
-      %Swoosh.Email{from: {"", "tony@stark.com"}, ...}
+      iex> email = new |> from("tony.stark@example.com") |> to("steve.rogers@example.com")
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, ...}
       iex> Mailer.deliver(email)
       :ok
 
@@ -50,8 +50,8 @@ defmodule Swoosh.Mailer do
   with your Mailer's config:
 
       # in an IEx console
-      iex> email = new |> from("tony@stark.com") |> to("steve@rogers.com")
-      %Swoosh.Email{from: {"", "tony@stark.com"}, ...}
+      iex> email = new |> from("tony.stark@example.com") |> to("steve.rogers@example.com")
+      %Swoosh.Email{from: {"", "tony.stark@example.com"}, ...}
       iex> Mailer.deliver(email, domain: "jarvis.com")
       :ok
   """

--- a/test/integration/adapters/mailgun_test.exs
+++ b/test/integration/adapters/mailgun_test.exs
@@ -18,9 +18,9 @@ defmodule Swoosh.Integration.Adapters.MailgunTest do
       new
       |> from({"Swoosh Mailgun", "swoosh@#{config[:domain]}"})
       |> reply_to("swoosh+replyto@#{config[:domain]}")
-      |> to("swoosh+to@elixirhq.com")
-      |> cc("swoosh+cc@elixirhq.com")
-      |> bcc("swoosh+bcc@elixirhq.com")
+      |> to("swoosh+to@#{config[:domain]}")
+      |> cc("swoosh+cc@#{config[:domain]}")
+      |> bcc("swoosh+bcc@#{config[:domain]}")
       |> subject("Swoosh - Mailgun integration test")
       |> text_body("This email was sent by the Swoosh library automation testing")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")
@@ -34,7 +34,7 @@ defmodule Swoosh.Integration.Adapters.MailgunTest do
     email =
       new
       |> from({"Swoosh Mailgun", "swoosh@#{config[:domain]}"})
-      |> to("swoosh+to@elixirhq.com")
+      |> to("swoosh+to@#{config[:domain]}")
       |> subject("Swoosh - Mailgun integration test")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")
 

--- a/test/integration/adapters/postmark_test.exs
+++ b/test/integration/adapters/postmark_test.exs
@@ -6,7 +6,7 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
   @moduletag integration: true
 
   setup_all do
-    config = [api_key: System.get_env("POSTMARK_API_KEY"), config: System.get_env("POSTMARK_DOMAIN")]
+    config = [api_key: System.get_env("POSTMARK_API_KEY"), domain: System.get_env("POSTMARK_DOMAIN")]
     {:ok, config: config}
   end
 

--- a/test/integration/adapters/postmark_test.exs
+++ b/test/integration/adapters/postmark_test.exs
@@ -6,18 +6,18 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
   @moduletag integration: true
 
   setup_all do
-    config = [api_key: System.get_env("POSTMARK_API_KEY")]
+    config = [api_key: System.get_env("POSTMARK_API_KEY"), config: System.get_env("POSTMARK_DOMAIN")]
     {:ok, config: config}
   end
 
   test "simple deliver", %{config: config} do
     email =
       new
-      |> from({"Swoosh Postmark", "swoosh@elixirhq.com"})
-      |> reply_to("swoosh+replyto@elixirhq.com")
-      |> to("swoosh+to@elixirhq.com")
-      |> cc("swoosh+cc@elixirhq.com")
-      |> bcc("swoosh+bcc@elixirhq.com")
+      |> from({"Swoosh Postmark", "swoosh#{config[:domain]}"})
+      |> reply_to("swoosh+replyto#{config[:domain]}")
+      |> to("swoosh+to#{config[:domain]}")
+      |> cc("swoosh+cc#{config[:domain]}")
+      |> bcc("swoosh+bcc#{config[:domain]}")
       |> subject("Swoosh - Postmark integration test")
       |> text_body("This email was sent by the Swoosh library automation testing")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")

--- a/test/integration/adapters/sendgrid_test.exs
+++ b/test/integration/adapters/sendgrid_test.exs
@@ -6,18 +6,18 @@ defmodule Swoosh.Integration.Adapters.SendgridTest do
   @moduletag integration: true
 
   setup_all do
-    config = [api_key: System.get_env("SENDGRID_API_KEY")]
+    config = [api_key: System.get_env("SENDGRID_API_KEY"), domain: Sytem.get_env("SENDGRID_DOMAIN")]
     {:ok, config: config}
   end
 
   test "simple deliver", %{config: config} do
     email =
       new
-      |> from({"Swoosh Sendgrid", "swoosh+sendgrid@elixirhq.com"})
-      |> reply_to("swoosh+replyto@elixirhq.com")
-      |> to("swoosh+to@elixirhq.com")
-      |> cc("swoosh+cc@elixirhq.com")
-      |> bcc("swoosh+bcc@elixirhq.com")
+      |> from({"Swoosh Sendgrid", "swoosh+sendgrid#{config[:domain]}"})
+      |> reply_to("swoosh+replyto#{config[:domain]}")
+      |> to("swoosh+to#{config[:domain]}")
+      |> cc("swoosh+cc#{config[:domain]}")
+      |> bcc("swoosh+bcc#{config[:domain]}")
       |> subject("Swoosh - Sendgrid integration test")
       |> text_body("This email was sent by the Swoosh library automation testing")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")

--- a/test/integration/adapters/smtp_test.exs
+++ b/test/integration/adapters/smtp_test.exs
@@ -10,6 +10,7 @@ defmodule Swoosh.Integration.Adapters.SMTPTest do
       relay: System.get_env("SMTP_RELAY"),
       username: System.get_env("SMTP_USERNAME"),
       password: System.get_env("SMTP_PASSWORD"),
+      domain: System.get_env("SMTP_DOMAIN"),
       tls: :always,
       auth: :always
     ]
@@ -19,11 +20,11 @@ defmodule Swoosh.Integration.Adapters.SMTPTest do
   test "simple deliver", %{config: config} do
     email =
       new
-      |> from({"Swoosh SMTP", "swoosh+smtp@elixirhq.com"})
-      |> reply_to("swoosh+replyto@elixirhq.com")
-      |> to("swoosh+to@elixirhq.com")
-      |> cc("swoosh+cc@elixirhq.com")
-      |> bcc("swoosh+bcc@elixirhq.com")
+      |> from({"Swoosh SMTP", "swoosh+smtp#{config[:domain]}"})
+      |> reply_to("swoosh+replyto#{config[:domain]}")
+      |> to("swoosh+to#{config[:domain]}")
+      |> cc("swoosh+cc#{config[:domain]}")
+      |> bcc("swoosh+bcc#{config[:domain]}")
       |> subject("Swoosh - SMTP integration test")
       |> text_body("This email was sent by the Swoosh library automation testing")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")

--- a/test/swoosh/adapters/local_test.exs
+++ b/test/swoosh/adapters/local_test.exs
@@ -6,8 +6,8 @@ defmodule Swoosh.Adapters.LocalTest do
   end
 
   test "deliver/1" do
-    email = Swoosh.Email.new(from: "tony@stark.com",
-                             to: "steve@rogers.com",
+    email = Swoosh.Email.new(from: "tony.stark@example.com",
+                             to: "steve.rogers@example.com",
                              subject: "Hello, Avengers!",
                              text_body: "Hello!")
     {status, _} = LocalMailer.deliver(email)

--- a/test/swoosh/adapters/logger_test.exs
+++ b/test/swoosh/adapters/logger_test.exs
@@ -9,8 +9,8 @@ defmodule Swoosh.Adapters.LoggerTest do
 
   setup_all do
     email = Swoosh.Email.new(
-      from: "tony@stark.com",
-      to: "steve@rogers.com",
+      from: "tony.stark@example.com",
+      to: "steve.rogers@example.com",
       subject: "Hello, Avengers!",
       text_body: "Hello!"
     )
@@ -21,13 +21,13 @@ defmodule Swoosh.Adapters.LoggerTest do
     assert capture_log(fn ->
       {status, _} = LoggerMailer.deliver(email)
       assert status == :ok
-    end) =~ "New email delivered to steve@rogers.com"
+    end) =~ "New email delivered to steve.rogers@example.com"
   end
 
   test "deliver/1, log full email", %{email: email} do
     assert capture_log(fn ->
       {status, _} = LoggerMailer.deliver(email, log_full_email: true)
       assert status == :ok
-    end) =~ "New email delivered\nFrom: tony@stark.com"
+    end) =~ "New email delivered\nFrom: tony.stark@example.com"
   end
 end

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -19,8 +19,8 @@ defmodule Swoosh.Adapters.MailgunTest do
 
     valid_email =
       new
-      |> from("tony@stark.com")
-      |> to("steve@rogers.com")
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
 
@@ -32,8 +32,8 @@ defmodule Swoosh.Adapters.MailgunTest do
       conn = parse(conn)
       expected_path = "/" <> config[:domain] <> "/messages"
       body_params = %{"subject" => "Hello, Avengers!",
-                      "to" => "steve@rogers.com",
-                      "from" => "tony@stark.com",
+                      "to" => "steve.rogers@example.com",
+                      "from" => "tony.stark@example.com",
                       "html" => "<h1>Hello</h1>"}
       assert body_params == conn.body_params
       assert expected_path == conn.request_path
@@ -48,14 +48,14 @@ defmodule Swoosh.Adapters.MailgunTest do
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
       new
-      |> from({"T Stark", "tony@stark.com"})
-      |> to({"Steve Rogers", "steve@rogers.com"})
-      |> to("wasp@avengers.com")
-      |> reply_to("office@avengers.com")
-      |> cc({"Bruce Banner", "hulk@smash.com"})
-      |> cc("thor@odinson.com")
-      |> bcc({"Clinton Francis Barton", "hawk@eye.com"})
-      |> bcc("beast@avengers.com")
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> to("wasp.avengers@example.com")
+      |> reply_to("office.avengers@example.com")
+      |> cc({"Bruce Banner", "hulk.smash@example.com"})
+      |> cc("thor.odinson@example.com")
+      |> bcc({"Clinton Francis Barton", "hawk.eye@example.com"})
+      |> bcc("beast.avengers@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
@@ -64,11 +64,11 @@ defmodule Swoosh.Adapters.MailgunTest do
       conn = parse(conn)
       expected_path = "/" <> config[:domain] <> "/messages"
       body_params = %{"subject" => "Hello, Avengers!",
-                      "to" => "wasp@avengers.com,Steve Rogers <steve@rogers.com>",
-                      "bcc" => "beast@avengers.com,Clinton Francis Barton <hawk@eye.com>",
-                      "cc" => "thor@odinson.com,Bruce Banner <hulk@smash.com>",
-                      "h:Reply-To" => "office@avengers.com",
-                      "from" => "T Stark <tony@stark.com>",
+                      "to" => "wasp.avengers@example.com,Steve Rogers <steve.rogers@example.com>",
+                      "bcc" => "beast.avengers@example.com,Clinton Francis Barton <hawk.eye@example.com>",
+                      "cc" => "thor.odinson@example.com,Bruce Banner <hulk.smash@example.com>",
+                      "h:Reply-To" => "office.avengers@example.com",
+                      "from" => "T Stark <tony.stark@example.com>",
                       "text" => "Hello",
                       "html" => "<h1>Hello</h1>"}
       assert body_params == conn.body_params
@@ -84,8 +84,8 @@ defmodule Swoosh.Adapters.MailgunTest do
   test "delivery/1 with custom variables returns :ok", %{bypass: bypass, config: config} do
     email =
       new
-      |> from("tony@stark.com")
-      |> to("steve@rogers.com")
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
       |> put_provider_option(:custom_vars, %{my_var: %{"my_message_id": 123}, my_other_var: %{"my_other_id": 1, "stuff": 2}})
@@ -94,8 +94,8 @@ defmodule Swoosh.Adapters.MailgunTest do
       conn = parse(conn)
       expected_path = "/" <> config[:domain] <> "/messages"
       body_params = %{"subject" => "Hello, Avengers!",
-                      "to" => "steve@rogers.com",
-                      "from" => "tony@stark.com",
+                      "to" => "steve.rogers@example.com",
+                      "from" => "tony.stark@example.com",
                       "html" => "<h1>Hello</h1>",
                       "v:my_var" => "{\"my_message_id\":123}",
                       "v:my_other_var" => "{\"stuff\":2,\"my_other_id\":1}"}

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -7,7 +7,7 @@ defmodule Swoosh.Adapters.MandrillTest do
   @success_response """
     [
       {
-        "email": "steve@rogers.com",
+        "email": "steve.rogers@example.com",
         "status": "sent",
         "_id": "9",
         "reject_reason" :null
@@ -18,7 +18,7 @@ defmodule Swoosh.Adapters.MandrillTest do
   @queued_response """
     [
       {
-        "email": "steve@rogers.com",
+        "email": "steve.rogers@example.com",
         "status": "queued",
         "_id": "9",
         "reject_reason": null
@@ -33,9 +33,9 @@ defmodule Swoosh.Adapters.MandrillTest do
 
     valid_email =
       new
-      |> from({"T Stark", "tony@stark.com"})
-      |> to("steve@rogers.com")
-      |> cc({"Bruce Banner", "hulk@smash.com"})
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to("steve.rogers@example.com")
+      |> cc({"Bruce Banner", "hulk.smash@example.com"})
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
 
@@ -48,10 +48,10 @@ defmodule Swoosh.Adapters.MandrillTest do
       body_params = %{"key" => "jarvis",
                       "message" => %{
                         "subject" => "Hello, Avengers!",
-                        "to" => [%{"type" => "cc", "email" => "hulk@smash.com", "name" => "Bruce Banner"},
-                                 %{"type" => "to", "email" => "steve@rogers.com"}],
+                        "to" => [%{"type" => "cc", "email" => "hulk.smash@example.com", "name" => "Bruce Banner"},
+                                 %{"type" => "to", "email" => "steve.rogers@example.com"}],
                         "from_name" => "T Stark",
-                        "from_email" => "tony@stark.com",
+                        "from_email" => "tony.stark@example.com",
                         "html" => "<h1>Hello</h1>"}}
       assert body_params == conn.body_params
       assert "/messages/send.json" == conn.request_path
@@ -66,14 +66,14 @@ defmodule Swoosh.Adapters.MandrillTest do
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
       new
-      |> from({"T Stark", "tony@stark.com"})
-      |> to({"Steve Rogers", "steve@rogers.com"})
-      |> to("wasp@avengers.com")
-      |> reply_to("office@avengers.com")
-      |> cc({"Bruce Banner", "hulk@smash.com"})
-      |> cc("thor@odinson.com")
-      |> bcc({"Clinton Francis Barton", "hawk@eye.com"})
-      |> bcc("beast@avengers.com")
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> to("wasp.avengers@example.com")
+      |> reply_to("office.avengers@example.com")
+      |> cc({"Bruce Banner", "hulk.smash@example.com"})
+      |> cc("thor.odinson@example.com")
+      |> bcc({"Clinton Francis Barton", "hawk.eye@example.com"})
+      |> bcc("beast.avengers@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
@@ -83,15 +83,15 @@ defmodule Swoosh.Adapters.MandrillTest do
       body_params = %{"key" => "jarvis",
                       "message" => %{
                         "subject" => "Hello, Avengers!",
-                        "headers" => %{"Reply-To" => "office@avengers.com"},
-                        "to" => [%{"type" => "bcc", "email" => "beast@avengers.com"},
-                                 %{"type" => "bcc", "email" => "hawk@eye.com", "name" => "Clinton Francis Barton"},
-                                 %{"type" => "cc", "email" => "thor@odinson.com"},
-                                 %{"type" => "cc", "email" => "hulk@smash.com", "name" => "Bruce Banner"},
-                                 %{"type" => "to", "email" => "wasp@avengers.com"},
-                                 %{"type" => "to", "email" => "steve@rogers.com", "name" => "Steve Rogers"}],
+                        "headers" => %{"Reply-To" => "office.avengers@example.com"},
+                        "to" => [%{"type" => "bcc", "email" => "beast.avengers@example.com"},
+                                 %{"type" => "bcc", "email" => "hawk.eye@example.com", "name" => "Clinton Francis Barton"},
+                                 %{"type" => "cc", "email" => "thor.odinson@example.com"},
+                                 %{"type" => "cc", "email" => "hulk.smash@example.com", "name" => "Bruce Banner"},
+                                 %{"type" => "to", "email" => "wasp.avengers@example.com"},
+                                 %{"type" => "to", "email" => "steve.rogers@example.com", "name" => "Steve Rogers"}],
                         "from_name" => "T Stark",
-                        "from_email" => "tony@stark.com",
+                        "from_email" => "tony.stark@example.com",
                         "html" => "<h1>Hello</h1>",
                         "text" => "Hello"}}
       assert body_params == conn.body_params
@@ -119,10 +119,10 @@ defmodule Swoosh.Adapters.MandrillTest do
 
   test "deliver/1 with 2xx response containing errors", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 200, "[{\"email\":\"leafybasil@gmail.com\",\"status\":\"rejected\",\"_id\":\"e1f1f16d3c6e47c5955ad2b4c3207986\",\"reject_reason\":\"unsigned\"}]")
+      Plug.Conn.resp(conn, 200, "[{\"email\":\"leafybasil.gmail@example.com\",\"status\":\"rejected\",\"_id\":\"e1f1f16d3c6e47c5955ad2b4c3207986\",\"reject_reason\":\"unsigned\"}]")
     end
 
-    assert Mandrill.deliver(email, config) == {:error, %{"_id" => "e1f1f16d3c6e47c5955ad2b4c3207986", "email" => "leafybasil@gmail.com", "reject_reason" => "unsigned", "status" => "rejected"}}
+    assert Mandrill.deliver(email, config) == {:error, %{"_id" => "e1f1f16d3c6e47c5955ad2b4c3207986", "email" => "leafybasil.gmail@example.com", "reject_reason" => "unsigned", "status" => "rejected"}}
   end
 
   test "deliver/1 with non 2xx response", %{bypass: bypass, config: config, valid_email: email} do

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -10,7 +10,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
       "Message": "OK",
       "MessageID": "b7bc2f4a-e38e-4336-af7d-e6c392c2f817",
       "SubmittedAt": "2010-11-26T12:01:05.1794748-05:00",
-      "To": "tony@stark.com"
+      "To": "tony.stark@example.com"
     }
   """
 
@@ -21,8 +21,8 @@ defmodule Swoosh.Adapters.PostmarkTest do
 
     valid_email =
       new
-      |> from("steve@rogers.com")
-      |> to("tony@stark.com")
+      |> from("steve.rogers@example.com")
+      |> to("tony.stark@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
 
@@ -33,8 +33,8 @@ defmodule Swoosh.Adapters.PostmarkTest do
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
       body_params = %{"Subject" => "Hello, Avengers!",
-                      "To" => "tony@stark.com",
-                      "From" => "steve@rogers.com",
+                      "To" => "tony.stark@example.com",
+                      "From" => "steve.rogers@example.com",
                       "HtmlBody" => "<h1>Hello</h1>"}
       assert body_params == conn.body_params
       assert "/email" == conn.request_path
@@ -49,27 +49,27 @@ defmodule Swoosh.Adapters.PostmarkTest do
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
       new
-      |> from({"T Stark", "tony@stark.com"})
-      |> to("wasp@avengers.com")
-      |> to({"Steve Rogers", "steve@rogers.com"})
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to("wasp.avengers@example.com")
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
-      |> cc({"Bruce Banner", "hulk@smash.com"})
-      |> cc("thor@odinson.com")
-      |> bcc({"Clinton Francis Barton", "hawk@eye.com"})
-      |> bcc("beast@avengers.com")
-      |> reply_to("iron@stark.com")
+      |> cc({"Bruce Banner", "hulk.smash@example.com"})
+      |> cc("thor.odinson@example.com")
+      |> bcc({"Clinton Francis Barton", "hawk.eye@example.com"})
+      |> bcc("beast.avengers@example.com")
+      |> reply_to("iron.stark@example.com")
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
 
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
       body_params = %{"Subject" => "Hello, Avengers!",
-                      "To" => "\"Steve Rogers\" <steve@rogers.com>,wasp@avengers.com",
-                      "From" => "tony@stark.com",
-                      "Cc" => "thor@odinson.com,\"Bruce Banner\" <hulk@smash.com>",
-                      "Bcc" => "beast@avengers.com,\"Clinton Francis Barton\" <hawk@eye.com>",
-                      "ReplyTo" => "iron@stark.com",
+                      "To" => "\"Steve Rogers\" <steve.rogers@example.com>,wasp.avengers@example.com",
+                      "From" => "tony.stark@example.com",
+                      "Cc" => "thor.odinson@example.com,\"Bruce Banner\" <hulk.smash@example.com>",
+                      "Bcc" => "beast.avengers@example.com,\"Clinton Francis Barton\" <hawk.eye@example.com>",
+                      "ReplyTo" => "iron.stark@example.com",
                       "TextBody" => "Hello",
                       "HtmlBody" => "<h1>Hello</h1>"}
 

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -24,8 +24,8 @@ defmodule Swoosh.Adapters.SendgridTest do
 
     valid_email =
       new
-      |> from("tony@stark.com")
-      |> to("steve@rogers.com")
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
@@ -36,8 +36,8 @@ defmodule Swoosh.Adapters.SendgridTest do
   test "successful delivery returns :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
-      body_params = %{"from" => "tony@stark.com",
-                      "to" => ["steve@rogers.com"],
+      body_params = %{"from" => "tony.stark@example.com",
+                      "to" => ["steve.rogers@example.com"],
                       "html" => "<h1>Hello</h1>",
                       "subject" => "Hello, Avengers!",
                       "text" => "Hello"}
@@ -52,27 +52,27 @@ defmodule Swoosh.Adapters.SendgridTest do
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
       new
-      |> from({"T Stark", "tony@stark.com"})
-      |> to({"Steve Rogers", "steve@rogers.com"})
-      |> reply_to("hulk@smash.com")
-      |> cc("hulk@smash.com")
-      |> cc({"Janet Pym", "wasp@avengers.com"})
-      |> bcc("thor@odinson.com")
-      |> bcc({"Henry McCoy", "beast@avengers.com"})
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> reply_to("hulk.smash@example.com")
+      |> cc("hulk.smash@example.com")
+      |> cc({"Janet Pym", "wasp.avengers@example.com"})
+      |> bcc("thor.odinson@example.com")
+      |> bcc({"Henry McCoy", "beast.avengers@example.com"})
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
 
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
-      body_params = %{"from" => "tony@stark.com",
+      body_params = %{"from" => "tony.stark@example.com",
                       "fromname" => "T Stark",
-                      "to" => ["steve@rogers.com"],
+                      "to" => ["steve.rogers@example.com"],
                       "toname" => ["Steve Rogers"],
-                      "replyto" => "hulk@smash.com",
-                      "cc" => ["wasp@avengers.com", "hulk@smash.com"],
+                      "replyto" => "hulk.smash@example.com",
+                      "cc" => ["wasp.avengers@example.com", "hulk.smash@example.com"],
                       "ccname" => ["Janet Pym", ""],
-                      "bcc" => ["beast@avengers.com", "thor@odinson.com"],
+                      "bcc" => ["beast.avengers@example.com", "thor.odinson@example.com"],
                       "bccname" => ["Henry McCoy", ""],
                       "html" => "<h1>Hello</h1>",
                       "subject" => "Hello, Avengers!",

--- a/test/swoosh/adapters/sendmail_test.exs
+++ b/test/swoosh/adapters/sendmail_test.exs
@@ -7,8 +7,8 @@ defmodule Swoosh.Adapters.SendmailTest do
   setup_all do
     valid_email =
       new
-      |> from("tony@stark.com")
-      |> to("steve@rogers.com")
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
@@ -41,7 +41,7 @@ defmodule Swoosh.Adapters.SendmailTest do
   end
 
   test "cmd", %{valid_email: email, valid_config: config} do
-    cmd = "#{config[:cmd_path]} -f'tony@stark.com' -oi -t #{config[:cmd_args]}"
+    cmd = "#{config[:cmd_path]} -f'tony.stark@example.com' -oi -t #{config[:cmd_args]}"
     assert Sendmail.cmd(email, config) == cmd
   end
 end

--- a/test/swoosh/adapters/smtp_test.exs
+++ b/test/swoosh/adapters/smtp_test.exs
@@ -7,8 +7,8 @@ defmodule Swoosh.Adapters.SMTPTest do
   setup_all do
     valid_email =
       new
-      |> from("tony@stark.com")
-      |> to("steve@rogers.com")
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
@@ -29,8 +29,8 @@ defmodule Swoosh.Adapters.SMTPTest do
     assert SMTP.prepare_message(email) ==
      {"text", "plain",
       [{"Content-Type", "text/plain; charset=\"utf-8\""},
-        {"From", "tony@stark.com"},
-        {"To", "steve@rogers.com"},
+        {"From", "tony.stark@example.com"},
+        {"To", "steve.rogers@example.com"},
         {"Subject", "Hello, Avengers!"},
         {"Mime-Version", "1.0"}],
       "Hello"}
@@ -40,23 +40,23 @@ defmodule Swoosh.Adapters.SMTPTest do
     email =
       email
       |> html_body(nil)
-      |> to({"Janet Pym", "wasp@avengers.com"})
-      |> cc({"Bruce Banner", "hulk@smash.com"})
-      |> cc("thor@odinson.com")
-      |> bcc({"Clinton Francis Barton", "hawk@eye.com"})
-      |> bcc("beast@avengers.com")
-      |> reply_to("black@widow.com")
+      |> to({"Janet Pym", "wasp.avengers@example.com"})
+      |> cc({"Bruce Banner", "hulk.smash@example.com"})
+      |> cc("thor.odinson@example.com")
+      |> bcc({"Clinton Francis Barton", "hawk.eye@example.com"})
+      |> bcc("beast.avengers@example.com")
+      |> reply_to("black.widow@example.com")
       |> header("X-Custom-ID", "4f034001")
       |> header("X-Feedback-ID", "403f4983b02a")
 
     assert SMTP.prepare_message(email) ==
     {"text", "plain",
       [{"Content-Type", "text/plain; charset=\"utf-8\""},
-        {"From", "tony@stark.com"},
-        {"To", "Janet Pym <wasp@avengers.com>, steve@rogers.com"},
-        {"Cc", "thor@odinson.com, Bruce Banner <hulk@smash.com>"},
+        {"From", "tony.stark@example.com"},
+        {"To", "Janet Pym <wasp.avengers@example.com>, steve.rogers@example.com"},
+        {"Cc", "thor.odinson@example.com, Bruce Banner <hulk.smash@example.com>"},
         {"Subject", "Hello, Avengers!"},
-        {"Reply-To", "black@widow.com"},
+        {"Reply-To", "black.widow@example.com"},
         {"Mime-Version", "1.0"},
         {"X-Custom-ID", "4f034001"},
         {"X-Feedback-ID", "403f4983b02a"}],
@@ -64,12 +64,12 @@ defmodule Swoosh.Adapters.SMTPTest do
   end
 
   test "simple email with multiple recipients", %{valid_email: email} do
-    email = email |> html_body(nil) |> to({"Bruce Banner", "bruce@banner.com"})
+    email = email |> html_body(nil) |> to({"Bruce Banner", "bruce.banner@example.com"})
     assert SMTP.prepare_message(email) ==
     {"text", "plain",
       [{"Content-Type", "text/plain; charset=\"utf-8\""},
-        {"From", "tony@stark.com"},
-        {"To", "Bruce Banner <bruce@banner.com>, steve@rogers.com"},
+        {"From", "tony.stark@example.com"},
+        {"To", "Bruce Banner <bruce.banner@example.com>, steve.rogers@example.com"},
         {"Subject", "Hello, Avengers!"},
         {"Mime-Version", "1.0"}],
       "Hello"}
@@ -79,15 +79,15 @@ defmodule Swoosh.Adapters.SMTPTest do
     email =
     email
     |> html_body(nil)
-    |> to({"Bruce Banner", "bruce@banner.com"})
-    |> cc("thor@odinson.com")
+    |> to({"Bruce Banner", "bruce.banner@example.com"})
+    |> cc("thor.odinson@example.com")
 
     assert SMTP.prepare_message(email) ==
       {"text", "plain",
        [{"Content-Type", "text/plain; charset=\"utf-8\""},
-        {"From", "tony@stark.com"},
-        {"To", "Bruce Banner <bruce@banner.com>, steve@rogers.com"},
-        {"Cc", "thor@odinson.com"},
+        {"From", "tony.stark@example.com"},
+        {"To", "Bruce Banner <bruce.banner@example.com>, steve.rogers@example.com"},
+        {"Cc", "thor.odinson@example.com"},
         {"Subject", "Hello, Avengers!"},
         {"Mime-Version", "1.0"}],
        "Hello"}
@@ -98,8 +98,8 @@ defmodule Swoosh.Adapters.SMTPTest do
     assert SMTP.prepare_message(email) ==
       {"text", "html",
        [{"Content-Type", "text/html; charset=\"utf-8\""},
-        {"From", "tony@stark.com"},
-        {"To", "steve@rogers.com"},
+        {"From", "tony.stark@example.com"},
+        {"To", "steve.rogers@example.com"},
         {"Subject", "Hello, Avengers!"},
         {"Mime-Version", "1.0"}],
       "<h1>Hello</h1>"}
@@ -108,8 +108,8 @@ defmodule Swoosh.Adapters.SMTPTest do
   test "multipart/alternative email", %{valid_email: email} do
     assert SMTP.prepare_message(email) ==
       {"multipart", "alternative",
-       [{"From", "tony@stark.com"},
-        {"To", "steve@rogers.com"},
+       [{"From", "tony.stark@example.com"},
+        {"To", "steve.rogers@example.com"},
         {"Subject", "Hello, Avengers!"},
         {"Mime-Version", "1.0"}],
        [{"text", "plain",

--- a/test/swoosh/email_test.exs
+++ b/test/swoosh/email_test.exs
@@ -21,17 +21,17 @@ defmodule Swoosh.EmailTest do
   end
 
   test "from/2" do
-    email = new |> from("tony@stark.com")
-    assert email == %Email{from: {"", "tony@stark.com"}}
+    email = new |> from("tony.stark@example.com")
+    assert email == %Email{from: {"", "tony.stark@example.com"}}
 
-    email = email |> from({"Steve Rogers", "steve@rogers.com"})
-    assert email == %Email{from: {"Steve Rogers", "steve@rogers.com"}}
+    email = email |> from({"Steve Rogers", "steve.rogers@example.com"})
+    assert email == %Email{from: {"Steve Rogers", "steve.rogers@example.com"}}
   end
 
   test "from/2 should raise if from value is invalid" do
     assert_raise ArgumentError, fn -> new |> from(nil) end
     assert_raise ArgumentError, fn -> new |> from("") end
-    assert_raise ArgumentError, fn -> new |> from({nil, "tony@stark.com"}) end
+    assert_raise ArgumentError, fn -> new |> from({nil, "tony.stark@example.com"}) end
     assert_raise ArgumentError, fn -> new |> from({nil, ""}) end
   end
 
@@ -60,145 +60,145 @@ defmodule Swoosh.EmailTest do
   end
 
   test "reply_to/2" do
-    email = new |> reply_to("welcome@avengers.com")
-    assert email == %Email{reply_to: {"", "welcome@avengers.com"}}
+    email = new |> reply_to("welcome.avengers@example.com")
+    assert email == %Email{reply_to: {"", "welcome.avengers@example.com"}}
 
-    email = email |> reply_to({"Jarvis Assist", "help@jarvis.com"})
-    assert email == %Email{reply_to: {"Jarvis Assist", "help@jarvis.com"}}
+    email = email |> reply_to({"Jarvis Assist", "help.jarvis@example.com"})
+    assert email == %Email{reply_to: {"Jarvis Assist", "help.jarvis@example.com"}}
   end
 
   test "to/2 add new recipient(s) to \"to\"" do
-    email = new |> to("tony@stark.com")
-    assert email == %Email{to: [{"", "tony@stark.com"}]}
+    email = new |> to("tony.stark@example.com")
+    assert email == %Email{to: [{"", "tony.stark@example.com"}]}
 
-    email = email |> to({"Steve Rogers", "steve@rogers.com"})
-    assert email == %Email{to: [{"Steve Rogers", "steve@rogers.com"}, {"", "tony@stark.com"}]}
+    email = email |> to({"Steve Rogers", "steve.rogers@example.com"})
+    assert email == %Email{to: [{"Steve Rogers", "steve.rogers@example.com"}, {"", "tony.stark@example.com"}]}
 
-    email = email |> to(["bruce@banner.com", {"Thor Odinson", "thor@odinson.com"}])
-    assert email == %Email{to: [{"", "bruce@banner.com"}, {"Thor Odinson", "thor@odinson.com"},
-                                {"Steve Rogers", "steve@rogers.com"}, {"", "tony@stark.com"}]}
+    email = email |> to(["bruce.banner@example.com", {"Thor Odinson", "thor.odinson@example.com"}])
+    assert email == %Email{to: [{"", "bruce.banner@example.com"}, {"Thor Odinson", "thor.odinson@example.com"},
+                                {"Steve Rogers", "steve.rogers@example.com"}, {"", "tony.stark@example.com"}]}
   end
 
   test "to/2 should raise if recipient(s) are invalid" do
     assert_raise ArgumentError, fn -> new |> to(nil) end
     assert_raise ArgumentError, fn -> new |> to("") end
-    assert_raise ArgumentError, fn -> new |> to({nil, "tony@stark.com"}) end
-    assert_raise ArgumentError, fn -> new |> to([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> to({nil, "tony.stark@example.com"}) end
+    assert_raise ArgumentError, fn -> new |> to([nil, "thor.odinson@example.com"]) end
     assert_raise ArgumentError, fn ->
-      new |> to([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> to([{"Bruce Banner", nil}, "thor.odinson@example.com"])
     end
   end
 
   test "put_to/2 replace new recipient(s) in \"to\"" do
-    email = new |> to("foo@bar.com")
+    email = new |> to("foo.bar@example.com")
 
-    email = email |> put_to("tony@stark.com")
-    assert email == %Email{to: [{"", "tony@stark.com"}]}
+    email = email |> put_to("tony.stark@example.com")
+    assert email == %Email{to: [{"", "tony.stark@example.com"}]}
 
-    email = email |> put_to({"Steve Rogers","steve@rogers.com"})
-    assert email == %Email{to: [{"Steve Rogers", "steve@rogers.com"}]}
+    email = email |> put_to({"Steve Rogers","steve.rogers@example.com"})
+    assert email == %Email{to: [{"Steve Rogers", "steve.rogers@example.com"}]}
 
-    email = email |> put_to(["bruce@banner.com", {"Thor Odinson", "thor@odinson.com"}])
-    assert email == %Email{to: [{"", "bruce@banner.com"}, {"Thor Odinson", "thor@odinson.com"}]}
+    email = email |> put_to(["bruce.banner@example.com", {"Thor Odinson", "thor.odinson@example.com"}])
+    assert email == %Email{to: [{"", "bruce.banner@example.com"}, {"Thor Odinson", "thor.odinson@example.com"}]}
   end
 
   test "put_to/2 should raise if recipient(s) are invalid" do
     assert_raise ArgumentError, fn -> new |> put_to(nil) end
     assert_raise ArgumentError, fn -> new |> put_to("") end
-    assert_raise ArgumentError, fn -> new |> put_to({nil, "tony@stark.com"}) end
-    assert_raise ArgumentError, fn -> new |> put_to([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> put_to({nil, "tony.stark@example.com"}) end
+    assert_raise ArgumentError, fn -> new |> put_to([nil, "thor.odinson@example.com"]) end
     assert_raise ArgumentError, fn ->
-      new |> put_to([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> put_to([{"Bruce Banner", nil}, "thor.odinson@example.com"])
     end
   end
 
   test "cc/2 add new recipient(s) to \"cc\"" do
-    email = new |> cc("ccny@stark.com")
-    assert email == %Email{cc: [{"", "ccny@stark.com"}]}
+    email = new |> cc("ccny.stark@example.com")
+    assert email == %Email{cc: [{"", "ccny.stark@example.com"}]}
 
-    email = email |> cc({"Steve Rogers", "steve@rogers.com"})
-    assert email == %Email{cc: [{"Steve Rogers", "steve@rogers.com"}, {"", "ccny@stark.com"}]}
+    email = email |> cc({"Steve Rogers", "steve.rogers@example.com"})
+    assert email == %Email{cc: [{"Steve Rogers", "steve.rogers@example.com"}, {"", "ccny.stark@example.com"}]}
 
-    email = email |> cc(["bruce@banner.com", {"Thor Odinson", "thor@odinson.com"}])
-    assert email == %Email{cc: [{"", "bruce@banner.com"}, {"Thor Odinson", "thor@odinson.com"},
-                               {"Steve Rogers", "steve@rogers.com"}, {"", "ccny@stark.com"}]}
+    email = email |> cc(["bruce.banner@example.com", {"Thor Odinson", "thor.odinson@example.com"}])
+    assert email == %Email{cc: [{"", "bruce.banner@example.com"}, {"Thor Odinson", "thor.odinson@example.com"},
+                               {"Steve Rogers", "steve.rogers@example.com"}, {"", "ccny.stark@example.com"}]}
   end
 
   test "cc/2 should raise if recipient(s) are invalid" do
     assert_raise ArgumentError, fn -> new |> cc(nil) end
     assert_raise ArgumentError, fn -> new |> cc("") end
-    assert_raise ArgumentError, fn -> new |> cc({nil, "ccny@stark.com"}) end
-    assert_raise ArgumentError, fn -> new |> cc([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> cc({nil, "ccny.stark@example.com"}) end
+    assert_raise ArgumentError, fn -> new |> cc([nil, "thor.odinson@example.com"]) end
     assert_raise ArgumentError, fn ->
-      new |> cc([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> cc([{"Bruce Banner", nil}, "thor.odinson@example.com"])
     end
   end
 
   test "put_cc/2 replace new recipient(s) in \"cc\"" do
-    email = new |> cc("foo@bar.com")
+    email = new |> cc("foo.bar@example.com")
 
-    email = email |> put_cc("ccny@stark.com")
-    assert email == %Email{cc: [{"", "ccny@stark.com"}]}
+    email = email |> put_cc("ccny.stark@example.com")
+    assert email == %Email{cc: [{"", "ccny.stark@example.com"}]}
 
-    email = email |> put_cc({"Steve Rogers","steve@rogers.com"})
-    assert email == %Email{cc: [{"Steve Rogers", "steve@rogers.com"}]}
+    email = email |> put_cc({"Steve Rogers","steve.rogers@example.com"})
+    assert email == %Email{cc: [{"Steve Rogers", "steve.rogers@example.com"}]}
 
-    email = email |> put_cc(["bruce@banner.com", {"Thor Odinson", "thor@odinson.com"}])
-    assert email == %Email{cc: [{"", "bruce@banner.com"}, {"Thor Odinson", "thor@odinson.com"}]}
+    email = email |> put_cc(["bruce.banner@example.com", {"Thor Odinson", "thor.odinson@example.com"}])
+    assert email == %Email{cc: [{"", "bruce.banner@example.com"}, {"Thor Odinson", "thor.odinson@example.com"}]}
   end
 
   test "put_cc/2 should raise if recipient(s) are invalid" do
     assert_raise ArgumentError, fn -> new |> put_cc(nil) end
     assert_raise ArgumentError, fn -> new |> put_cc("") end
-    assert_raise ArgumentError, fn -> new |> put_cc({nil, "ccny@stark.com"}) end
-    assert_raise ArgumentError, fn -> new |> put_cc([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> put_cc({nil, "ccny.stark@example.com"}) end
+    assert_raise ArgumentError, fn -> new |> put_cc([nil, "thor.odinson@example.com"]) end
     assert_raise ArgumentError, fn ->
-      new |> put_cc([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> put_cc([{"Bruce Banner", nil}, "thor.odinson@example.com"])
     end
   end
 
   test "bcc/2 add new recipient(s) to \"bcc\"" do
-    email = new |> bcc("bccny@stark.com")
-    assert email == %Email{bcc: [{"", "bccny@stark.com"}]}
+    email = new |> bcc("bccny.stark@example.com")
+    assert email == %Email{bcc: [{"", "bccny.stark@example.com"}]}
 
-    email = email |> bcc({"Steve Rogers", "steve@rogers.com"})
-    assert email == %Email{bcc: [{"Steve Rogers", "steve@rogers.com"}, {"", "bccny@stark.com"}]}
+    email = email |> bcc({"Steve Rogers", "steve.rogers@example.com"})
+    assert email == %Email{bcc: [{"Steve Rogers", "steve.rogers@example.com"}, {"", "bccny.stark@example.com"}]}
 
-    email = email |> bcc(["bruce@banner.com", {"Thor Odinson", "thor@odinson.com"}])
-    assert email == %Email{bcc: [{"", "bruce@banner.com"}, {"Thor Odinson", "thor@odinson.com"},
-                               {"Steve Rogers", "steve@rogers.com"}, {"", "bccny@stark.com"}]}
+    email = email |> bcc(["bruce.banner@example.com", {"Thor Odinson", "thor.odinson@example.com"}])
+    assert email == %Email{bcc: [{"", "bruce.banner@example.com"}, {"Thor Odinson", "thor.odinson@example.com"},
+                               {"Steve Rogers", "steve.rogers@example.com"}, {"", "bccny.stark@example.com"}]}
   end
 
   test "bcc/2 should raise if recipient(s) are invalid" do
     assert_raise ArgumentError, fn -> new |> bcc(nil) end
     assert_raise ArgumentError, fn -> new |> bcc("") end
-    assert_raise ArgumentError, fn -> new |> bcc({nil, "bccny@stark.com"}) end
-    assert_raise ArgumentError, fn -> new |> bcc([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> bcc({nil, "bccny.stark@example.com"}) end
+    assert_raise ArgumentError, fn -> new |> bcc([nil, "thor.odinson@example.com"]) end
     assert_raise ArgumentError, fn ->
-      new |> bcc([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> bcc([{"Bruce Banner", nil}, "thor.odinson@example.com"])
     end
   end
 
   test "put_bcc/2 replace new recipient(s) in \"bcc\"" do
-    email = new |> bcc("foo@bar.com")
+    email = new |> bcc("foo.bar@example.com")
 
-    email = email |> put_bcc("bccny@stark.com")
-    assert email == %Email{bcc: [{"", "bccny@stark.com"}]}
+    email = email |> put_bcc("bccny.stark@example.com")
+    assert email == %Email{bcc: [{"", "bccny.stark@example.com"}]}
 
-    email = email |> put_bcc({"Steve Rogers","steve@rogers.com"})
-    assert email == %Email{bcc: [{"Steve Rogers", "steve@rogers.com"}]}
+    email = email |> put_bcc({"Steve Rogers","steve.rogers@example.com"})
+    assert email == %Email{bcc: [{"Steve Rogers", "steve.rogers@example.com"}]}
 
-    email = email |> put_bcc(["bruce@banner.com", {"Thor Odinson", "thor@odinson.com"}])
-    assert email == %Email{bcc: [{"", "bruce@banner.com"}, {"Thor Odinson", "thor@odinson.com"}]}
+    email = email |> put_bcc(["bruce.banner@example.com", {"Thor Odinson", "thor.odinson@example.com"}])
+    assert email == %Email{bcc: [{"", "bruce.banner@example.com"}, {"Thor Odinson", "thor.odinson@example.com"}]}
   end
 
   test "put_bcc/2 should raise if recipient(s) are invalid" do
     assert_raise ArgumentError, fn -> new |> put_bcc(nil) end
     assert_raise ArgumentError, fn -> new |> put_bcc("") end
-    assert_raise ArgumentError, fn -> new |> put_bcc({nil, "bccny@stark.com"}) end
-    assert_raise ArgumentError, fn -> new |> put_bcc([nil, "thor@odinson.com"]) end
+    assert_raise ArgumentError, fn -> new |> put_bcc({nil, "bccny.stark@example.com"}) end
+    assert_raise ArgumentError, fn -> new |> put_bcc([nil, "thor.odinson@example.com"]) end
     assert_raise ArgumentError, fn ->
-      new |> put_bcc([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> put_bcc([{"Bruce Banner", nil}, "thor.odinson@example.com"])
     end
   end
 
@@ -244,7 +244,7 @@ defmodule Swoosh.EmailTest do
       The recipient `nil` is invalid.
 
       Recipients must be a string representing an email address like
-      `foo@bar.com` or a two-element tuple `{name, address}`, where
+      `foo.bar@example.com` or a two-element tuple `{name, address}`, where
       name and address are strings.
       """, fn ->
       new |> to(nil)
@@ -252,13 +252,13 @@ defmodule Swoosh.EmailTest do
 
     assert_raise ArgumentError,
       """
-      The recipient `{nil, "tony@stark.com"}` is invalid.
+      The recipient `{nil, "tony.stark@example.com"}` is invalid.
 
       Recipients must be a string representing an email address like
-      `foo@bar.com` or a two-element tuple `{name, address}`, where
+      `foo.bar@example.com` or a two-element tuple `{name, address}`, where
       name and address are strings.
       """, fn ->
-      new |> to({nil, "tony@stark.com"})
+      new |> to({nil, "tony.stark@example.com"})
     end
 
     assert_raise ArgumentError,
@@ -266,10 +266,10 @@ defmodule Swoosh.EmailTest do
       The recipient `nil` is invalid.
 
       Recipients must be a string representing an email address like
-      `foo@bar.com` or a two-element tuple `{name, address}`, where
+      `foo.bar@example.com` or a two-element tuple `{name, address}`, where
       name and address are strings.
       """, fn ->
-      new |> to([nil, "thor@odinson.com"])
+      new |> to([nil, "thor.odinson@example.com"])
     end
 
     assert_raise ArgumentError,
@@ -277,10 +277,10 @@ defmodule Swoosh.EmailTest do
       The recipient `{"Bruce Banner", nil}` is invalid.
 
       Recipients must be a string representing an email address like
-      `foo@bar.com` or a two-element tuple `{name, address}`, where
+      `foo.bar@example.com` or a two-element tuple `{name, address}`, where
       name and address are strings.
       """, fn ->
-      new |> to([{"Bruce Banner", nil}, "thor@odinson.com"])
+      new |> to([{"Bruce Banner", nil}, "thor.odinson@example.com"])
     end
   end
 end

--- a/test/swoosh/mailer_test.exs
+++ b/test/swoosh/mailer_test.exs
@@ -18,8 +18,8 @@ defmodule Swoosh.MailerTest do
   end
 
   setup_all do
-    valid_email = Swoosh.Email.new(from: "tony@stark.com",
-                                   to: "steve@rogers.com",
+    valid_email = Swoosh.Email.new(from: "tony.stark@example.com",
+                                   to: "steve.rogers@example.com",
                                    subject: "Hello, Avengers!",
                                    html_body: "<h1>Hello</h1>",
                                    text_body: "Hello")

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -7,8 +7,8 @@ defmodule Swoosh.TestAssertionsTest do
   setup do
     email =
       new
-      |> from("tony@stark.com")
-      |> to("steve@rogers.com")
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
     Swoosh.Adapters.Test.deliver(email, nil)
     {:ok, email: email}
@@ -19,11 +19,11 @@ defmodule Swoosh.TestAssertionsTest do
   end
 
   test "assert email sent with specific params" do
-    assert_email_sent [subject: "Hello, Avengers!", to: "steve@rogers.com"]
+    assert_email_sent [subject: "Hello, Avengers!", to: "steve.rogers@example.com"]
   end
 
   test "assert email sent with specific to (list)" do
-    assert_email_sent [to: ["steve@rogers.com"]]
+    assert_email_sent [to: ["steve.rogers@example.com"]]
   end
 
   test "assert email sent with wrong subject" do
@@ -32,7 +32,7 @@ defmodule Swoosh.TestAssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "Email `subject` does not match\n" <>
-        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}\n" <>
         "lhs: \"Hello, Avengers!\"\n" <>
         "rhs: \"Hello, X-Men!\"" = error.message
     end
@@ -40,60 +40,60 @@ defmodule Swoosh.TestAssertionsTest do
 
   test "assert email sent with wrong from" do
     try do
-      assert_email_sent [from: "thor@odinson.com"]
+      assert_email_sent [from: "thor.odinson@example.com"]
     rescue
       error in [ExUnit.AssertionError] ->
         "Email `from` does not match\n" <>
-        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-        "lhs: {\"\", \"tony@stark.com\"}\n" <>
-        "rhs: {\"\", \"thor@odinson.com\"}" = error.message
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}\n" <>
+        "lhs: {\"\", \"tony.stark@example.com\"}\n" <>
+        "rhs: {\"\", \"thor.odinson@example.com\"}" = error.message
     end
   end
 
   test "assert email sent with wrong to" do
     try do
-      assert_email_sent [to: "bruce@banner.com"]
+      assert_email_sent [to: "bruce.banner@example.com"]
     rescue
       error in [ExUnit.AssertionError] ->
         "Email `to` does not match\n" <>
-        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-        "lhs: {\"\", \"bruce@banner.com\"}\n" <>
-        "rhs: [{\"\", \"steve@rogers.com\"}]" = error.message
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}\n" <>
+        "lhs: {\"\", \"bruce.banner@example.com\"}\n" <>
+        "rhs: [{\"\", \"steve.rogers@example.com\"}]" = error.message
     end
   end
 
   test "assert email sent with wrong to (list)" do
     try do
-      assert_email_sent [to: ["bruce@banner.com"]]
+      assert_email_sent [to: ["bruce.banner@example.com"]]
     rescue
       error in [ExUnit.AssertionError] ->
         "Email `to` does not match\n" <>
-        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-        "lhs: [{\"\", \"steve@rogers.com\"}]\n" <>
-        "rhs: [{\"\", \"bruce@banner.com\"}]" = error.message
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}\n" <>
+        "lhs: [{\"\", \"steve.rogers@example.com\"}]\n" <>
+        "rhs: [{\"\", \"bruce.banner@example.com\"}]" = error.message
     end
   end
 
   test "assert email sent with wrong cc" do
     try do
-      assert_email_sent [cc: "bruce@banner.com"]
+      assert_email_sent [cc: "bruce.banner@example.com"]
     rescue
       error in [ExUnit.AssertionError] ->
         "Email `cc` does not match\n" <>
-        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-        "lhs: {\"\", \"bruce@banner.com\"}\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}\n" <>
+        "lhs: {\"\", \"bruce.banner@example.com\"}\n" <>
         "rhs: []" = error.message
     end
   end
 
   test "assert email sent with wrong bcc" do
     try do
-      assert_email_sent [bcc: "bruce@banner.com"]
+      assert_email_sent [bcc: "bruce.banner@example.com"]
     rescue
       error in [ExUnit.AssertionError] ->
         "Email `bcc` does not match\n" <>
-        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}\n" <>
-        "lhs: {\"\", \"bruce@banner.com\"}\n" <>
+        "email: %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}\n" <>
+        "lhs: {\"\", \"bruce.banner@example.com\"}\n" <>
         "rhs: []" = error.message
     end
   end
@@ -108,7 +108,7 @@ defmodule Swoosh.TestAssertionsTest do
         "The following variables were pinned:\n" <>
         "  email = %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: nil, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Wrong, Avengers!\", text_body: nil, to: []}\n" <>
         "Process mailbox:\n" <>
-        "  {:email, %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}}"
+        "  {:email, %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}}"
         = error.message
     end
   end
@@ -123,7 +123,7 @@ defmodule Swoosh.TestAssertionsTest do
       assert_email_not_sent email
     rescue
       error in [ExUnit.AssertionError] ->
-        "Unexpectedly received message {:email, %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}} " <>
+        "Unexpectedly received message {:email, %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}} " <>
         "(which matched {:email, ^email})" = error.message
     end
   end
@@ -140,7 +140,7 @@ defmodule Swoosh.TestAssertionsTest do
       assert_no_email_sent
     rescue
       error in [ExUnit.AssertionError] ->
-        "Unexpectedly received message {:email, %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony@stark.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve@rogers.com\"}]}} " <>
+        "Unexpectedly received message {:email, %Swoosh.Email{assigns: %{}, attachments: nil, bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}} " <>
         "(which matched {:email, _})" = error.message
     end
   end


### PR DESCRIPTION
Hello,

I felt that I had probably send you enough spam and made the domain in integration tests configurable. 

I also changed the e-mail addresses in tests from, i. e. tony@stark.com to tony.stark@example.com. I felt uncomfortable with the possibility of them leaking into production code and possibly interfering with real people.

I hope these changes are useful. Thx!