### PR TITLE
Refactor to use get_content in all adapters

### DIFF
--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -126,9 +126,9 @@ defmodule Swoosh.Adapters.Mandrill do
   end
 
   defp prepare_attachments_structure(attachments) do
-    Enum.map(attachments, fn %{content_type: type, path: path, filename: filename} ->
-      content = path |> File.read! |> Base.encode64
-      %{type: type, name: filename, content: content}
+    Enum.map(attachments, fn attachment ->
+      content = Swoosh.Attachment.get_content(attachment, :base64)
+      %{type: attachment.content_type, name: attachment.filename, content: content}
     end)
   end
 

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -88,7 +88,7 @@ defmodule Swoosh.Adapters.Postmark do
     attachment_data = %{
       "Name"        => attachment.filename,
       "ContentType" => attachment.content_type,
-      "Content"     => attachment.path |> File.read! |> Base.encode64,
+      "Content"     => Swoosh.Attachment.get_content(attachment, :base64)
     }
 
     case attachment.type do

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -106,12 +106,20 @@ defmodule Swoosh.Adapters.Sendgrid do
 
   defp prepare_attachments(body, %{attachments: []}), do: body
   defp prepare_attachments(body, %{attachments: attachments}) do
-    attachments = Enum.map(attachments, fn %{content_type: content_type, path: path, filename: filename, type: type} ->
-      content = path |> File.read! |> Base.encode64
-      case type do
-        :inline -> %{type: content_type, filename: filename, content: content, disposition: "inline", content_id: filename}
-        _ -> %{type: content_type, filename: filename, content: content}
-      end
+    attachments = Enum.map(attachments, fn attachment ->
+      attachment_info = %{
+        filename: attachment.filename,
+        type: attachment.content_type,
+        content: Swoosh.Attachment.get_content(attachment, :base64)
+      }
+
+      extra =
+        case attachment.type do
+          :inline -> %{disposition: "inline", content_id: attachment.filename}
+          :attachment -> %{disposition: "attachment"}
+        end
+
+      Map.merge(attachment_info, extra)
     end)
 
     Map.put(body, :attachments, attachments)

--- a/lib/swoosh/adapters/sparkpost.ex
+++ b/lib/swoosh/adapters/sparkpost.ex
@@ -119,8 +119,12 @@ defmodule Swoosh.Adapters.SparkPost do
   end
 
   defp prepare_attachments(attachments) do
-    Enum.map(attachments, fn %{content_type: type, path: path, filename: name} ->
-      %{type: type, name: name, data: path |> File.read! |> Base.encode64}
+    Enum.map(attachments, fn attachment ->
+      %{
+        type: attachment.content_type,
+        name: attachment.filename,
+        data: Swoosh.Attachment.get_content(attachment, :base64)
+      }
     end)
   end
 

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -75,13 +75,7 @@ defmodule Swoosh.Attachment do
     raise Swoosh.AttachmentContentError, message: "No path or data is provided"
   end
   def get_content(%__MODULE__{data: data, path: path}, encoding \\ :raw) do
-    content =
-      case data do
-        nil -> File.read!(path)
-        _   -> data
-      end
-
-    encode(content, encoding)
+    encode(data || File.read!(path), encoding)
   end
 
   defp encode(content, :raw), do: content

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -3,9 +3,16 @@ defmodule Swoosh.Attachment do
   Struct representing an attachment in an email.
   """
 
-  defstruct filename: nil, content_type: nil, path: nil, type: nil, headers: [], data: nil
+  defstruct [:filename, :content_type, :path, :type, :headers, :data]
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+    filename: String.t,
+    content_type: String.t,
+    path: String.t,
+    type: :inline | :attachment,
+    headers: [{String.t, String.t}],
+    data: binary
+  }
 
   @doc ~S"""
   Creates a new Attachment
@@ -52,14 +59,28 @@ defmodule Swoosh.Attachment do
     content_type = opts[:content_type] || MIME.from_path(path)
     type = opts[:type] || :attachment
     headers = opts[:headers] || []
-    %__MODULE__{path: path, filename: filename, content_type: content_type, type: type, headers: headers}
+
+    %__MODULE__{
+      path: path,
+      filename: filename,
+      content_type: content_type,
+      type: type,
+      headers: headers
+    }
   end
 
-  @spec get_content(%__MODULE__{}) :: binary | no_return
-  def get_content(%__MODULE__{data: data, path: path}) do
-    case data do
-      nil -> File.read!(path)
-      _   -> data
-    end
+  @type content_encoding :: :raw | :base64
+  @spec get_content(%__MODULE__{}, content_encoding) :: binary | no_return
+  def get_content(%__MODULE__{data: data, path: path}, encoding \\ :raw) do
+    content =
+      case data do
+        nil -> File.read!(path)
+        _   -> data
+      end
+
+    encode(content, encoding)
   end
+
+  defp encode(content, :raw), do: content
+  defp encode(content, :base64), do: Base.encode64(content)
 end

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -71,6 +71,9 @@ defmodule Swoosh.Attachment do
 
   @type content_encoding :: :raw | :base64
   @spec get_content(%__MODULE__{}, content_encoding) :: binary | no_return
+  def get_content(%__MODULE__{data: nil, path: nil}) do
+    raise Swoosh.AttachmentContentError, message: "No path or data is provided"
+  end
   def get_content(%__MODULE__{data: data, path: path}, encoding \\ :raw) do
     content =
       case data do

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -8,10 +8,10 @@ defmodule Swoosh.Attachment do
   @type t :: %__MODULE__{
     filename: String.t,
     content_type: String.t,
-    path: String.t,
+    path: String.t | nil,
+    data: binary | nil,
     type: :inline | :attachment,
     headers: [{String.t, String.t}],
-    data: binary
   }
 
   @doc ~S"""
@@ -32,7 +32,7 @@ defmodule Swoosh.Attachment do
       Attachment.new(params["file"], type: "inline") # Where params["file"] is a %Plug.Upload
 
   """
-  @spec new(binary, Keyword.t) :: %__MODULE__{}
+  @spec new(binary | struct, Keyword.t) :: %__MODULE__{}
   def new(path, opts \\ [])
 
   if Code.ensure_loaded?(Plug) do

--- a/lib/swoosh/attachment_content_error.ex
+++ b/lib/swoosh/attachment_content_error.ex
@@ -1,0 +1,3 @@
+defmodule Swoosh.AttachmentContentError do
+  defexception [:message]
+end

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -472,22 +472,30 @@ defmodule Swoosh.Email do
       %Swoosh.Email{assigns: %{}, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: [],
-       attachments: [%Swoosh.Attachment{path: "/data/att.zip", content_type: "application/zip", filename: "att.zip", type: :attachment}]}
+       attachments: [%Swoosh.Attachment{path: "/data/att.zip",
+        content_type: "application/zip", filename: "att.zip",
+        type: :attachment, data: nil, headers: []}]}
       iex> new() |> attachment(Swoosh.Attachment.new("/data/att.zip"))
       %Swoosh.Email{assigns: %{}, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: [],
-       attachments: [%Swoosh.Attachment{path: "/data/att.zip", content_type: "application/zip", filename: "att.zip", type: :attachment}]}
+       attachments: [%Swoosh.Attachment{path: "/data/att.zip",
+        content_type: "application/zip", filename: "att.zip",
+        type: :attachment, data: nil, headers: []}]}
       iex> new() |> attachment(%Plug.Upload{path: "/data/abcdefg", content_type: "test/type", filename: "att.zip"})
       %Swoosh.Email{assigns: %{}, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: [],
-       attachments: [%Swoosh.Attachment{path: "/data/abcdefg", content_type: "test/type", filename: "att.zip", type: :attachment}]}
+       attachments: [%Swoosh.Attachment{path: "/data/abcdefg",
+        content_type: "test/type", filename: "att.zip",
+        type: :attachment, data: nil, headers: []}]}
       iex> new() |> attachment(Swoosh.Attachment.new("/data/att.png", type: :inline))
       %Swoosh.Email{assigns: %{}, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: [],
-       attachments: [%Swoosh.Attachment{path: "/data/att.png", content_type: "image/png", filename: "att.png", type: :inline}]}
+       attachments: [%Swoosh.Attachment{path: "/data/att.png",
+        content_type: "image/png", filename: "att.png",
+        type: :inline, data: nil, headers: []}]}
   """
   @spec attachment(t, binary | Swoosh.Attachment.t) :: t
   def attachment(%__MODULE__{attachments: attachments} = email, path) when is_binary(path) do

--- a/test/integration/adapters/smtp_test.exs
+++ b/test/integration/adapters/smtp_test.exs
@@ -33,13 +33,19 @@ defmodule Swoosh.Integration.Adapters.SMTPTest do
   end
 
   test "deliver with attachment in memory", %{config: config} do
-    email = 
+    email =
       new()
       |> from({"Swoosh SMTP", "swoosh+smtp@#{config[:domain]}"})
       |> to("swoosh+to@#{config[:domain]}")
       |> subject("Swoosh - SMTP integration test")
       |> text_body("This email was sent by the Swoosh library automation testing")
-      |> attachment(%Swoosh.Attachment{content_type: "text/plain", data: "this is an attachment", filename: "example.txt"})
+      |> attachment(%Swoosh.Attachment{
+        content_type: "text/plain",
+        data: "this is an attachment",
+        filename: "example.txt",
+        type: :attachment,
+        headers: []
+      })
     assert {:ok, _response} = Swoosh.Adapters.SMTP.deliver(email, config)
   end
 


### PR DESCRIPTION
Close #179 
Fixes #183 

This PR will allow sending attachments from in-memory data in all adapters.
However, we only provide one convenience function `Attachment.new` that works with `path`, and `Plug.Conn` if it's included in the code base. I filed a separate issue #181 for further improvements that will allow in-memory data and maybe other ways of adding attachments in the future.