### PR TITLE
Add support for custom email headers across all adapters

### DIFF
--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -54,7 +54,7 @@ defmodule Swoosh.Adapters.Mandrill do
   end
 
   defp prepare_message(email) do
-    %{to: []}
+    %{to: [], headers: %{}}
     |> prepare_from(email)
     |> prepare_to(email)
     |> prepare_subject(email)
@@ -64,6 +64,7 @@ defmodule Swoosh.Adapters.Mandrill do
     |> prepare_bcc(email)
     |> prepare_attachments(email)
     |> prepare_reply_to(email)
+    |> prepare_custom_headers(email)
   end
 
   defp set_api_key(body, config), do: Map.put(body, :key, config[:api_key])
@@ -82,7 +83,8 @@ defmodule Swoosh.Adapters.Mandrill do
 
   defp prepare_reply_to(body, %{reply_to: nil}), do: body
   defp prepare_reply_to(body, %{reply_to: {_name, address}}) do
-    Map.put(body, :headers, %{"Reply-To" => address})
+    put_in(body, [:headers, "Reply-To"], address)
+    #Map.put(body, :headers, %{"Reply-To" => address})
   end
 
   defp prepare_cc(body, %{cc: []}), do: body
@@ -119,4 +121,8 @@ defmodule Swoosh.Adapters.Mandrill do
 
   defp prepare_html(body, %{html_body: nil}), do: body
   defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, :html, html_body)
+
+  defp prepare_custom_headers(body, %{headers: headers}) do
+    %{body | headers: Map.merge(body[:headers], headers)}
+  end
 end

--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -54,7 +54,7 @@ defmodule Swoosh.Adapters.Mandrill do
   end
 
   defp prepare_message(email) do
-    %{to: [], headers: %{}}
+    %{to: []}
     |> prepare_from(email)
     |> prepare_to(email)
     |> prepare_subject(email)
@@ -83,8 +83,7 @@ defmodule Swoosh.Adapters.Mandrill do
 
   defp prepare_reply_to(body, %{reply_to: nil}), do: body
   defp prepare_reply_to(body, %{reply_to: {_name, address}}) do
-    put_in(body, [:headers, "Reply-To"], address)
-    #Map.put(body, :headers, %{"Reply-To" => address})
+    Map.put(body, :headers, %{"Reply-To" => address})
   end
 
   defp prepare_cc(body, %{cc: []}), do: body
@@ -122,7 +121,9 @@ defmodule Swoosh.Adapters.Mandrill do
   defp prepare_html(body, %{html_body: nil}), do: body
   defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, :html, html_body)
 
+  defp prepare_custom_headers(body, %{headers: headers}) when map_size(headers) == 0, do: body
   defp prepare_custom_headers(body, %{headers: headers}) do
-    %{body | headers: Map.merge(body[:headers], headers)}
+    custom_headers =  Map.merge(body[:headers] || %{}, headers)
+    Map.put(body, :headers, custom_headers)
   end
 end

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -66,6 +66,7 @@ defmodule Swoosh.Adapters.Postmark do
     |> prepare_attachments(email)
     |> prepare_reply_to(email)
     |> prepare_template(email)
+    |> prepare_custom_headers(email)
   end
 
   defp prepare_from(body, %{from: from}), do: Map.put(body, "From", render_recipient(from))
@@ -114,4 +115,9 @@ defmodule Swoosh.Adapters.Postmark do
   defp put_in_body({:template_id, val}, body_acc),
     do: Map.put(body_acc, "TemplateId", val)
   defp put_in_body(_, body_acc), do: body_acc
+
+  defp prepare_custom_headers(body, %{headers: headers}) do
+    custom_headers = Enum.map(headers, fn {k, v} -> %{"Name" => k, "Value" => v} end)
+    Map.put(body, "Headers", custom_headers)
+  end
 end

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -116,6 +116,7 @@ defmodule Swoosh.Adapters.Postmark do
     do: Map.put(body_acc, "TemplateId", val)
   defp put_in_body(_, body_acc), do: body_acc
 
+  defp prepare_custom_headers(body, %{headers: headers}) when map_size(headers) == 0, do: body
   defp prepare_custom_headers(body, %{headers: headers}) do
     custom_headers = Enum.map(headers, fn {k, v} -> %{"Name" => k, "Value" => v} end)
     Map.put(body, "Headers", custom_headers)

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -52,6 +52,7 @@ defmodule Swoosh.Adapters.Sendgrid do
     |> prepare_reply_to(email)
     |> prepare_template_id(email)
     |> prepare_categories(email)
+    |> prepare_custom_headers(email)
   end
 
   defp email_item({"", email}), do: %{email: email}
@@ -125,4 +126,8 @@ defmodule Swoosh.Adapters.Sendgrid do
     Map.put(body, :categories, categories)
   end
   defp prepare_categories(body, _email), do: body
+
+  defp prepare_custom_headers(body, %{headers: headers}) do
+    Map.put(body, :headers, headers)
+  end
 end

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -127,6 +127,7 @@ defmodule Swoosh.Adapters.Sendgrid do
   end
   defp prepare_categories(body, _email), do: body
 
+  defp prepare_custom_headers(body, %{headers: headers}) when map_size(headers) == 0, do: body
   defp prepare_custom_headers(body, %{headers: headers}) do
     Map.put(body, :headers, headers)
   end

--- a/lib/swoosh/adapters/sparkpost.ex
+++ b/lib/swoosh/adapters/sparkpost.ex
@@ -74,6 +74,7 @@ defmodule Swoosh.Adapters.SparkPost do
     |> prepare_reply_to(email)
     |> prepare_cc(email)
     |> prepare_bcc(email)
+    |> prepare_custom_headers(email)
   end
 
   defp prepare_reply_to(body, %{reply_to: nil}), do: body
@@ -117,5 +118,10 @@ defmodule Swoosh.Adapters.SparkPost do
     Enum.map(attachments, fn %{content_type: type, path: path, filename: name} ->
       %{type: type, name: name, data: path |> File.read! |> Base.encode64}
     end)
+  end
+
+  defp prepare_custom_headers(body, %{headers: headers}) do
+    custom_headers = Map.merge(body.content.headers, headers)
+    put_in(body, [:content, :headers], custom_headers)
   end
 end


### PR DESCRIPTION
Fixes #153 and adds support across the board.