### PR TITLE
Amazon SES Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ end
     end
     ```
 
-3. (Optional) If you are using `Swoosh.Adapters.SMTP` or `Swoosh.Adapters.Sendmail`, you also need to add gen_stmp to your deps and list of applications:
+3. (Optional) If you are using `Swoosh.Adapters.SMTP`, `Swoosh.Adapters.Sendmail` or `Swoosh.Adapters.AmazonSES`, you also need to add gen_stmp to your deps and list of applications:
 
     ```elixir
     # You only need to do this if you are using Elixir < 1.4
@@ -99,6 +99,7 @@ Mandrill   | Swoosh.Adapters.Mandrill
 Mailgun    | Swoosh.Adapters.Mailgun
 Postmark   | Swoosh.Adapters.Postmark
 SparkPost  | Swoosh.Adapters.SparkPost
+Amazon SES | Swoosh.Adapters.AmazonSES
 
 Configure which adapter you want to use by updating your `config/config.exs` file:
 

--- a/lib/swoosh/adapters/amazon_ses.ex
+++ b/lib/swoosh/adapters/amazon_ses.ex
@@ -1,0 +1,257 @@
+defmodule Swoosh.Adapters.AmazonSes do
+  @moduledoc ~S"""
+  An adapter that sends email using the Amazon Simple Email Service Query API.
+
+  For reference: [Amazone SES Query Api Docs](http://docs.aws.amazon.com/ses/latest/APIReference/Welcome.html)
+
+  ## Example
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.AmazonSes,
+        region: 'region-endpoint',
+        access_key: 'aws-access-key',
+        secret: 'aws-secret-key'
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample
+      end
+  """
+
+  use Swoosh.Adapter, required_config: [:region, :access_key, :secret]
+  alias Swoosh.Email
+  alias Swoosh.Adapters.XML.Helpers, as: XmlHelper
+  alias Swoosh.Adapters.SMTP.Helpers, as: SMTPHelper
+
+  @encoding     "AWS4-HMAC-SHA256"
+  @host_prefix  "email."
+  @host_suffix  ".amazonaws.com"
+  @service_name "ses"
+  @action       "SendRawEmail"
+  @base_headers %{"Content-Type" => "application/x-www-form-urlencoded"}
+  @version      "2010-12-01"
+
+  def deliver(%Email{} = email, config \\ []) do
+    body = email |> prepare_body(config) |> encode_body
+    url = base_url(config)
+    headers = prepare_headers(@base_headers, body, config)
+
+    case :hackney.post(url, headers, body, [:with_body]) do
+      {:ok, 200, _headers, body} -> {:ok, interpret_response(body)}
+      {:ok, code, _headers, body} when code > 399 ->
+        {:error, interpret_error_response(body)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp interpret_response(body) do
+    id =
+      body
+      |> XmlHelper.parse
+      |> XmlHelper.first("//MessageId")
+      |> XmlHelper.text
+
+    %{id: id}
+  end
+
+  defp interpret_error_response(body) do
+    IO.inspect body
+    node =
+      body
+      |> XmlHelper.parse
+
+    code =
+      node
+      |> XmlHelper.first("//Error/Code")
+      |> XmlHelper.text
+
+    message =
+      node
+      |> XmlHelper.first("//Error/Message")
+      |> XmlHelper.text
+
+    %{code: code, message: message}
+  end
+
+  defp base_url(config) do
+    case config[:host] do
+      nil -> "https://" <> @host_prefix <> config[:region] <> @host_suffix
+      _ -> config[:host]
+    end
+  end
+
+  defp version(config) do
+    case config[:version] do
+      nil -> @version
+      _ -> config[:version]
+    end
+  end
+
+  defp prepare_body(email, config) do
+    raw_body =
+      SMTPHelper.body(email, config)
+      |> Base.encode64
+      |> URI.encode_www_form
+
+    %{}
+    |> Map.put("Action", @action)
+    |> Map.put("Version", version(config))
+    |> Map.put("RawMessage.Data", raw_body)
+    # |> prepare_source(from)
+    # |> prepare_recipients(to)
+    # |> prepare_recipients(cc, "CcAddresses")
+    # |> prepare_recipients(bcc, "BccAddresses")
+    # |> prepare_reply_to(email)
+    # |> prepare_subject(email)
+    # |> prepare_content(email)
+  end
+
+  defp prepare_content(body, email) do
+    body
+    |> prepare_html(email)
+    |> prepare_text(email)
+  end
+
+  defp prepare_content(body, _), do: body
+
+  defp prepare_source(body, {"", from_email}), do: Map.put(body, "Source", from_email)
+  defp prepare_source(body, {from_name, from_email}) do
+    Map.put(body, "Source", "\"#{from_name}\" <#{from_email}>")
+  end
+
+  defp prepare_recipients(body, emails, type \\ "ToAddresses", count \\ 1)
+  defp prepare_recipients(body, [{name, address} | tail], type, count) when name == "" or name == nil do
+    Map.put(body, "Destination.#{type}.member.#{count}", address)
+    |> prepare_recipients(tail, type, count + 1)
+  end
+
+  defp prepare_recipients(body, [{name, address} | tail], type, count) do
+    Map.put(body, "Destination.#{type}.member.#{count}", "\"#{name}\" <#{address}>")
+    |> prepare_recipients(tail, type, count + 1)
+  end
+
+  defp prepare_reply_to(body, %{reply_to: nil}), do: body
+  defp prepare_reply_to(body, %{reply_to: reply_to}), do: prepare_reply_to(body, reply_to)
+  defp prepare_reply_to(body, [{_name, address} | tail], count \\ 0) do
+    body
+    |> Map.put("ReplyToAddresses.member.#{count}", address)
+    |> prepare_reply_to(tail, count)
+  end
+  defp prepare_reply_to(body, [], _), do: body
+
+  defp prepare_recipients(body, [], _, _), do: body
+
+  defp encode_body(body) do
+    Map.keys(body)
+    |> Enum.sort
+    |> Enum.map(fn(key) -> "#{key}=#{body[key]}" end)
+    |> Enum.join("&")
+    |> URI.encode
+  end
+
+  defp prepare_headers(headers, body, config) do
+    signed_header_list = "content-type;host;x-amz-date"
+    current_date_time = DateTime.utc_now()
+
+    headers =
+      headers
+      |> prepare_header_host(config)
+      |> prepare_header_date(config, current_date_time)
+
+    headers_string = setup_headers_string(headers)
+    signature =
+      determine_request_hash(body, headers_string, signed_header_list)
+      |> generate_signing_string(config, current_date_time)
+      |> generate_signature(current_date_time, signed_header_list, config[:region], config[:access_key], config[:secret])
+
+    prepare_authorization(headers, config, signed_header_list, current_date_time, signature)
+    |> Enum.map(fn {k, v} -> {k, v} end)
+  end
+
+  defp setup_headers_string(headers) do
+    Map.keys(headers)
+    |> Enum.sort
+    |> Enum.map(fn(key) -> "#{String.downcase(key)}:#{headers[key]}" end)
+    |> Enum.join("\n")
+  end
+
+  defp determine_request_hash(query, headers, signed_header_list) do
+    canonical_request =
+      [
+        "POST",
+        "/",
+        "",
+        "#{headers}",
+        "",
+        signed_header_list,
+        :crypto.hash(:sha256, query) |> Base.encode16 |> String.downcase
+      ]
+      |> Enum.join("\n")
+
+    :crypto.hash(:sha256, canonical_request) |> Base.encode16 |> String.downcase
+  end
+
+  defp prepare_header_host(headers, config) do
+    Map.put(headers, "Host", @host_prefix <> config[:region] <> @host_suffix)
+  end
+
+  defp prepare_authorization(headers, config, signed_header_list, date_time, signature) do
+    date = extract_date_string(date_time)
+    credential = "#{config[:access_key]}/#{date}/#{config[:region]}/#{@service_name}/aws4_request"
+    authorization = "#{@encoding} Credential=#{credential}, SignedHeaders=#{signed_header_list}, Signature=#{signature}"
+    Map.put(headers, "Authorization", authorization)
+  end
+
+  defp generate_signature(string_to_sign, date_time, signed_header_list, region, access_key, secret) do
+    encrypt_value("AWS4" <> secret, extract_date_string(date_time))
+    |> encrypt_value(region)
+    |> encrypt_value(@service_name)
+    |> encrypt_value("aws4_request")
+    |> encrypt_value(string_to_sign)
+    |> Base.encode16
+    |> String.downcase
+  end
+
+  defp encrypt_value(secret, unencrypted_data), do: :crypto.hmac(:sha256, secret, unencrypted_data)
+
+  defp extract_date_string(dt), do: "#{dt.year}#{dt.month}#{dt.day}"
+
+  defp generate_signing_string(request_hash, config, dt) do
+    date = extract_date_string(dt)
+    normalized_date_time = normalize_iso8601(dt)
+
+    [
+      @encoding,
+      "#{normalized_date_time}",
+      "#{date}/#{config[:region]}/#{@service_name}/aws4_request",
+      request_hash
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp normalize_iso8601(dt) do
+    date = extract_date_string(dt)
+    {_, time} = Time.new(dt.hour, dt.minute, dt.second)
+    time_string = Time.to_string(time) |> String.replace(":", "")
+    "#{date}T#{time_string}Z"
+  end
+
+  defp prepare_header_date(headers, config, date_time) do
+    Map.put(headers, "X-Amz-Date", normalize_iso8601(date_time))
+  end
+
+  defp prepare_subject(body, %{subject: subject}), do: Map.put(body, "Message.Subject.Data", subject)
+
+  defp prepare_text(body, %{text_body: nil}), do: body
+  defp prepare_text(body, %{text_body: text_body}), do: Map.put(body, "Message.Body.Text.Data", text_body)
+
+  defp prepare_html(body, %{html_body: nil}), do: body
+  defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, "Message.Body.Html.Data", html_body)
+
+  defp prepare_custom_headers(body, %{headers: headers}) when map_size(headers) == 0, do: body
+  defp prepare_custom_headers(body, %{headers: headers}) do
+    custom_headers =  Map.merge(body[:headers] || %{}, headers)
+    Map.put(body, :headers, custom_headers)
+  end
+end

--- a/lib/swoosh/adapters/amazon_ses.ex
+++ b/lib/swoosh/adapters/amazon_ses.ex
@@ -2,7 +2,29 @@ defmodule Swoosh.Adapters.AmazonSES do
   @moduledoc ~S"""
   An adapter that sends email using the Amazon Simple Email Service Query API.
 
-  For reference: [Amazone SES Query Api Docs](http://docs.aws.amazon.com/ses/latest/APIReference/Welcome.html)
+  This email adapter makes use of the Amazon SES SendRawEmail action and generates
+  a SMTP style message containing the information to be emailed. This allows for
+  greater more customizable email message and ensures the capability to add
+  attachments. As a result, however, the `gen_smtp` dependency is required in order
+  to correctly generate the SMTP message that will be sent.
+
+  Ensure sure you have the dependency added in your mix.exs file
+
+    # You only need to do this if you are using Elixir < 1.4
+    def application do
+      [applications: [:swoosh, :gen_smtp]]
+    end
+
+    def deps do
+      [{:swoosh, "~> 0.10.0"},
+       {:gen_smtp, "~> 0.12.0"}]
+    end
+
+  See Also:
+
+  [Amazon SES Query Api Docs](http://docs.aws.amazon.com/ses/latest/APIReference/Welcome.html)
+
+  [Amazon SES SendRawEmail Documentation](http://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html)
 
   ## Example
 

--- a/lib/swoosh/adapters/amazon_ses.ex
+++ b/lib/swoosh/adapters/amazon_ses.ex
@@ -1,4 +1,4 @@
-defmodule Swoosh.Adapters.AmazonSes do
+defmodule Swoosh.Adapters.AmazonSES do
   @moduledoc ~S"""
   An adapter that sends email using the Amazon Simple Email Service Query API.
 
@@ -8,10 +8,10 @@ defmodule Swoosh.Adapters.AmazonSes do
 
       # config/config.exs
       config :sample, Sample.Mailer,
-        adapter: Swoosh.Adapters.AmazonSes,
-        region: 'region-endpoint',
-        access_key: 'aws-access-key',
-        secret: 'aws-secret-key'
+        adapter: Swoosh.Adapters.AmazonSES,
+        region: "region-endpoint",
+        access_key: "aws-access-key",
+        secret: "aws-secret-key"
 
       # lib/sample/mailer.ex
       defmodule Sample.Mailer do
@@ -21,7 +21,7 @@ defmodule Swoosh.Adapters.AmazonSes do
 
   use Swoosh.Adapter, required_config: [:region, :access_key, :secret]
   alias Swoosh.Email
-  alias Swoosh.Adapters.XML.Helpers, as: XmlHelper
+  alias Swoosh.Adapters.XML.Helpers, as: XMLHelper
   alias Swoosh.Adapters.SMTP.Helpers, as: SMTPHelper
 
   @encoding     "AWS4-HMAC-SHA256"
@@ -33,43 +33,33 @@ defmodule Swoosh.Adapters.AmazonSes do
   @version      "2010-12-01"
 
   def deliver(%Email{} = email, config \\ []) do
-    body = email |> prepare_body(config) |> encode_body
+    query = email |> prepare_body(config) |> encode_body
     url = base_url(config)
-    headers = prepare_headers(@base_headers, body, config)
+    headers = prepare_headers(@base_headers, query, config)
 
-    case :hackney.post(url, headers, body, [:with_body]) do
-      {:ok, 200, _headers, body} -> {:ok, interpret_response(body)}
+    case :hackney.post(url, headers, query, [:with_body]) do
+      {:ok, 200, _headers, body} ->
+        {:ok, parse_response(body)}
       {:ok, code, _headers, body} when code > 399 ->
-        {:error, interpret_error_response(body)}
-      {:error, reason} -> {:error, reason}
+        {:error, parse_error_response(body)}
+      {_, reason} ->
+        {:error, reason}
     end
   end
 
-  defp interpret_response(body) do
-    id =
-      body
-      |> XmlHelper.parse
-      |> XmlHelper.first("//MessageId")
-      |> XmlHelper.text
+  defp parse_response(body) do
+    node = XMLHelper.parse(body)
+    message_id = XMLHelper.first_text(node, "//MessageId")
+    request_id = XMLHelper.first_text(node, "//RequestId")
 
-    %{id: id}
+    %{id: message_id, request_id: request_id}
   end
 
-  defp interpret_error_response(body) do
-    IO.inspect body
-    node =
-      body
-      |> XmlHelper.parse
+  defp parse_error_response(body) do
+    node = XMLHelper.parse(body)
 
-    code =
-      node
-      |> XmlHelper.first("//Error/Code")
-      |> XmlHelper.text
-
-    message =
-      node
-      |> XmlHelper.first("//Error/Message")
-      |> XmlHelper.text
+    code = XMLHelper.first_text(node, "//Error/Code")
+    message = XMLHelper.first_text(node, "//Message")
 
     %{code: code, message: message}
   end
@@ -81,102 +71,64 @@ defmodule Swoosh.Adapters.AmazonSes do
     end
   end
 
-  defp version(config) do
-    case config[:version] do
-      nil -> @version
-      _ -> config[:version]
-    end
-  end
-
   defp prepare_body(email, config) do
-    raw_body =
-      SMTPHelper.body(email, config)
-      |> Base.encode64
-      |> URI.encode_www_form
-
     %{}
     |> Map.put("Action", @action)
-    |> Map.put("Version", version(config))
-    |> Map.put("RawMessage.Data", raw_body)
-    # |> prepare_source(from)
-    # |> prepare_recipients(to)
-    # |> prepare_recipients(cc, "CcAddresses")
-    # |> prepare_recipients(bcc, "BccAddresses")
-    # |> prepare_reply_to(email)
-    # |> prepare_subject(email)
-    # |> prepare_content(email)
+    |> Map.put("Version", Keyword.get(config, :version, @version))
+    |> Map.put("RawMessage.Data", generate_raw_message_data(email, config))
   end
-
-  defp prepare_content(body, email) do
-    body
-    |> prepare_html(email)
-    |> prepare_text(email)
-  end
-
-  defp prepare_content(body, _), do: body
-
-  defp prepare_source(body, {"", from_email}), do: Map.put(body, "Source", from_email)
-  defp prepare_source(body, {from_name, from_email}) do
-    Map.put(body, "Source", "\"#{from_name}\" <#{from_email}>")
-  end
-
-  defp prepare_recipients(body, emails, type \\ "ToAddresses", count \\ 1)
-  defp prepare_recipients(body, [{name, address} | tail], type, count) when name == "" or name == nil do
-    Map.put(body, "Destination.#{type}.member.#{count}", address)
-    |> prepare_recipients(tail, type, count + 1)
-  end
-
-  defp prepare_recipients(body, [{name, address} | tail], type, count) do
-    Map.put(body, "Destination.#{type}.member.#{count}", "\"#{name}\" <#{address}>")
-    |> prepare_recipients(tail, type, count + 1)
-  end
-
-  defp prepare_reply_to(body, %{reply_to: nil}), do: body
-  defp prepare_reply_to(body, %{reply_to: reply_to}), do: prepare_reply_to(body, reply_to)
-  defp prepare_reply_to(body, [{_name, address} | tail], count \\ 0) do
-    body
-    |> Map.put("ReplyToAddresses.member.#{count}", address)
-    |> prepare_reply_to(tail, count)
-  end
-  defp prepare_reply_to(body, [], _), do: body
-
-  defp prepare_recipients(body, [], _, _), do: body
 
   defp encode_body(body) do
-    Map.keys(body)
-    |> Enum.sort
-    |> Enum.map(fn(key) -> "#{key}=#{body[key]}" end)
-    |> Enum.join("&")
+    body |> Enum.sort |> URI.encode_query
+  end
+
+  defp generate_raw_message_data(email, config) do
+    email
+    |> SMTPHelper.body(config)
+    |> Base.encode64
     |> URI.encode
   end
 
-  defp prepare_headers(headers, body, config) do
-    signed_header_list = "content-type;host;x-amz-date"
+  defp prepare_headers(headers, query, config) do
     current_date_time = DateTime.utc_now()
 
-    headers =
-      headers
-      |> prepare_header_host(config)
-      |> prepare_header_date(config, current_date_time)
+    headers
+    |> prepare_header_host(config)
+    |> prepare_header_date(current_date_time)
+    |> prepare_header_length(query)
+    |> prepare_header_authorization(query, current_date_time, config)
+    |> Map.to_list
+  end
 
+  defp prepare_header_authorization(headers, query, current_date_time, config) do
+    signed_header_list = generate_signed_header_list(headers)
     headers_string = setup_headers_string(headers)
-    signature =
-      determine_request_hash(body, headers_string, signed_header_list)
-      |> generate_signing_string(config, current_date_time)
-      |> generate_signature(current_date_time, signed_header_list, config[:region], config[:access_key], config[:secret])
 
-    prepare_authorization(headers, config, signed_header_list, current_date_time, signature)
-    |> Enum.map(fn {k, v} -> {k, v} end)
+    signature =
+      query
+      |> determine_request_hash(headers_string, signed_header_list)
+      |> generate_signing_string(config, current_date_time)
+      |> generate_signature(current_date_time, config[:region], config[:secret])
+
+    authorization = prepare_authorization(config, signed_header_list, current_date_time, signature)
+    Map.put(headers, "Authorization", authorization)
   end
 
   defp setup_headers_string(headers) do
-    Map.keys(headers)
+    headers
     |> Enum.sort
-    |> Enum.map(fn(key) -> "#{String.downcase(key)}:#{headers[key]}" end)
-    |> Enum.join("\n")
+    |> Enum.map_join("\n", fn {k, v} -> "#{String.downcase(k)}:#{v}" end)
+  end
+
+  defp generate_signed_header_list(headers) do
+    headers
+    |> Map.keys
+    |> Enum.map_join(";", &String.downcase/1)
   end
 
   defp determine_request_hash(query, headers, signed_header_list) do
+    hashed_query = :crypto.hash(:sha256, query) |> Base.encode16(case: :lower)
+
     canonical_request =
       [
         "POST",
@@ -185,41 +137,44 @@ defmodule Swoosh.Adapters.AmazonSes do
         "#{headers}",
         "",
         signed_header_list,
-        :crypto.hash(:sha256, query) |> Base.encode16 |> String.downcase
+        hashed_query
       ]
       |> Enum.join("\n")
 
-    :crypto.hash(:sha256, canonical_request) |> Base.encode16 |> String.downcase
+    :crypto.hash(:sha256, canonical_request) |> Base.encode16(case: :lower)
   end
 
   defp prepare_header_host(headers, config) do
     Map.put(headers, "Host", @host_prefix <> config[:region] <> @host_suffix)
   end
 
-  defp prepare_authorization(headers, config, signed_header_list, date_time, signature) do
-    date = extract_date_string(date_time)
-    credential = "#{config[:access_key]}/#{date}/#{config[:region]}/#{@service_name}/aws4_request"
-    authorization = "#{@encoding} Credential=#{credential}, SignedHeaders=#{signed_header_list}, Signature=#{signature}"
-    Map.put(headers, "Authorization", authorization)
+  defp prepare_header_date(headers, date_time) do
+    Map.put(headers, "X-Amz-Date", amz_datetime(date_time))
   end
 
-  defp generate_signature(string_to_sign, date_time, signed_header_list, region, access_key, secret) do
-    encrypt_value("AWS4" <> secret, extract_date_string(date_time))
+  defp prepare_header_length(headers, query) do
+    Map.put(headers, "Content-Length", String.length(query))
+  end
+
+  defp prepare_authorization(config, signed_header_list, date_time, signature) do
+    date = amz_date(date_time)
+    credential = "#{config[:access_key]}/#{date}/#{config[:region]}/#{@service_name}/aws4_request"
+    "#{@encoding} Credential=#{credential}, SignedHeaders=#{signed_header_list}, Signature=#{signature}"
+  end
+
+  defp generate_signature(string_to_sign, date_time, region, secret) do
+    "AWS4" <> secret
+    |> encrypt_value(amz_date(date_time))
     |> encrypt_value(region)
     |> encrypt_value(@service_name)
     |> encrypt_value("aws4_request")
     |> encrypt_value(string_to_sign)
-    |> Base.encode16
-    |> String.downcase
+    |> Base.encode16(case: :lower)
   end
 
-  defp encrypt_value(secret, unencrypted_data), do: :crypto.hmac(:sha256, secret, unencrypted_data)
-
-  defp extract_date_string(dt), do: "#{dt.year}#{dt.month}#{dt.day}"
-
   defp generate_signing_string(request_hash, config, dt) do
-    date = extract_date_string(dt)
-    normalized_date_time = normalize_iso8601(dt)
+    date = amz_date(dt)
+    normalized_date_time = amz_datetime(dt)
 
     [
       @encoding,
@@ -230,28 +185,15 @@ defmodule Swoosh.Adapters.AmazonSes do
     |> Enum.join("\n")
   end
 
-  defp normalize_iso8601(dt) do
-    date = extract_date_string(dt)
-    {_, time} = Time.new(dt.hour, dt.minute, dt.second)
-    time_string = Time.to_string(time) |> String.replace(":", "")
-    "#{date}T#{time_string}Z"
-  end
+  defp encrypt_value(secret, unencrypted_data), do: :crypto.hmac(:sha256, secret, unencrypted_data)
 
-  defp prepare_header_date(headers, config, date_time) do
-    Map.put(headers, "X-Amz-Date", normalize_iso8601(date_time))
-  end
+  defp amz_date(dt), do: "#{dt.year}#{dt.month}#{dt.day}"
+  defp amz_datetime(dt) do
+    time_string = Enum.map_join(
+      [dt.hour, dt.minute, dt.second],
+      &String.pad_leading(to_string(&1), 2, "0")
+    )
 
-  defp prepare_subject(body, %{subject: subject}), do: Map.put(body, "Message.Subject.Data", subject)
-
-  defp prepare_text(body, %{text_body: nil}), do: body
-  defp prepare_text(body, %{text_body: text_body}), do: Map.put(body, "Message.Body.Text.Data", text_body)
-
-  defp prepare_html(body, %{html_body: nil}), do: body
-  defp prepare_html(body, %{html_body: html_body}), do: Map.put(body, "Message.Body.Html.Data", html_body)
-
-  defp prepare_custom_headers(body, %{headers: headers}) when map_size(headers) == 0, do: body
-  defp prepare_custom_headers(body, %{headers: headers}) do
-    custom_headers =  Map.merge(body[:headers] || %{}, headers)
-    Map.put(body, :headers, custom_headers)
+    "#{amz_date(dt)}T#{time_string}Z"
   end
 end

--- a/lib/swoosh/adapters/xml/helpers.ex
+++ b/lib/swoosh/adapters/xml/helpers.ex
@@ -1,26 +1,41 @@
 defmodule Swoosh.Adapters.XML.Helpers do
+  @moduledoc false
   require Record
 
   Record.defrecord :xmlText, Record.extract(:xmlText, from_lib: "xmerl/include/xmerl.hrl")
 
-  def parse(xml_string, options \\ [quiet: true]) do
+  @doc false
+  def parse(xml_string, options \\ []) do
     {node, _} =
       xml_string
       |> :binary.bin_to_list
-      |> :xmerl_scan.string(options)
+      |> :xmerl_scan.string(Keyword.merge([quiet: true], options))
 
     node
   end
 
-  def first(node, path) do
-    :xmerl_xpath.string(to_char_list(path), node)
-    |> extract_first
+  @doc """
+    returns the text value of the first found node
+  """
+  def first_text(node, path) do
+    node
+    |> first(path)
+    |> text
   end
 
-  defp extract_first([head | _]), do: head
+  @doc false
+  def first(node, path) do
+    path
+    |> to_char_list
+    |> :xmerl_xpath.string(node)
+    |> List.first
+  end
 
+  @doc false
   def text(node) do
-    :xmerl_xpath.string(to_char_list("./text()"), node)
+    "./text()"
+    |> to_char_list
+    |> :xmerl_xpath.string(node)
     |> extract_text
   end
 

--- a/lib/swoosh/adapters/xml/helpers.ex
+++ b/lib/swoosh/adapters/xml/helpers.ex
@@ -1,0 +1,29 @@
+defmodule Swoosh.Adapters.XML.Helpers do
+  require Record
+
+  Record.defrecord :xmlText, Record.extract(:xmlText, from_lib: "xmerl/include/xmerl.hrl")
+
+  def parse(xml_string, options \\ [quiet: true]) do
+    {node, _} =
+      xml_string
+      |> :binary.bin_to_list
+      |> :xmerl_scan.string(options)
+
+    node
+  end
+
+  def first(node, path) do
+    :xmerl_xpath.string(to_char_list(path), node)
+    |> extract_first
+  end
+
+  defp extract_first([head | _]), do: head
+
+  def text(node) do
+    :xmerl_xpath.string(to_char_list("./text()"), node)
+    |> extract_text
+  end
+
+  defp extract_text([xmlText(value: value)]), do: List.to_string(value)
+  defp extract_text(_), do: ""
+end

--- a/test/swoosh/adapters/amazonses_test.exs
+++ b/test/swoosh/adapters/amazonses_test.exs
@@ -18,9 +18,10 @@ defmodule Swoosh.Adapters.AmazonSesTest do
   setup do
     bypass = Bypass.open
     config = [
-      region: "http://localhost:#{bypass.port}",
-      access_key: "fake_username",
-      secret: "fake_password"
+      host: "http://localhost:#{bypass.port}",
+      region: "us-east-1",
+      access_key: "AKIAJNAKMOVOTLN2XJWA",
+      secret: "1QQZ6mgRS2iOWUbOQkowfgZwB+9hVSZZDEKUFi8Y"
     ]
 
     valid_email =
@@ -37,14 +38,14 @@ defmodule Swoosh.Adapters.AmazonSesTest do
   test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
-      expected_path = "/" <> config[:domain] <> "/messages"
+      expected_path = "/"
       body_params = %{
         "Action" => "SendEmail",
         "Destination.ToAddresses.member.1" => "murry@lechucksship.gov",
-        "Source" => "guybrush.threepwood@pirates.grog",
         "Message.Body.Text.Data" => "Hello",
         "Message.Body.Html.Data" => "<h1>Hello</h1>",
-        "Message.Subject.Data" => "Mighty Pirate Newsletter"
+        "Message.Subject.Data" => "Mighty Pirate Newsletter",
+        "Source" => "guybrush.threepwood@pirates.grog",
       }
       assert body_params == conn.body_params
       assert expected_path == conn.request_path
@@ -72,17 +73,18 @@ defmodule Swoosh.Adapters.AmazonSesTest do
 
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
-      expected_path = "/" <> config[:domain] <> "/messages"
+      expected_path = "/"
       body_params = %{
         "Action" => "SendEmail",
-        "Destination.ToAddresses.member.1" => ~s("Murry The Skull" <murry@lechucksship.gov>),
-        "Destination.ToAddresses.member.2" => "elaine.marley@triisland.gov",
-        "Destination.CcAddresses.member.1" => ~s("Cannibals" <canni723@monkeyisland.com>),
-        "Destination.CcAddresses.member.2" => "carla@sworddojo.org",
-        "Destination.BccAddresses.member.1" => ~s("LeChuck" <lechuck@underworld.com>),
-        "Destination.BccAddresses.member.2" => "stan@coolshirt.com",
-        "Message.Body.Text.Data" => "Hello",
+        "Destination.BccAddresses.member.1" => "stan@coolshirt.com",
+        "Destination.BccAddresses.member.2" => ~s("LeChuck" <lechuck@underworld.com>),
+        "Destination.CcAddresses.member.1" => "carla@sworddojo.org",
+        "Destination.CcAddresses.member.2" => ~s("Cannibals" <canni723@monkeyisland.com>),
+        "Destination.ToAddresses.member.1" => "elaine.marley@triisland.gov",
+        "Destination.ToAddresses.member.2" => ~s("Murry The Skull" <murry@lechucksship.gov>),
         "Message.Body.Html.Data" => "<h1>Hello</h1>",
+        "Message.Body.Text.Data" => "Hello",
+        "Source" => ~s("G Threepwood" <guybrush.threepwood@pirates.grog>),
         "Message.Subject.Data" => "Mighty Pirate Newsletter"
       }
 
@@ -177,7 +179,7 @@ defmodule Swoosh.Adapters.AmazonSesTest do
 
   test "validate_config/1 with invalid config" do
     assert_raise ArgumentError, """
-    expected [:base_url, :access_key, :secret] to be set, got: []
+    expected [:secret, :access_key, :region] to be set, got: []
     """, fn ->
       AmazonSes.validate_config([])
     end

--- a/test/swoosh/adapters/amazonses_test.exs
+++ b/test/swoosh/adapters/amazonses_test.exs
@@ -1,0 +1,170 @@
+defmodule Swoosh.Adapters.AmazonSesTest do
+  use AdapterCase, async: true
+
+  import Swoosh.Email
+  alias Swoosh.Adapters.AmazonSes
+
+  # @success_response """
+  #   {
+  #     "message": "Queued. Thank you.",
+  #     "id": "<20111114174239.25659.5817@samples.AmazonSes.org>"
+  #   }
+  # """
+
+  # setup do
+  #   bypass = Bypass.open
+  #   config = [base_url: "http://localhost:#{bypass.port}",
+  #             smtp_username: "fake_username",
+  #             smtp_password: "fake_password"]
+
+  #   valid_email =
+  #     new()
+  #     |> from("guybrush.threepwood@pirates.grog")
+  #     |> to("murry@lechucksship.gov")
+  #     |> subject("Mighty Pirate Newsletter")
+  #     |> html_body("<h1>Hello</h1>")
+
+  #   {:ok, bypass: bypass, valid_email: valid_email, config: config}
+  # end
+
+  # test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
+  #   Bypass.expect bypass, fn conn ->
+  #     conn = parse(conn)
+  #     expected_path = "/" <> config[:domain] <> "/messages"
+  #     body_params = %{"subject" => "Mighty Pirate Newsletter",
+  #                     "to" => "murry@lechucksship.gov",
+  #                     "from" => "guybrush.threepwood@pirates.grog",
+  #                     "html" => "<h1>Hello</h1>"}
+  #     assert body_params == conn.body_params
+  #     assert expected_path == conn.request_path
+  #     assert "POST" == conn.method
+
+  #     Plug.Conn.resp(conn, 200, @success_response)
+  #   end
+
+  #   assert AmazonSes.deliver(email, config) == {:ok, %{id: "<20111114174239.25659.5817@samples.AmazonSes.org>"}}
+  # end
+
+  # test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
+  #   email =
+  #     new()
+  #     |> from({"G Threepwood", "guybrush.threepwood@pirates.grog"})
+  #     |> to({"Murry The Skull", "murry@lechucksship.gov"})
+  #     |> to("wasp.avengers@example.com")
+  #     |> reply_to("office.avengers@example.com")
+  #     |> cc({"Bruce Banner", "hulk.smash@example.com"})
+  #     |> cc("thor.odinson@example.com")
+  #     |> bcc({"Clinton Francis Barton", "hawk.eye@example.com"})
+  #     |> bcc("beast.avengers@example.com")
+  #     |> subject("Mighty Pirate Newsletter")
+  #     |> html_body("<h1>Hello</h1>")
+  #     |> text_body("Hello")
+
+  #   Bypass.expect bypass, fn conn ->
+  #     conn = parse(conn)
+  #     expected_path = "/" <> config[:domain] <> "/messages"
+  #     body_params = %{"subject" => "Mighty Pirate Newsletter",
+  #                     "to" => ~s(wasp.avengers@example.com, "Murry The Skull" <murry@lechucksship.gov>),
+  #                     "bcc" => ~s(beast.avengers@example.com, "Clinton Francis Barton" <hawk.eye@example.com>),
+  #                     "cc" => ~s(thor.odinson@example.com, "Bruce Banner" <hulk.smash@example.com>),
+  #                     "h:Reply-To" => "office.avengers@example.com",
+  #                     "from" => ~s("G Threepwood" <guybrush.threepwood@pirates.grog>),
+  #                     "text" => "Hello",
+  #                     "html" => "<h1>Hello</h1>"}
+  #     assert body_params == conn.body_params
+  #     assert expected_path == conn.request_path
+  #     assert "POST" == conn.method
+
+  #     Plug.Conn.resp(conn, 200, @success_response)
+  #   end
+
+  #   assert AmazonSes.deliver(email, config) == {:ok, %{id: "<20111114174239.25659.5817@samples.AmazonSes.org>"}}
+  # end
+
+  # test "delivery/1 with custom variables returns :ok", %{bypass: bypass, config: config} do
+  #   email =
+  #     new()
+  #     |> from("guybrush.threepwood@pirates.grog")
+  #     |> to("murry@lechucksship.gov")
+  #     |> subject("Mighty Pirate Newsletter")
+  #     |> html_body("<h1>Hello</h1>")
+  #     |> put_provider_option(:custom_vars, %{my_var: %{"my_message_id": 123}, my_other_var: %{"my_other_id": 1, "stuff": 2}})
+
+  #   Bypass.expect bypass, fn conn ->
+  #     conn = parse(conn)
+  #     expected_path = "/" <> config[:domain] <> "/messages"
+  #     body_params = %{"subject" => "Mighty Pirate Newsletter",
+  #                     "to" => "murry@lechucksship.gov",
+  #                     "from" => "guybrush.threepwood@pirates.grog",
+  #                     "html" => "<h1>Hello</h1>",
+  #                     "v:my_var" => "{\"my_message_id\":123}",
+  #                     "v:my_other_var" => "{\"stuff\":2,\"my_other_id\":1}"}
+  #     assert body_params == conn.body_params
+  #     assert expected_path == conn.request_path
+  #     assert "POST" == conn.method
+
+  #     Plug.Conn.resp(conn, 200, @success_response)
+  #   end
+
+  #   assert AmazonSes.deliver(email, config) == {:ok, %{id: "<20111114174239.25659.5817@samples.AmazonSes.org>"}}
+  # end
+
+  # test "delivery/1 with custom headers returns :ok", %{bypass: bypass, config: config} do
+  #   email =
+  #     new()
+  #     |> from("guybrush.threepwood@pirates.grog")
+  #     |> to("murry@lechucksship.gov")
+  #     |> subject("Mighty Pirate Newsletter")
+  #     |> html_body("<h1>Hello</h1>")
+  #     |> header("In-Reply-To", "<1234@example.com>")
+  #     |> header("X-Accept-Language", "en")
+  #     |> header("X-Mailer", "swoosh")
+
+  #   Bypass.expect bypass, fn conn ->
+  #     conn = parse(conn)
+  #     expected_path = "/" <> config[:domain] <> "/messages"
+  #     body_params = %{"subject" => "Mighty Pirate Newsletter",
+  #                     "to" => "murry@lechucksship.gov",
+  #                     "from" => "guybrush.threepwood@pirates.grog",
+  #                     "html" => "<h1>Hello</h1>",
+  #                     "h:In-Reply-To" => "<1234@example.com>",
+  #                     "h:X-Accept-Language" => "en",
+  #                     "h:X-Mailer" => "swoosh"}
+  #     assert body_params == conn.body_params
+  #     assert expected_path == conn.request_path
+  #     assert "POST" == conn.method
+
+  #     Plug.Conn.resp(conn, 200, @success_response)
+  #   end
+
+  #   assert AmazonSes.deliver(email, config) == {:ok, %{id: "<20111114174239.25659.5817@samples.AmazonSes.org>"}}
+  # end
+
+  # test "delivery/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do
+  #   Bypass.expect bypass, fn conn ->
+  #     Plug.Conn.resp(conn, 401, "Forbidden")
+  #   end
+
+  #   assert AmazonSes.deliver(email, config) == {:error, {401, "Forbidden"}}
+  # end
+
+  # test "deliver/1 with 5xx response", %{bypass: bypass, valid_email: email, config: config} do
+  #   Bypass.expect bypass, fn conn ->
+  #     Plug.Conn.resp(conn, 500, "{\"errors\":[\"The provided authorization grant is invalid, expired, or revoked\"], \"message\":\"error\"}")
+  #   end
+
+  #   assert AmazonSes.deliver(email, config) == {:error, {500, %{"errors" => ["The provided authorization grant is invalid, expired, or revoked"], "message" => "error"}}}
+  # end
+
+  # test "validate_config/1 with valid config", %{config: config} do
+  #   assert AmazonSes.validate_config(config) == :ok
+  # end
+
+  # test "validate_config/1 with invalid config" do
+  #   assert_raise ArgumentError, """
+  #   expected [:domain, :api_key] to be set, got: []
+  #   """, fn ->
+  #     AmazonSes.validate_config([])
+  #   end
+  # end
+end

--- a/test/swoosh/adapters/xml/helpers_test.exs
+++ b/test/swoosh/adapters/xml/helpers_test.exs
@@ -1,9 +1,12 @@
 defmodule Swoosh.Adapters.XML.HelpersTest do
+  require Record
   use ExUnit.Case, async: true
   alias Swoosh.Adapters.XML.Helpers, as: XmlHelper
 
+  Record.defrecord :xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
+
   setup do
-    xml_string ="""
+    xml_string = """
     <xml>
         <test>Test Text</test>
         <test>Test 2 Text</test>
@@ -16,20 +19,21 @@ defmodule Swoosh.Adapters.XML.HelpersTest do
     {:ok, xml_string: xml_string}
   end
 
-  test "parse returns xmlnode ", %{xml_string: xml_string} do
-    assert XmlHelper.parse(xml_string) == %{}
-  end
-
-  test "first returns the first xml node found", %{xml_string: xml_string} do
-    xml_node = XmlHelper.parse(xml_string)
-    assert XmlHelper.first(xml_node, "//test") == %{}
-  end
-
-  test "text returns the text value of the xml node", %{xml_string: xml_string} do
-    xml_node =
+  test "first returns the first xml node found and prints text", %{xml_string: xml_string} do
+    text =
       XmlHelper.parse(xml_string)
       |> XmlHelper.first("//test")
+      |> XmlHelper.text
 
-    assert XmlHelper.text(xml_node) == "Test Text"
+    assert text == "Test Text"
+  end
+
+  test "text prints blank on empty node", %{xml_string: xml_string} do
+    text =
+      XmlHelper.parse(xml_string)
+      |> XmlHelper.first("//test2/inside")
+      |> XmlHelper.text
+
+    assert text == ""
   end
 end

--- a/test/swoosh/adapters/xml/helpers_test.exs
+++ b/test/swoosh/adapters/xml/helpers_test.exs
@@ -1,0 +1,35 @@
+defmodule Swoosh.Adapters.XML.Helpers do
+  use ExUnit.Case, async: true
+  alias Swoosh.Adapters.XML.Helpers, as: XmlHelper
+
+  setup do
+    xml_string ="""
+    <xml>
+        <test>Test Text</test>
+        <test>Test 2 Text</test>
+        <test2>
+            <inside></inside>
+        </test2>
+    </xml>
+    """
+
+    {:ok, xml_string: xml_string}
+  end
+
+  test "parse returns xmlnode ", %{xml_string: xml_string} do
+    assert XmlHelper.parse(xml_string) == %{}
+  end
+
+  test "first returns the first xml node found", %{xml_string: xml_string} do
+    xml_node = XmlHelper.parse(xml_string)
+    assert XmlHelper.first(xml_node, "//test") == %{}
+  end
+
+  test "text returns the text value of the xml node", %{xml_string: xml_string} do
+    xml_node =
+      XmlHelper.parse(xml_string)
+      |> XmlHelper.first("//test")
+
+    assert XmlHelper.text(xml_node) == "Test Text"
+  end
+end

--- a/test/swoosh/adapters/xml/helpers_test.exs
+++ b/test/swoosh/adapters/xml/helpers_test.exs
@@ -1,4 +1,4 @@
-defmodule Swoosh.Adapters.XML.Helpers do
+defmodule Swoosh.Adapters.XML.HelpersTest do
   use ExUnit.Case, async: true
   alias Swoosh.Adapters.XML.Helpers, as: XmlHelper
 

--- a/test/swoosh/adapters/xml/helpers_test.exs
+++ b/test/swoosh/adapters/xml/helpers_test.exs
@@ -2,7 +2,7 @@ defmodule Swoosh.Adapters.XML.HelpersTest do
   use ExUnit.Case, async: true
   alias Swoosh.Adapters.XML.Helpers, as: XMLHelper
 
-  setup do
+  setup_all do
     xml_string = """
     <xml>
         <test>Test Text</test>

--- a/test/swoosh/adapters/xml/helpers_test.exs
+++ b/test/swoosh/adapters/xml/helpers_test.exs
@@ -1,9 +1,6 @@
 defmodule Swoosh.Adapters.XML.HelpersTest do
-  require Record
   use ExUnit.Case, async: true
   alias Swoosh.Adapters.XML.Helpers, as: XmlHelper
-
-  Record.defrecord :xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
 
   setup do
     xml_string = """

--- a/test/swoosh/adapters/xml/helpers_test.exs
+++ b/test/swoosh/adapters/xml/helpers_test.exs
@@ -1,6 +1,6 @@
 defmodule Swoosh.Adapters.XML.HelpersTest do
   use ExUnit.Case, async: true
-  alias Swoosh.Adapters.XML.Helpers, as: XmlHelper
+  alias Swoosh.Adapters.XML.Helpers, as: XMLHelper
 
   setup do
     xml_string = """
@@ -9,6 +9,7 @@ defmodule Swoosh.Adapters.XML.HelpersTest do
         <test>Test 2 Text</test>
         <test2>
             <inside></inside>
+            <inside>test 2</inside>
         </test2>
     </xml>
     """
@@ -16,20 +17,40 @@ defmodule Swoosh.Adapters.XML.HelpersTest do
     {:ok, xml_string: xml_string}
   end
 
+  test "first_text returns the text of the first xml node found", %{xml_string: xml_string} do
+    text =
+      xml_string
+      |> XMLHelper.parse
+      |> XMLHelper.first_text("//test")
+
+    assert text == "Test Text"
+  end
+
+  test "first_text returns the a blank on first xml found where empty", %{xml_string: xml_string} do
+    text =
+      xml_string
+      |> XMLHelper.parse
+      |> XMLHelper.first_text("//inside")
+
+    assert text == ""
+  end
+
   test "first returns the first xml node found and prints text", %{xml_string: xml_string} do
     text =
-      XmlHelper.parse(xml_string)
-      |> XmlHelper.first("//test")
-      |> XmlHelper.text
+      xml_string
+      |> XMLHelper.parse
+      |> XMLHelper.first("//test")
+      |> XMLHelper.text
 
     assert text == "Test Text"
   end
 
   test "text prints blank on empty node", %{xml_string: xml_string} do
     text =
-      XmlHelper.parse(xml_string)
-      |> XmlHelper.first("//test2/inside")
-      |> XmlHelper.text
+      xml_string
+      |> XMLHelper.parse
+      |> XMLHelper.first("//test2/inside")
+      |> XMLHelper.text
 
     assert text == ""
   end


### PR DESCRIPTION
Attempt at adding a new Amazon SES adapter to send out basic emails. Uses their SendRawEmail interface on their query api since that is the interface that allows for attachments.

Addresses #6 