### PR TITLE
Quote name portion of recipient for Mailgun

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -116,7 +116,7 @@ defmodule Swoosh.Adapters.Mailgun do
   end
 
   defp prepare_recipient({"", address}), do: address
-  defp prepare_recipient({name, address}), do: "#{name} <#{address}>"
+  defp prepare_recipient({name, address}), do: ~s("#{name}" <#{address}>)
 
   defp prepare_subject(body, %{subject: subject}), do: Map.put(body, :subject, subject)
 

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -96,7 +96,7 @@ defmodule Swoosh.Adapters.Postmark do
   end
 
   defp prepare_recipient({"", address}), do: address
-  defp prepare_recipient({name, address}), do: "\"#{name}\" <#{address}>"
+  defp prepare_recipient({name, address}), do: ~s("#{name}" <#{address}>)
 
   defp prepare_subject(body, %{subject: ""}), do: body
   defp prepare_subject(body, %{subject: subject}), do: Map.put(body, "Subject", subject)

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -64,11 +64,11 @@ defmodule Swoosh.Adapters.MailgunTest do
       conn = parse(conn)
       expected_path = "/" <> config[:domain] <> "/messages"
       body_params = %{"subject" => "Hello, Avengers!",
-                      "to" => "wasp.avengers@example.com,Steve Rogers <steve.rogers@example.com>",
-                      "bcc" => "beast.avengers@example.com,Clinton Francis Barton <hawk.eye@example.com>",
-                      "cc" => "thor.odinson@example.com,Bruce Banner <hulk.smash@example.com>",
+                      "to" => ~s(wasp.avengers@example.com,"Steve Rogers" <steve.rogers@example.com>),
+                      "bcc" => ~s(beast.avengers@example.com,"Clinton Francis Barton" <hawk.eye@example.com>),
+                      "cc" => ~s(thor.odinson@example.com,"Bruce Banner" <hulk.smash@example.com>),
                       "h:Reply-To" => "office.avengers@example.com",
-                      "from" => "T Stark <tony.stark@example.com>",
+                      "from" => ~s("T Stark" <tony.stark@example.com>),
                       "text" => "Hello",
                       "html" => "<h1>Hello</h1>"}
       assert body_params == conn.body_params


### PR DESCRIPTION
If the name portion of a recipient contains a comma, weird things will happen. With multiple recipients, some of them will be chopped off without any warnings or errors.

This changes the formatting from

`Acme Inc, headquarters <hq@acme.com>`

to

`"Acme Inc, headquarters" <hq@acme.com>`

Ref: https://stackoverflow.com/questions/35370571/how-to-add-a-comma-to-a-mailgun-from-field-for-outbound-emails

Ref: http://www.rfc-editor.org/rfc/rfc2822.txt

> Note that the display names for Joe Q. Public and Giant; "Big" Box needed to be enclosed in double-quotes because the former contains the period and the latter contains both semicolon and double-quote characters (the double-quote characters appearing as quoted-pair construct).

This bit me HARD, so I hope you'll consider this PR.

Thanks!