### PR TITLE
Full runtime config support

### DIFF
--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -25,9 +25,7 @@ defmodule Swoosh.Mailer do
   Most of the configuration that goes into the config is specific to the adapter,
   so check the adapter's documentation for more information.
 
-  Note that the configuration is set into your mailer at compile time. If you
-  need to reference config at runtime you can use a tuple like
-  `{:system, "ENV_VAR"}`.
+  System environment variables can be specified with `{:system, "ENV_VAR_NAME"}`:
 
       config :sample, Sample.Mailer,
         adapter: Swoosh.Adapters.SMTP,

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -25,6 +25,14 @@ defmodule Swoosh.Mailer do
   Most of the configuration that goes into the config is specific to the adapter,
   so check the adapter's documentation for more information.
 
+  Per module configuration is also supported:
+  
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample,
+          adapter: Swoosh.Adapters.Sendgrid,
+          api_key: "SG.x.x"
+      end
+
   System environment variables can be specified with `{:system, "ENV_VAR_NAME"}`:
 
       config :sample, Sample.Mailer,

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -25,7 +25,7 @@ defmodule Swoosh.Mailer do
   Most of the configuration that goes into the config is specific to the adapter,
   so check the adapter's documentation for more information.
 
-  Per module configuration is also supported:
+  Per module configuration is also supported, it has priority over mix configs:
   
       defmodule Sample.Mailer do
         use Swoosh.Mailer, otp_app: :sample,

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "gen_smtp": {:hex, :gen_smtp, "0.11.0", "d90ff2f021fc86cb2a4259b1f2b177ab6e506676265e26454bf5755855adc956", [], [], "hexpm"},
+  "gen_smtp": {:hex, :gen_smtp, "0.11.0", "d90ff2f021fc86cb2a4259b1f2b177ab6e506676265e26454bf5755855adc956", [:rebar3], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.8.0", "8388a22f4e7eb04d171f2cf0285b217410f266d6c13a4c397a6c22ab823a486c", [:rebar3], [{:certifi, "1.1.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "4.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], [], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/swoosh/mailer_test.exs
+++ b/test/swoosh/mailer_test.exs
@@ -31,16 +31,9 @@ defmodule Swoosh.MailerTest do
     {:ok, valid_email: valid_email}
   end
 
-  test "should raise if no adapter is specified" do
-    assert_raise ArgumentError, fn ->
-      defmodule NoAdapterMailer do
-        use Swoosh.Mailer, otp_app: :swoosh
-      end
-    end
-  end
-
   test "dynamic adapter", %{valid_email: email} do
     defmodule OtherAdapterMailer do
+      # sending with NotExistAdapter would raise
       use Swoosh.Mailer, otp_app: :swoosh, adapter: NotExistAdapter
     end
 
@@ -103,6 +96,16 @@ defmodule Swoosh.MailerTest do
 
     assert_raise ArgumentError, ~r/expected \[:api_key\] to be set/, fn ->
       NoConfigMailer.deliver(email, domain: "jarvis.com")
+    end
+  end
+
+  test "raise when sending without an adapter configured", %{valid_email: email} do
+    defmodule NoAdapterMailer do
+      use Swoosh.Mailer, otp_app: :swoosh
+    end
+
+    assert_raise KeyError, ~r/:adapter not found/, fn ->
+      NoAdapterMailer.deliver(email)
     end
   end
 end


### PR DESCRIPTION
Configs are loaded at runtime.
Module configs are kept, still having higher priority.

Configs now are read in the following order, the later ones take priority:

1. mix configs
```elixir
config :my_app, MyMailer, # the configs
```

2. module configs
```elixir
defmodule MyMailer do
  use Swoosh.Mailer, otp_app: :my_app, # other configs
end
```

3. function configs
```elixir
MyMailer.deliver(email, the_custom_configs)
```

4. system env
All the `{:system, "ENV_VAR"}` are finally loaded

close #84 