### PR TITLE
Support SendGrid categories

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -50,6 +50,7 @@ defmodule Swoosh.Adapters.Sendgrid do
     |> prepare_content(email)
     |> prepare_reply_to(email)
     |> prepare_template_id(email)
+    |> prepare_categories(email)
   end
 
   defp email_item({"", email}), do: %{email: email}
@@ -77,12 +78,12 @@ defmodule Swoosh.Adapters.Sendgrid do
   defp prepare_bcc(personalizations, %Email{bcc: bcc}), do: Map.put(personalizations, :bcc, bcc |> Enum.map(&email_item(&1)))
 
   # example custom_vars
-  # 
-  # %{"my_var" => %{"my_message_id": 123}, 
+  #
+  # %{"my_var" => %{"my_message_id": 123},
   #   "my_other_var" => %{"my_other_id": 1, "stuff": 2}}
   defp prepare_custom_vars(personalizations, %Email{provider_options: %{custom_args: my_vars}}) do
     Map.put(personalizations, :custom_args, my_vars)
-  end   
+  end
   defp prepare_custom_vars(personalizations, _email), do: personalizations
 
   defp prepare_substitutions(personalizations, %Email{provider_options: %{substitutions: substitutions}}) do
@@ -110,4 +111,9 @@ defmodule Swoosh.Adapters.Sendgrid do
     Map.put(body, :template_id, template_id)
   end
   defp prepare_template_id(body, _email), do: body
+
+  defp prepare_categories(body, %Email{provider_options: %{categories: categories}}) do
+    Map.put(body, :categories, categories)
+  end
+  defp prepare_categories(body, _email), do: body
 end

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -231,4 +231,33 @@ defmodule Swoosh.Adapters.SendgridTest do
       Sendgrid.validate_config([])
     end
   end
+
+  test "delivery/1 with catogories returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> put_provider_option(:categories, ["welcome"])
+
+    Bypass.expect bypass, fn conn ->
+      conn = parse(conn)
+      body_params = %{"from" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
+                      "categories" => ["welcome"],
+                      "personalizations" => [%{
+                        "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}]
+                      }],
+                      "content" => [%{"type" => "text/plain", "value" => "Hello"}, %{"type" => "text/html", "value" => "<h1>Hello</h1>"}],
+                      "subject" => "Hello, Avengers!"
+                    }
+      assert body_params == conn.body_params
+      assert "/mail/send" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+    end
+    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+  end
+
 end


### PR DESCRIPTION
This makes it possible to attach categories: 
`|> put_provider_option(:categories, ["hello", ...])`