### PR TITLE
Enforce config values having correct types before passing to gen_smtp

### DIFF
--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -55,9 +55,9 @@ if Code.ensure_loaded?(:gen_smtp_client) do
     @config_transformations %{
       port: &String.to_integer/1,
       retries: &String.to_integer/1,
-      ssl: {&String.to_existing_atom/1, [true, false]},
-      tls: {&String.to_existing_atom/1, [:always, :never, :if_available]},
-      auth: {&String.to_existing_atom/1, [:always, :if_available]}
+      ssl: {&String.to_atom/1, [true, false]},
+      tls: {&String.to_atom/1, [:always, :never, :if_available]},
+      auth: {&String.to_atom/1, [:always, :if_available]}
     }
     @config_keys Map.keys(@config_transformations)
 

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -20,6 +20,7 @@ if Code.ensure_loaded?(:gen_smtp_client) do
           password: "ilovepepperpotts",
           tls: :always,
           auth: :always,
+          port: 1025,
           dkim: [
             s: "default", d: "domain.com",
             private_key: {:pem_plain, File.read!("priv/keys/domain.private")}
@@ -40,10 +41,47 @@ if Code.ensure_loaded?(:gen_smtp_client) do
       sender = Helpers.sender(email)
       recipients = all_recipients(email)
       body = Helpers.body(email, config)
-      case :gen_smtp_client.send_blocking({sender, recipients, body}, config) do
+
+      case :gen_smtp_client.send_blocking(
+        {sender, recipients, body},
+        gen_smtp_config(config)
+      ) do
         receipt when is_binary(receipt) -> {:ok, receipt}
         {:error, type, message} -> {:error, {type, message}}
         {:error, reason} -> {:error, reason}
+      end
+    end
+
+    @config_transformations %{
+      port: &String.to_integer/1,
+      retries: &String.to_integer/1,
+      ssl: {&String.to_existing_atom/1, [true, false]},
+      tls: {&String.to_existing_atom/1, [:always, :never, :if_available]},
+      auth: {&String.to_existing_atom/1, [:always, :if_available]}
+    }
+    @config_keys Map.keys(@config_transformations)
+
+    defp gen_smtp_config(config) do
+      Enum.reduce(config, [], fn {key, value}, config_acc ->
+        [enforce_type!(key, value) | config_acc]
+      end)
+    end
+
+    defp enforce_type!(key, value) when key in @config_keys and is_binary(value) do
+      case Map.get(@config_transformations, key) do
+        {func, valid_values} ->
+          value = func.(value)
+          if value in valid_values do
+            {key, value}
+          else
+            raise ArgumentError, """
+              #{key} is not configured properly,
+              got: #{value}, expected one of the followings:
+              #{valid_values |> Enum.map(&inspect/1) |> Enum.join(", ")}
+            """
+          end
+        func ->
+          {key, func.(value)}
       end
     end
 

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -84,6 +84,7 @@ if Code.ensure_loaded?(:gen_smtp_client) do
           {key, func.(value)}
       end
     end
+    defp enforce_type!(key, value), do: {key, value}
 
     defp all_recipients(email) do
       [email.to, email.cc, email.bcc]

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -61,7 +61,7 @@ if Code.ensure_loaded?(:gen_smtp_client) do
     }
     @config_keys Map.keys(@config_transformations)
 
-    defp gen_smtp_config(config) do
+    def gen_smtp_config(config) do
       Enum.reduce(config, [], fn {key, value}, config_acc ->
         [enforce_type!(key, value) | config_acc]
       end)

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -78,7 +78,7 @@ if Code.ensure_loaded?(:gen_smtp_client) do
               #{key} is not configured properly,
               got: #{value}, expected one of the followings:
               #{valid_values |> Enum.map(&inspect/1) |> Enum.join(", ")}
-            """
+              """
           end
         func ->
           {key, func.(value)}

--- a/test/swoosh/adapters/smtp_test.exs
+++ b/test/swoosh/adapters/smtp_test.exs
@@ -20,4 +20,58 @@ defmodule Swoosh.Adapters.SMTPTest do
       SMTP.validate_config([])
     end
   end
+
+  test "gen_smtp_config/1 enforces config date type" do
+    assert MapSet.new(SMTP.gen_smtp_config([
+      port: "2525",
+      retries: "3",
+      ssl: "true",
+      tls: "always",
+      auth: "if_available",
+    ])) == MapSet.new([
+      port: 2525,
+      retries: 3,
+      ssl: true,
+      tls: :always,
+      auth: :if_available,
+    ])
+  end
+
+  import Swoosh.Email
+
+  @email new()
+    |> from("test@test.com")
+    |> to("test@test.com")
+    |> subject("test")
+    |> text_body("test")
+
+  test "gen_smtp_config/1 with invalid ssl config" do
+    assert_raise ArgumentError, """
+    ssl is not configured properly,
+    got: INVALID, expected one of the followings:
+    true, false
+    """, fn ->
+      SMTP.deliver(@email, [ssl: "INVALID"])
+    end
+  end
+
+  test "gen_smtp_config/1 with invalid auth config" do
+    assert_raise ArgumentError, """
+    auth is not configured properly,
+    got: INVALID, expected one of the followings:
+    :always, :if_available
+    """, fn ->
+      SMTP.deliver(@email, [auth: "INVALID"])
+    end
+  end
+
+  test "gen_smtp_config/1 with invalid tls config" do
+    assert_raise ArgumentError, """
+    tls is not configured properly,
+    got: INVALID, expected one of the followings:
+    :always, :never, :if_available
+    """, fn ->
+      SMTP.deliver(@email, [tls: "INVALID"])
+    end
+  end
 end


### PR DESCRIPTION
Fixes #161 