### PR TITLE
Respect from name in the postmark adapter

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -66,7 +66,7 @@ defmodule Swoosh.Adapters.Postmark do
     |> prepare_template(email)
   end
 
-  defp prepare_from(body, %Email{from: {_name, address}}), do: Map.put(body, "From", address)
+  defp prepare_from(body, %Email{from: from}), do: Map.put(body, "From", prepare_recipient(from))
 
   defp prepare_to(body, %Email{to: to}), do: Map.put(body, "To", prepare_recipients(to))
 

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -66,7 +66,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
       conn = parse(conn)
       body_params = %{"Subject" => "Hello, Avengers!",
                       "To" => "\"Steve Rogers\" <steve.rogers@example.com>,wasp.avengers@example.com",
-                      "From" => "tony.stark@example.com",
+                      "From" => "\"T Stark\" <tony.stark@example.com>",
                       "Cc" => "thor.odinson@example.com,\"Bruce Banner\" <hulk.smash@example.com>",
                       "Bcc" => "beast.avengers@example.com,\"Clinton Francis Barton\" <hawk.eye@example.com>",
                       "ReplyTo" => "iron.stark@example.com",
@@ -100,7 +100,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
       conn = parse(conn)
       body_params = %{
         "To"            => "avengers@example.com",
-        "From"          => "tony.stark@example.com",
+        "From"          => "\"T Stark\" <tony.stark@example.com>",
         "TemplateId"    => 1,
         "TemplateModel" => %{
           "company" => "Avengers",


### PR DESCRIPTION
For some reason it wasn't respected. The API documents that it should be: 
> The From and To fields are able to accept name, in the format of `John Doe <email@example.com>`

http://developer.postmarkapp.com/developer-send-api.html#message-format