### PR TITLE
Support SendGrid templates and substitutions

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -64,6 +64,7 @@ defmodule Swoosh.Adapters.Sendgrid do
       |> prepare_cc(email)
       |> prepare_bcc(email)
       |> prepare_custom_vars(email)
+      |> prepare_substitutions(email)
 
     Map.put(body, :personalizations, [personalizations])
   end
@@ -83,6 +84,11 @@ defmodule Swoosh.Adapters.Sendgrid do
     Map.put(personalizations, :custom_args, my_vars)
   end   
   defp prepare_custom_vars(personalizations, _email), do: personalizations
+
+  defp prepare_substitutions(personalizations, %Email{provider_options: %{substitutions: substitutions}}) do
+    Map.put(personalizations, :substitutions, substitutions)
+  end
+  defp prepare_substitutions(personalizations, _email), do: personalizations
 
   defp prepare_subject(body, %Email{subject: subject}), do: Map.put(body, :subject, subject)
 

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -49,6 +49,7 @@ defmodule Swoosh.Adapters.Sendgrid do
     |> prepare_subject(email)
     |> prepare_content(email)
     |> prepare_reply_to(email)
+    |> prepare_template_id(email)
   end
 
   defp email_item({"", email}), do: %{email: email}
@@ -98,4 +99,9 @@ defmodule Swoosh.Adapters.Sendgrid do
 
   defp prepare_reply_to(body, %Email{reply_to: nil}), do: body
   defp prepare_reply_to(body, %Email{reply_to: reply_to}), do: Map.put(body, :reply_to, reply_to |> email_item)
+
+  defp prepare_template_id(body, %Email{provider_options: %{template_id: template_id}}) do
+    Map.put(body, :template_id, template_id)
+  end
+  defp prepare_template_id(body, _email), do: body
 end

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -154,6 +154,34 @@ defmodule Swoosh.Adapters.SendgridTest do
     assert Sendgrid.deliver(email, config) == {:ok, %{}}
   end
 
+  test "delivery/1 with template_id returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> put_provider_option(:template_id, "Welcome")
+
+    Bypass.expect bypass, fn conn ->
+      conn = parse(conn)
+      body_params = %{"from" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
+                      "personalizations" => [%{
+                        "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}]
+                      }],
+                      "content" => [%{"type" => "text/plain", "value" => "Hello"}, %{"type" => "text/html", "value" => "<h1>Hello</h1>"}],
+                      "subject" => "Hello, Avengers!",
+                      "template_id" => "Welcome"
+                    }
+      assert body_params == conn.body_params
+      assert "/mail/send" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+    end
+    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+  end
+
   test "delivery/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       assert "/mail/send" == conn.request_path

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -182,6 +182,34 @@ defmodule Swoosh.Adapters.SendgridTest do
     assert Sendgrid.deliver(email, config) == {:ok, %{}}
   end
 
+  test "delivery/1 with substitutions returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> put_provider_option(:substitutions, %{"-name-" => "Steve Rogers"})
+
+    Bypass.expect bypass, fn conn ->
+      conn = parse(conn)
+      body_params = %{"from" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
+                      "personalizations" => [%{
+                        "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}],
+                        "substitutions" => %{"-name-" => "Steve Rogers"}
+                      }],
+                      "content" => [%{"type" => "text/plain", "value" => "Hello"}, %{"type" => "text/html", "value" => "<h1>Hello</h1>"}],
+                      "subject" => "Hello, Avengers!"
+                    }
+      assert body_params == conn.body_params
+      assert "/mail/send" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+    end
+    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+  end
+
   test "delivery/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       assert "/mail/send" == conn.request_path


### PR DESCRIPTION
Howdy! We use SendGrid's templates at work, so I just needed to support a couple of extra fields through `put_provider_option` to make it work. The template data can be passed in like this:

```
|> put_provider_option(:template_id, "some-guid")
|> put_provider_option(:substitutions, %{"-name-" => "Steve Rogers"})
```