### PR TITLE
add in memory attachment for smtp adapter

### DIFF
--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -102,21 +102,24 @@ if Code.ensure_loaded?(:mimemail) do
        content}
     end
 
-    defp prepare_attachment(%{filename: filename, path: path, content_type: content_type, type: attachment_type, headers: custom_headers}) do
+    defp prepare_attachment(%{filename: filename, path: path, content_type: content_type, type: attachment_type, headers: custom_headers, data: data}) do
       [type, format] = String.split(content_type, "/")
-      file = File.read!(path)
+      content = case data do
+        nil -> File.read!(path)
+        _   -> data
+      end
 
       case attachment_type do
         :attachment -> {type, format,
                          [{"Content-Transfer-Encoding", "base64"}] ++ custom_headers,
                          [{"disposition", "attachment"}, {"disposition-params", [{"filename", filename}]}],
-                         file}
+                         content}
         :inline     -> {type, format,
                          [{"Content-Transfer-Encoding", "base64"}, {"Content-Id", "<#{filename}>"}] ++ custom_headers,
                          [{"content-type-params", []},
                           {"disposition", "inline"},
                           {"disposition-params", []}],
-                         file}
+                         content}
       end
 
     end

--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -102,12 +102,9 @@ if Code.ensure_loaded?(:mimemail) do
        content}
     end
 
-    defp prepare_attachment(%{filename: filename, path: path, content_type: content_type, type: attachment_type, headers: custom_headers, data: data}) do
+    defp prepare_attachment(%{filename: filename, content_type: content_type, type: attachment_type, headers: custom_headers} = attachment) do
       [type, format] = String.split(content_type, "/")
-      content = case data do
-        nil -> File.read!(path)
-        _   -> data
-      end
+      content = Swoosh.Attachment.get_content(attachment)
 
       case attachment_type do
         :attachment -> {type, format,

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -3,7 +3,7 @@ defmodule Swoosh.Attachment do
   Struct representing an attachment in an email.
   """
 
-  defstruct filename: nil, content_type: nil, path: nil, type: nil, headers: []
+  defstruct filename: nil, content_type: nil, path: nil, type: nil, headers: [], data: nil
 
   @type t :: %__MODULE__{}
 

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -54,4 +54,12 @@ defmodule Swoosh.Attachment do
     headers = opts[:headers] || []
     %__MODULE__{path: path, filename: filename, content_type: content_type, type: type, headers: headers}
   end
+
+  @spec get_content(%__MODULE__{}) :: binary | no_return
+  def get_content(%__MODULE__{data: data, path: path}) do
+    case data do
+      nil -> File.read!(path)
+      _   -> data
+    end
+  end
 end

--- a/test/integration/adapters/smtp_test.exs
+++ b/test/integration/adapters/smtp_test.exs
@@ -31,4 +31,16 @@ defmodule Swoosh.Integration.Adapters.SMTPTest do
 
     assert {:ok, _response} = Swoosh.Adapters.SMTP.deliver(email, config)
   end
+
+  test "deliver with attachment in memory", %{config: config} do
+    email = 
+      new()
+      |> from({"Swoosh SMTP", "swoosh+smtp@#{config[:domain]}"})
+      |> to("swoosh+to@#{config[:domain]}")
+      |> subject("Swoosh - SMTP integration test")
+      |> text_body("This email was sent by the Swoosh library automation testing")
+      |> attachment(%Swoosh.Attachment{content_type: "text/plain", data: "this is an attachment", filename: "example.txt"})
+    assert {:ok, _response} = Swoosh.Adapters.SMTP.deliver(email, config)
+  end
+
 end


### PR DESCRIPTION
Added "data" key in Swoosh.Attachment so you can add "in memory" data as attachment. Added this feature for SMTP adapter.

