### PR TITLE
Handle templates for postmark

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -55,10 +55,8 @@ defmodule Swoosh.Adapters.Postmark do
   defp base_url(config),
     do: config[:base_url] || @base_url
 
-  defp api_endpoint([{:template, true} | _]),
-    do: @api_endpoint <> "/withTemplate"
-  defp api_endpoint(_config),
-    do: @api_endpoint
+  defp api_endpoint(config),
+    do: @api_endpoint <> if config[:template], do: "/withTemplate", else: ""
 
   defp prepare_body(email) do
     %{}

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -55,7 +55,7 @@ defmodule Swoosh.Adapters.Postmark do
     do: @api_endpoint
 
   defp prepare_body(email) do
-    %{}
+    Map.new()
     |> prepare_from(email)
     |> prepare_to(email)
     |> prepare_subject(email)

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -26,9 +26,8 @@ defmodule Swoosh.Adapters.Postmark do
 
   def deliver(%Email{} = email, config \\ []) do
     headers = prepare_headers(config)
-    email   = prepare_body(email)
+    params  = email |> prepare_body |> Poison.encode!
     url     = prepare_url(config, email)
-    params  = Poison.encode!(email)
 
     case :hackney.post(url, headers, params, [:with_body]) do
       {:ok, 200, _headers, body} ->
@@ -53,7 +52,7 @@ defmodule Swoosh.Adapters.Postmark do
   defp base_url(config),
     do: config[:base_url] || @base_url
 
-  defp api_endpoint(%{"TemplateModel" => _, "TemplateId" => _}),
+  defp api_endpoint(%Email{provider_options: %{template_id: _, template_model: _}}),
     do: @api_endpoint <> "/withTemplate"
   defp api_endpoint(_email),
     do: @api_endpoint

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -109,10 +109,10 @@ defmodule Swoosh.Adapters.Postmark do
 
   defp make_request(url, headers, params) do
     case :hackney.post(url, headers, params, [:with_body]) do
-      {:ok, 200, _headers, body} ->
-        {:ok, %{id: Poison.decode!(body)["MessageID"]}}
       {:ok, code, _headers, body} when code > 399 ->
         {:error, {code, Poison.decode!(body)}}
+      {:ok, 200, _headers, body} ->
+        {:ok, %{id: Poison.decode!(body)["MessageID"]}}
       {:error, reason} ->
         {:error, reason}
     end

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -26,8 +26,8 @@ defmodule Swoosh.Adapters.Postmark do
 
   def deliver(%Email{} = email, config \\ []) do
     headers = prepare_headers(config)
-    params = email |> prepare_body |> Poison.encode!
-    url = [base_url(config), @api_endpoint]
+    params  = email |> prepare_body() |> Poison.encode!()
+    url     = [base_url(config), @api_endpoint]
 
     case :hackney.post(url, headers, params, [:with_body]) do
       {:ok, 200, _headers, body} ->
@@ -42,10 +42,12 @@ defmodule Swoosh.Adapters.Postmark do
   defp base_url(config), do: config[:base_url] || @base_url
 
   defp prepare_headers(config) do
-    [{"User-Agent", "swoosh/#{Swoosh.version}"},
-     {"X-Postmark-Server-Token", config[:api_key]},
-     {"Content-Type", "application/json"},
-     {"Accept", "application/json"}]
+    [
+      {"User-Agent",              "swoosh/#{Swoosh.version}"},
+      {"X-Postmark-Server-Token", config[:api_key]},
+      {"Content-Type",            "application/json"},
+      {"Accept",                  "application/json"}
+    ]
   end
 
   defp prepare_body(email) do
@@ -67,10 +69,10 @@ defmodule Swoosh.Adapters.Postmark do
   defp prepare_cc(body, %Email{cc: []}), do: body
   defp prepare_cc(body, %Email{cc: cc}), do: Map.put(body, "Cc", prepare_recipients(cc))
 
-  defp prepare_bcc(body, %Email{bcc: []}), do: body
+  defp prepare_bcc(body, %Email{bcc: []}),  do: body
   defp prepare_bcc(body, %Email{bcc: bcc}), do: Map.put(body, "Bcc", prepare_recipients(bcc))
 
-  defp prepare_reply_to(body, %Email{reply_to: nil}), do: body
+  defp prepare_reply_to(body, %Email{reply_to: nil}),              do: body
   defp prepare_reply_to(body, %Email{reply_to: {_name, address}}), do: Map.put(body, "ReplyTo", address)
 
   defp prepare_recipients(recipients) do
@@ -79,14 +81,14 @@ defmodule Swoosh.Adapters.Postmark do
     |> Enum.join(",")
   end
 
-  defp prepare_recipient({"", address}), do: address
+  defp prepare_recipient({"",   address}), do: address
   defp prepare_recipient({name, address}), do: "\"#{name}\" <#{address}>"
 
   defp prepare_subject(body, %Email{subject: subject}), do: Map.put(body, "Subject", subject)
 
-  defp prepare_text(body, %{text_body: nil}), do: body
+  defp prepare_text(body, %{text_body: nil}),       do: body
   defp prepare_text(body, %{text_body: text_body}), do: Map.put(body, "TextBody", text_body)
 
-  defp prepare_html(body, %{html_body: nil}), do: body
+  defp prepare_html(body, %{html_body: nil}),       do: body
   defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, "HtmlBody", html_body)
 end

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -109,9 +109,8 @@ defmodule Swoosh.Adapters.Postmark do
     do: Enum.reduce(provider_options, body, &put_in_body/2)
   defp prepare_custom_vars(body, _email), do: body
 
-  defp put_in_body({key, value}, body_acc) do
+  defp put_in_body({key, val}, body_acc) do
     key = key |> to_string() |> Macro.camelize()
-    val = Poison.encode!(value)
     Map.put(body_acc, key, val)
   end
 

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -90,6 +90,7 @@ defmodule Swoosh.Adapters.Postmark do
   defp prepare_recipient({"",   address}), do: address
   defp prepare_recipient({name, address}), do: "\"#{name}\" <#{address}>"
 
+  defp prepare_subject(body, %Email{subject: ""}),      do: body
   defp prepare_subject(body, %Email{subject: subject}), do: Map.put(body, "Subject", subject)
 
   defp prepare_text(body, %Email{text_body: nil}),       do: body

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -63,6 +63,8 @@ defmodule Swoosh.Adapters.Postmark do
     |> prepare_cc(email)
     |> prepare_bcc(email)
     |> prepare_reply_to(email)
+    |> prepare_template_id(email)
+    |> prepare_template_model(email)
     |> Poison.encode!()
   end
 
@@ -95,6 +97,14 @@ defmodule Swoosh.Adapters.Postmark do
 
   defp prepare_html(body, %{html_body: nil}),       do: body
   defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, "HtmlBody", html_body)
+
+  defp prepare_template_id(body, %{template_id: nil}),         do: body
+  defp prepare_template_id(body, %{template_id: template_id}), do: Map.put(body, "TemplateId", template_id)
+  defp prepare_template_id(body, _email),                      do: body
+
+  defp prepare_template_model(body, %{template_model: nil}),            do: body
+  defp prepare_template_model(body, %{template_model: template_model}), do: Map.put(body, "TemplateModel", template_model)
+  defp prepare_template_model(body, _email),                            do: body
 
   defp make_request(url, headers, params) do
     case :hackney.post(url, headers, params, [:with_body]) do

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -41,11 +41,17 @@ defmodule Swoosh.Adapters.Postmark do
     ]
   end
 
-  defp prepare_url(config) do
-    [base_url(config), @api_endpoint]
-  end
+  defp prepare_url(config),
+    do: [base_url(config), api_endpoint(config)]
 
-  defp base_url(config), do: config[:base_url] || @base_url
+  defp base_url(config),
+    do: config[:base_url] || @base_url
+
+  defp api_endpoint([template: template])
+  when not is_nil(template),
+    do: @api_endpoint <>  "/withTemplate"
+  defp api_endpoint(_config),
+    do: @api_endpoint
 
   defp prepare_body(email) do
     %{}

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -34,10 +34,10 @@ defmodule Swoosh.Adapters.Postmark do
 
   defp prepare_headers(config) do
     [
-      {"User-Agent",              "swoosh/#{Swoosh.version}"},
+      {"User-Agent", "swoosh/#{Swoosh.version}"},
       {"X-Postmark-Server-Token", config[:api_key]},
-      {"Content-Type",            "application/json"},
-      {"Accept",                  "application/json"}
+      {"Content-Type", "application/json"},
+      {"Accept", "application/json"}
     ]
   end
 
@@ -49,12 +49,12 @@ defmodule Swoosh.Adapters.Postmark do
 
   defp api_endpoint([{:template, template} | _])
   when not is_nil(template),
-    do: @api_endpoint <>  "/withTemplate"
+    do: @api_endpoint <> "/withTemplate"
   defp api_endpoint(_config),
     do: @api_endpoint
 
   defp prepare_body(email) do
-    Map.new()
+    %{}
     |> prepare_from(email)
     |> prepare_to(email)
     |> prepare_subject(email)
@@ -74,10 +74,10 @@ defmodule Swoosh.Adapters.Postmark do
   defp prepare_cc(body, %Email{cc: []}), do: body
   defp prepare_cc(body, %Email{cc: cc}), do: Map.put(body, "Cc", prepare_recipients(cc))
 
-  defp prepare_bcc(body, %Email{bcc: []}),  do: body
+  defp prepare_bcc(body, %Email{bcc: []}), do: body
   defp prepare_bcc(body, %Email{bcc: bcc}), do: Map.put(body, "Bcc", prepare_recipients(bcc))
 
-  defp prepare_reply_to(body, %Email{reply_to: nil}),              do: body
+  defp prepare_reply_to(body, %Email{reply_to: nil}), do: body
   defp prepare_reply_to(body, %Email{reply_to: {_name, address}}), do: Map.put(body, "ReplyTo", address)
 
   defp prepare_recipients(recipients) do
@@ -86,16 +86,16 @@ defmodule Swoosh.Adapters.Postmark do
     |> Enum.join(",")
   end
 
-  defp prepare_recipient({"",   address}), do: address
+  defp prepare_recipient({"", address}), do: address
   defp prepare_recipient({name, address}), do: "\"#{name}\" <#{address}>"
 
-  defp prepare_subject(body, %Email{subject: ""}),      do: body
+  defp prepare_subject(body, %Email{subject: ""}), do: body
   defp prepare_subject(body, %Email{subject: subject}), do: Map.put(body, "Subject", subject)
 
-  defp prepare_text(body, %Email{text_body: nil}),       do: body
+  defp prepare_text(body, %Email{text_body: nil}), do: body
   defp prepare_text(body, %Email{text_body: text_body}), do: Map.put(body, "TextBody", text_body)
 
-  defp prepare_html(body, %Email{html_body: nil}),       do: body
+  defp prepare_html(body, %Email{html_body: nil}), do: body
   defp prepare_html(body, %Email{html_body: html_body}), do: Map.put(body, "HtmlBody", html_body)
 
   # example custom vars

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -48,7 +48,7 @@ defmodule Swoosh.Adapters.Postmark do
   defp base_url(config),
     do: config[:base_url] || @base_url
 
-  defp api_endpoint([template: template])
+  defp api_endpoint([{:template, template} | _])
   when not is_nil(template),
     do: @api_endpoint <>  "/withTemplate"
   defp api_endpoint(_config),

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -8,8 +8,9 @@ defmodule Swoosh.Adapters.Postmark do
 
       # config/config.exs
       config :sample, Sample.Mailer,
-        adapter: Swoosh.Adapters.Postmark,
-        api_key: "my-api-key"
+        adapter:  Swoosh.Adapters.Postmark,
+        api_key:  "my-api-key",
+        template: true # optional
 
       # lib/sample/mailer.ex
       defmodule Sample.Mailer do

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -9,7 +9,8 @@ defmodule Swoosh.Adapters.Postmark do
       # config/config.exs
       config :sample, Sample.Mailer,
         adapter:  Swoosh.Adapters.Postmark,
-        api_key:  "my-api-key"
+        api_key:  "my-api-key",
+        template: true # optional
 
       # lib/sample/mailer.ex
       defmodule Sample.Mailer do
@@ -54,8 +55,7 @@ defmodule Swoosh.Adapters.Postmark do
   defp base_url(config),
     do: config[:base_url] || @base_url
 
-  defp api_endpoint([{:template, template} | _])
-  when not is_nil(template),
+  defp api_endpoint([{:template, true} | _]),
     do: @api_endpoint <> "/withTemplate"
   defp api_endpoint(_config),
     do: @api_endpoint

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -9,8 +9,7 @@ defmodule Swoosh.Adapters.Postmark do
       # config/config.exs
       config :sample, Sample.Mailer,
         adapter:  Swoosh.Adapters.Postmark,
-        api_key:  "my-api-key",
-        template: true # optional
+        api_key:  "my-api-key"
 
       # lib/sample/mailer.ex
       defmodule Sample.Mailer do

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -26,8 +26,8 @@ defmodule Swoosh.Adapters.Postmark do
 
   def deliver(%Email{} = email, config \\ []) do
     headers = prepare_headers(config)
-    params  = email |> prepare_body |> Poison.encode!
-    url     = prepare_url(config, email)
+    params = email |> prepare_body |> Poison.encode!
+    url = [base_url(config), api_endpoint(email)]
 
     case :hackney.post(url, headers, params, [:with_body]) do
       {:ok, 200, _headers, body} ->
@@ -39,18 +39,14 @@ defmodule Swoosh.Adapters.Postmark do
     end
   end
 
+  defp base_url(config), do: config[:base_url] || @base_url
+
   defp prepare_headers(config) do
     [{"User-Agent", "swoosh/#{Swoosh.version}"},
      {"X-Postmark-Server-Token", config[:api_key]},
      {"Content-Type", "application/json"},
      {"Accept", "application/json"}]
   end
-
-  defp prepare_url(config, email),
-    do: [base_url(config), api_endpoint(email)]
-
-  defp base_url(config),
-    do: config[:base_url] || @base_url
 
   defp api_endpoint(%Email{provider_options: %{template_id: _, template_model: _}}),
     do: @api_endpoint <> "/withTemplate"

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -93,11 +93,11 @@ defmodule Swoosh.Adapters.Postmark do
 
   defp prepare_subject(body, %Email{subject: subject}), do: Map.put(body, "Subject", subject)
 
-  defp prepare_text(body, %{text_body: nil}),       do: body
-  defp prepare_text(body, %{text_body: text_body}), do: Map.put(body, "TextBody", text_body)
+  defp prepare_text(body, %Email{text_body: nil}),       do: body
+  defp prepare_text(body, %Email{text_body: text_body}), do: Map.put(body, "TextBody", text_body)
 
-  defp prepare_html(body, %{html_body: nil}),       do: body
-  defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, "HtmlBody", html_body)
+  defp prepare_html(body, %Email{html_body: nil}),       do: body
+  defp prepare_html(body, %Email{html_body: html_body}), do: Map.put(body, "HtmlBody", html_body)
 
   defp prepare_template_id(body, %{template_id: nil}),         do: body
   defp prepare_template_id(body, %{template_id: template_id}), do: Map.put(body, "TemplateId", template_id)

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -31,22 +31,20 @@ defmodule Swoosh.Adapters.Postmark do
     params  = Poison.encode!(email)
 
     case :hackney.post(url, headers, params, [:with_body]) do
-      {:ok, code, _headers, body} when code > 399 ->
-        {:error, {code, Poison.decode!(body)}}
       {:ok, 200, _headers, body} ->
         {:ok, %{id: Poison.decode!(body)["MessageID"]}}
+      {:ok, code, _headers, body} when code > 399 ->
+        {:error, {code, Poison.decode!(body)}}
       {:error, reason} ->
         {:error, reason}
     end
   end
 
   defp prepare_headers(config) do
-    [
-      {"User-Agent", "swoosh/#{Swoosh.version}"},
-      {"X-Postmark-Server-Token", config[:api_key]},
-      {"Content-Type", "application/json"},
-      {"Accept", "application/json"}
-    ]
+    [{"User-Agent", "swoosh/#{Swoosh.version}"},
+     {"X-Postmark-Server-Token", config[:api_key]},
+     {"Content-Type", "application/json"},
+     {"Accept", "application/json"}]
   end
 
   defp prepare_url(config, email),
@@ -88,7 +86,7 @@ defmodule Swoosh.Adapters.Postmark do
 
   defp prepare_recipients(recipients) do
     recipients
-    |> Enum.map(&prepare_recipient/1)
+    |> Enum.map(&prepare_recipient(&1))
     |> Enum.join(",")
   end
 

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -65,7 +65,7 @@ defmodule Swoosh.Email do
   @type text_body :: String.t
   @type html_body :: String.t
 
-  @type t :: %__MODULE__{subject: String.t,
+  @type t :: %__MODULE__{subject: subject,
                          from: mailbox | nil,
                          to: [mailbox],
                          cc: [mailbox] | [],

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -65,7 +65,7 @@ defmodule Swoosh.Email do
   @type text_body :: String.t
   @type html_body :: String.t
 
-  @type t :: %__MODULE__{subject: subject,
+  @type t :: %__MODULE__{subject: String.t,
                          from: mailbox | nil,
                          to: [mailbox],
                          cc: [mailbox] | [],

--- a/test/integration/adapters/postmark_test.exs
+++ b/test/integration/adapters/postmark_test.exs
@@ -5,42 +5,46 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
 
   @moduletag integration: true
 
-  @config [
-    api_key: System.get_env("POSTMARK_API_KEY"),
-    domain:  System.get_env("POSTMARK_DOMAIN"),
-  ]
+  setup_all do
+    config = [
+      api_key: System.get_env("POSTMARK_API_KEY"),
+      domain:  System.get_env("POSTMARK_DOMAIN"),
+    ]
+    valid_email =
+      new
+      |> from({"Swoosh Postmark", "swoosh@#{config[:domain]}"})
+      |> reply_to("swoosh+replyto@#{config[:domain]}")
+      |> to("swoosh+to@#{config[:domain]}")
+      |> cc("swoosh+cc@#{config[:domain]}")
+      |> bcc("swoosh+bcc@#{config[:domain]}")
 
-  @base_email new
-              |> from({"Swoosh Postmark", "swoosh@#{@config[:domain]}"})
-              |> reply_to("swoosh+replyto@#{@config[:domain]}")
-              |> to("swoosh+to@#{@config[:domain]}")
-              |> cc("swoosh+cc@#{@config[:domain]}")
-              |> bcc("swoosh+bcc@#{@config[:domain]}")
+    {:ok, valid_email: valid_email, config: config}
+  end
 
-  test "simple deliver" do
+  test "simple deliver", %{valid_email: valid_email, config: config} do
     email =
-      @base_email
+      valid_email
       |> subject("Swoosh - Postmark integration test")
       |> text_body("This email was sent by the Swoosh library automation testing")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")
 
-    assert_ok_response(email)
+    assert_ok_response(email, config)
   end
 
-  test "template deliver" do
-    config         = Keyword.put_new(@config, :template, true)
+  test "template deliver", %{valid_email: valid_email, config: config} do
+    config         = Keyword.put_new(config, :template, true)
     template_model = %{
       name:    "Swoosh",
       action_url: "Postmark",
     }
     email =
-      @base_email
+      valid_email
       |> put_provider_option(:template_id,    968101)
       |> put_provider_option(:template_model, template_model)
 
     assert_ok_response(email, config)
   end
 
-  defp assert_ok_response(email, config \\ @config),
+  defp assert_ok_response(email, config),
     do: assert {:ok, _response} = Swoosh.Adapters.Postmark.deliver(email, config)
 end

--- a/test/integration/adapters/postmark_test.exs
+++ b/test/integration/adapters/postmark_test.exs
@@ -6,10 +6,7 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
   @moduletag integration: true
 
   setup_all do
-    config = [
-      api_key: System.get_env("POSTMARK_API_KEY"),
-      domain:  System.get_env("POSTMARK_DOMAIN"),
-    ]
+    config = [api_key: System.get_env("POSTMARK_API_KEY"), domain: System.get_env("POSTMARK_DOMAIN")]
     valid_email =
       new
       |> from({"Swoosh Postmark", "swoosh@#{config[:domain]}"})
@@ -32,14 +29,14 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
   end
 
   test "template deliver", %{valid_email: valid_email, config: config} do
-    config         = Keyword.put_new(config, :template, true)
+    config = Keyword.put_new(config, :template, true)
     template_model = %{
-      name:    "Swoosh",
+      name: "Swoosh",
       action_url: "Postmark",
     }
     email =
       valid_email
-      |> put_provider_option(:template_id,    968101)
+      |> put_provider_option(:template_id, 968101)
       |> put_provider_option(:template_model, template_model)
 
     assert_ok_response(email, config)

--- a/test/integration/adapters/postmark_test.exs
+++ b/test/integration/adapters/postmark_test.exs
@@ -5,23 +5,42 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
 
   @moduletag integration: true
 
-  setup_all do
-    config = [api_key: System.get_env("POSTMARK_API_KEY"), domain: System.get_env("POSTMARK_DOMAIN")]
-    {:ok, config: config}
-  end
+  @config [
+    api_key: System.get_env("POSTMARK_API_KEY"),
+    domain:  System.get_env("POSTMARK_DOMAIN"),
+  ]
 
-  test "simple deliver", %{config: config} do
+  @base_email new
+              |> from({"Swoosh Postmark", "swoosh@#{@config[:domain]}"})
+              |> reply_to("swoosh+replyto@#{@config[:domain]}")
+              |> to("swoosh+to@#{@config[:domain]}")
+              |> cc("swoosh+cc@#{@config[:domain]}")
+              |> bcc("swoosh+bcc@#{@config[:domain]}")
+
+  test "simple deliver" do
     email =
-      new
-      |> from({"Swoosh Postmark", "swoosh@#{config[:domain]}"})
-      |> reply_to("swoosh+replyto@#{config[:domain]}")
-      |> to("swoosh+to@#{config[:domain]}")
-      |> cc("swoosh+cc@#{config[:domain]}")
-      |> bcc("swoosh+bcc@#{config[:domain]}")
+      @base_email
       |> subject("Swoosh - Postmark integration test")
       |> text_body("This email was sent by the Swoosh library automation testing")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")
 
-    assert {:ok, _response} = Swoosh.Adapters.Postmark.deliver(email, config)
+    assert_ok_response(email)
   end
+
+  test "template deliver" do
+    config         = Keyword.put_new(@config, :template, true)
+    template_model = %{
+      name:    "Swoosh",
+      action_url: "Postmark",
+    }
+    email =
+      @base_email
+      |> put_provider_option(:template_id,    968101)
+      |> put_provider_option(:template_model, template_model)
+
+    assert_ok_response(email, config)
+  end
+
+  defp assert_ok_response(email, config \\ @config),
+    do: assert {:ok, _response} = Swoosh.Adapters.Postmark.deliver(email, config)
 end

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -16,7 +16,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
   """
 
   setup_all do
-    bypass = Bypass.open()
+    bypass = Bypass.open
     config = [
       base_url: "http://localhost:#{bypass.port}",
       api_key:  "jarvis",
@@ -43,8 +43,8 @@ defmodule Swoosh.Adapters.PostmarkTest do
       }
 
       assert body_params == conn.body_params
-      assert "/email"    == conn.request_path
-      assert "POST"      == conn.method
+      assert "/email" == conn.request_path
+      assert "POST" == conn.method
 
       Plug.Conn.resp(conn, 200, @success_response)
     end
@@ -116,9 +116,9 @@ defmodule Swoosh.Adapters.PostmarkTest do
         }
       }
 
-      assert body_params           == conn.body_params
+      assert body_params == conn.body_params
       assert "/email/withTemplate" == conn.request_path
-      assert "POST"                == conn.method
+      assert "POST" == conn.method
 
       Plug.Conn.resp(conn, 200, @success_response)
     end

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -31,12 +31,11 @@ defmodule Swoosh.Adapters.PostmarkTest do
 
   test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
-      conn        = parse(conn)
+      conn = parse(conn)
       body_params = %{"Subject" => "Hello, Avengers!",
                       "To" => "tony.stark@example.com",
                       "From" => "steve.rogers@example.com",
                       "HtmlBody" => "<h1>Hello</h1>"}
-
       assert body_params == conn.body_params
       assert "/email" == conn.request_path
       assert "POST" == conn.method
@@ -64,7 +63,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
       |> text_body("Hello")
 
     Bypass.expect bypass, fn conn ->
-      conn        = parse(conn)
+      conn = parse(conn)
       body_params = %{"Subject" => "Hello, Avengers!",
                       "To" => "\"Steve Rogers\" <steve.rogers@example.com>,wasp.avengers@example.com",
                       "From" => "tony.stark@example.com",
@@ -98,7 +97,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
       |> put_provider_option(:template_model, template_model)
 
     Bypass.expect bypass, fn conn ->
-      conn        = parse(conn)
+      conn = parse(conn)
       body_params = %{
         "To"            => "avengers@example.com",
         "From"          => "tony.stark@example.com",

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -92,7 +92,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
   end
 
   test "delivery/1 with all fields for template returns :ok", %{bypass: bypass, config: config} do
-    config         = Keyword.put_new(config, :template, true)
+    config         = Keyword.merge(config, template: true)
     template_model = %{
       name:    "Tony Stark",
       company: "Avengers",

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -2,7 +2,6 @@ defmodule Swoosh.Adapters.PostmarkTest do
   use AdapterCase, async: true
 
   import Swoosh.Email
-
   alias Swoosh.Adapters.Postmark
 
   @success_response """
@@ -17,10 +16,8 @@ defmodule Swoosh.Adapters.PostmarkTest do
 
   setup_all do
     bypass = Bypass.open
-    config = [
-      base_url: "http://localhost:#{bypass.port}",
-      api_key:  "jarvis",
-    ]
+    config = [base_url: "http://localhost:#{bypass.port}",
+              api_key: "jarvis"]
 
     valid_email =
       new
@@ -35,12 +32,10 @@ defmodule Swoosh.Adapters.PostmarkTest do
   test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       conn        = parse(conn)
-      body_params = %{
-        "Subject"  => "Hello, Avengers!",
-        "To"       => "tony.stark@example.com",
-        "From"     => "steve.rogers@example.com",
-        "HtmlBody" => "<h1>Hello</h1>"
-      }
+      body_params = %{"Subject" => "Hello, Avengers!",
+                      "To" => "tony.stark@example.com",
+                      "From" => "steve.rogers@example.com",
+                      "HtmlBody" => "<h1>Hello</h1>"}
 
       assert body_params == conn.body_params
       assert "/email" == conn.request_path
@@ -70,20 +65,18 @@ defmodule Swoosh.Adapters.PostmarkTest do
 
     Bypass.expect bypass, fn conn ->
       conn        = parse(conn)
-      body_params = %{
-        "Subject"  => "Hello, Avengers!",
-        "To"       => "\"Steve Rogers\" <steve.rogers@example.com>,wasp.avengers@example.com",
-        "From"     => "tony.stark@example.com",
-        "Cc"       => "thor.odinson@example.com,\"Bruce Banner\" <hulk.smash@example.com>",
-        "Bcc"      => "beast.avengers@example.com,\"Clinton Francis Barton\" <hawk.eye@example.com>",
-        "ReplyTo"  => "iron.stark@example.com",
-        "TextBody" => "Hello",
-        "HtmlBody" => "<h1>Hello</h1>"
-      }
+      body_params = %{"Subject" => "Hello, Avengers!",
+                      "To" => "\"Steve Rogers\" <steve.rogers@example.com>,wasp.avengers@example.com",
+                      "From" => "tony.stark@example.com",
+                      "Cc" => "thor.odinson@example.com,\"Bruce Banner\" <hulk.smash@example.com>",
+                      "Bcc" => "beast.avengers@example.com,\"Clinton Francis Barton\" <hawk.eye@example.com>",
+                      "ReplyTo" => "iron.stark@example.com",
+                      "TextBody" => "Hello",
+                      "HtmlBody" => "<h1>Hello</h1>"}
 
       assert body_params == conn.body_params
-      assert "/email"    == conn.request_path
-      assert "POST"      == conn.method
+      assert "/email" == conn.request_path
+      assert "POST" == conn.method
 
       Plug.Conn.resp(conn, 200, @success_response)
     end

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -2,6 +2,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
   use AdapterCase, async: true
 
   import Swoosh.Email
+
   alias Swoosh.Adapters.Postmark
 
   @success_response """
@@ -15,9 +16,11 @@ defmodule Swoosh.Adapters.PostmarkTest do
   """
 
   setup_all do
-    bypass = Bypass.open
-    config = [base_url: "http://localhost:#{bypass.port}",
-              api_key: "jarvis"]
+    bypass = Bypass.open()
+    config = [
+      base_url: "http://localhost:#{bypass.port}",
+      api_key:  "jarvis",
+    ]
 
     valid_email =
       new
@@ -31,14 +34,17 @@ defmodule Swoosh.Adapters.PostmarkTest do
 
   test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
-      conn = parse(conn)
-      body_params = %{"Subject" => "Hello, Avengers!",
-                      "To" => "tony.stark@example.com",
-                      "From" => "steve.rogers@example.com",
-                      "HtmlBody" => "<h1>Hello</h1>"}
+      conn        = parse(conn)
+      body_params = %{
+        "Subject"  => "Hello, Avengers!",
+        "To"       => "tony.stark@example.com",
+        "From"     => "steve.rogers@example.com",
+        "HtmlBody" => "<h1>Hello</h1>"
+      }
+
       assert body_params == conn.body_params
-      assert "/email" == conn.request_path
-      assert "POST" == conn.method
+      assert "/email"    == conn.request_path
+      assert "POST"      == conn.method
 
       Plug.Conn.resp(conn, 200, @success_response)
     end
@@ -63,19 +69,21 @@ defmodule Swoosh.Adapters.PostmarkTest do
       |> text_body("Hello")
 
     Bypass.expect bypass, fn conn ->
-      conn = parse(conn)
-      body_params = %{"Subject" => "Hello, Avengers!",
-                      "To" => "\"Steve Rogers\" <steve.rogers@example.com>,wasp.avengers@example.com",
-                      "From" => "tony.stark@example.com",
-                      "Cc" => "thor.odinson@example.com,\"Bruce Banner\" <hulk.smash@example.com>",
-                      "Bcc" => "beast.avengers@example.com,\"Clinton Francis Barton\" <hawk.eye@example.com>",
-                      "ReplyTo" => "iron.stark@example.com",
-                      "TextBody" => "Hello",
-                      "HtmlBody" => "<h1>Hello</h1>"}
+      conn        = parse(conn)
+      body_params = %{
+        "Subject"  => "Hello, Avengers!",
+        "To"       => "\"Steve Rogers\" <steve.rogers@example.com>,wasp.avengers@example.com",
+        "From"     => "tony.stark@example.com",
+        "Cc"       => "thor.odinson@example.com,\"Bruce Banner\" <hulk.smash@example.com>",
+        "Bcc"      => "beast.avengers@example.com,\"Clinton Francis Barton\" <hawk.eye@example.com>",
+        "ReplyTo"  => "iron.stark@example.com",
+        "TextBody" => "Hello",
+        "HtmlBody" => "<h1>Hello</h1>"
+      }
 
       assert body_params == conn.body_params
-      assert "/email" == conn.request_path
-      assert "POST" == conn.method
+      assert "/email"    == conn.request_path
+      assert "POST"      == conn.method
 
       Plug.Conn.resp(conn, 200, @success_response)
     end
@@ -84,19 +92,23 @@ defmodule Swoosh.Adapters.PostmarkTest do
   end
 
   test "delivery/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 422, "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}")
-    end
+    errors = "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}"
 
-    assert Postmark.deliver(email, config) == {:error, {422, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}}
+    Bypass.expect(bypass, &Plug.Conn.resp(&1, 422, errors))
+
+    response = {:error, {422, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}}
+
+    assert Postmark.deliver(email, config) == response
   end
 
   test "deliver/1 with 5xx response", %{bypass: bypass, valid_email: email, config: config} do
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 500, "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}")
-    end
+    errors = "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}"
 
-    assert Postmark.deliver(email, config) == {:error, {500, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}}
+    Bypass.expect(bypass, &Plug.Conn.resp(&1, 500, errors))
+
+    response = {:error, {500, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}}
+
+    assert Postmark.deliver(email, config) == response
   end
 
   test "validate_config/1 with valid config", %{config: config} do
@@ -104,10 +116,12 @@ defmodule Swoosh.Adapters.PostmarkTest do
   end
 
   test "validate_config/1 with invalid config" do
-    assert_raise ArgumentError, """
-    expected [:api_key] to be set, got: []
-    """, fn ->
-      Postmark.validate_config([])
-    end
+    assert_raise(
+      ArgumentError,
+      "expected [:api_key] to be set, got: []\n",
+      fn ->
+        Postmark.validate_config([])
+      end
+    )
   end
 end


### PR DESCRIPTION
[Postmark](https://postmarkapp.com/) allows using [predefined templates](http://developer.postmarkapp.com/developer-api-templates.html) instead of sending `HTML` or `TEXT` body.

To do that, we need to provide 2 things:

- `TemplateId` - which is the ID of template to use when sending an email defined in Postmark account
- `TemplateModel` - which presents the model to be applied to the specified template to generate `HtmlBody`, `TextBody`, and `Subject`

This PR is supposed to give users a possibility to send email using these templates instead of defining custom templates from the code.