### PR TITLE
Update README.md re: when to include gen_smtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ end
     end
     ```
 
-3. (Optional) If you are using the `Swoosh.Adapters.SMTP`, you also need to add gen_stmp to your deps and list of applications:
+3. (Optional) If you are using `Swoosh.Adapters.SMTP` or `Swoosh.Adapters.Sendmail`, you also need to add gen_stmp to your deps and list of applications:
 
     ```elixir
     def application do


### PR DESCRIPTION
```
==> swoosh
Compiling 22 files (.ex)
warning: function :mimemail.encode/2 is undefined (module :mimemail is not available)
  lib/swoosh/adapters/smtp/helpers.ex:17
```

`:mimemail` is defined in `gen_smtp`

Maybe wrap `SMTP.Helpers` and `Swoosh.Adapters.Sendmail` with `Code.ensure_loaded?` as well?