### PR TITLE
add optional headers to attachment

### DIFF
--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -102,23 +102,23 @@ if Code.ensure_loaded?(:mimemail) do
        content}
     end
 
-    defp prepare_attachment(%{filename: filename, path: path, content_type: content_type, type: attachment_type}) do
+    defp prepare_attachment(%{filename: filename, path: path, content_type: content_type, type: attachment_type, headers: custom_headers}) do
       [type, format] = String.split(content_type, "/")
       file = File.read!(path)
 
       case attachment_type do
         :attachment -> {type, format,
-                         [{"Content-Transfer-Encoding", "base64"}],
+                         [{"Content-Transfer-Encoding", "base64"}] ++ custom_headers,
                          [{"disposition", "attachment"}, {"disposition-params", [{"filename", filename}]}],
                          file}
         :inline     -> {type, format,
-                         [{"Content-Transfer-Encoding", "base64"}, {"Content-Id", "<#{filename}>"}],
+                         [{"Content-Transfer-Encoding", "base64"}, {"Content-Id", "<#{filename}>"}] ++ custom_headers,
                          [{"content-type-params", []},
                           {"disposition", "inline"},
                           {"disposition-params", []}],
                          file}
       end
-      
+
     end
   end
 end

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -3,7 +3,7 @@ defmodule Swoosh.Attachment do
   Struct representing an attachment in an email.
   """
 
-  defstruct filename: nil, content_type: nil, path: nil, type: nil
+  defstruct filename: nil, content_type: nil, path: nil, type: nil, headers: []
 
   @type t :: %__MODULE__{}
 
@@ -51,6 +51,7 @@ defmodule Swoosh.Attachment do
     filename = opts[:filename] || Path.basename(path)
     content_type = opts[:content_type] || MIME.from_path(path)
     type = opts[:type] || :attachment
-    %__MODULE__{path: path, filename: filename, content_type: content_type, type: type}
+    headers = opts[:headers] || []
+    %__MODULE__{path: path, filename: filename, content_type: content_type, type: type, headers: headers}
   end
 end

--- a/test/swoosh/attachment_test.exs
+++ b/test/swoosh/attachment_test.exs
@@ -51,4 +51,13 @@ defmodule Swoosh.AttachmentTest do
     attachment = Attachment.new("/data/file.png", type: :inline)
     assert attachment.type == :inline
   end
+
+  test "create an attachment with custom headers" do
+    attachment = Attachment.new("/data/file.png", headers: [{"Content-Type", "text/calendar; method=\"REQUEST\""}])
+    assert length(attachment.headers) == 1
+    {a, b} = Enum.at(attachment.headers, 0)
+    assert a == "Content-Type"
+    assert b == "text/calendar; method=\"REQUEST\""
+  end
+
 end


### PR DESCRIPTION
When you add an attachment, sometimes, you need to add some custom headers (i.e. for a ical). This PR add a (optional) list of custom headers when a new attachment struct is created.  