### PR TITLE
Fix dialyzer warnings when using Swoosh.Mailer

### DIFF
--- a/lib/swoosh/adapters/sendmail.ex
+++ b/lib/swoosh/adapters/sendmail.ex
@@ -28,6 +28,7 @@ if Code.ensure_loaded?(:mimemail) do
       port = Port.open({:spawn, cmd(email, config)}, [:binary])
       Port.command(port, body)
       Port.close(port)
+      :ok
     end
 
     @doc false

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -84,7 +84,6 @@ defmodule Swoosh.Mailer do
         case deliver(email, config) do
           {:ok, result} -> result
           {:error, reason} -> raise DeliveryError, reason: reason
-          {:error, reason, payload} -> raise DeliveryError, reason: reason, payload: payload
         end
       end
     end


### PR DESCRIPTION
As soon as a module uses Swoosh.Mailer, dialyzer warns about:

> lib/my_mailer.ex:3: The pattern {'error', _@5, _@6} can never match the type {'error',_} | {'ok',_}

This happens because the case into mailer.ex looks for a `triple` which never happens in any of the adapters. As confirmation the deliver callback typespec does not specify such triple.

This PR fixes that and also fixes the return value from the sendmail.ex deliver fun, because Port.close returns :true while the specs expects at least :ok