### PR TITLE
Return the message id from the sendgrid adapter mirroring other adapters

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -31,13 +31,19 @@ defmodule Swoosh.Adapters.Sendgrid do
     body = email |> prepare_body() |> Poison.encode!
     url = [base_url(config), @api_endpoint]
     case :hackney.post(url, headers, body, [:with_body]) do
-      {:ok, code, _headers, _body} when code >= 200 and code <= 399 ->
-        {:ok, %{}}
+      {:ok, code, headers, _body} when code >= 200 and code <= 399 ->
+        {:ok, %{id: extract_id(headers)}}
       {:ok, code, _headers, body} when code > 399 ->
         {:error, {code, body}}
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp extract_id(headers) do
+    headers
+    |> Enum.into(%{})
+    |> Map.get("X-Message-Id")
   end
 
   defp base_url(config), do: config[:base_url] || @base_url

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -19,6 +19,12 @@ defmodule Swoosh.Adapters.SendgridTest do
     {:ok, bypass: bypass, config: config, valid_email: valid_email}
   end
 
+  defp respond_with(conn, [body: body, id: id]) do
+    conn
+    |> Plug.Conn.put_resp_header("X-Message-Id", id)
+    |> Plug.Conn.resp(200, body)
+  end
+
   test "successful delivery returns :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
@@ -35,12 +41,6 @@ defmodule Swoosh.Adapters.SendgridTest do
       respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
-  end
-
-  defp respond_with(conn, [body: body, id: id]) do
-    conn
-    |> Plug.Conn.put_resp_header("X-Message-Id", id)
-    |> Plug.Conn.resp(200, body)
   end
 
   test "text-only delivery returns :ok", %{bypass: bypass, config: config} do

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -32,11 +32,15 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
+  end
+
+  defp respond_with(conn, [body: body, id: id]) do
+    conn
+    |> Plug.Conn.put_resp_header("X-Message-Id", id)
+    |> Plug.Conn.resp(200, body)
   end
 
   test "text-only delivery returns :ok", %{bypass: bypass, config: config} do
@@ -59,9 +63,7 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
@@ -86,9 +88,7 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
@@ -123,9 +123,7 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
@@ -162,9 +160,7 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
@@ -193,9 +189,7 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
@@ -224,9 +218,7 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
@@ -261,9 +253,7 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
 
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
@@ -315,9 +305,7 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
 
-      conn
-      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
-      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
     end
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -31,9 +31,12 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
   test "text-only delivery returns :ok", %{bypass: bypass, config: config} do
@@ -55,9 +58,12 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
   test "html-only delivery returns :ok", %{bypass: bypass, config: config} do
@@ -79,9 +85,12 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
@@ -113,9 +122,12 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
   test "delivery/1 with custom variables returns :ok", %{bypass: bypass, config: config} do
@@ -149,9 +161,12 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
   test "delivery/1 with template_id returns :ok", %{bypass: bypass, config: config} do
@@ -177,9 +192,12 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
   test "delivery/1 with substitutions returns :ok", %{bypass: bypass, config: config} do
@@ -205,9 +223,12 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
   test "delivery/1 with custom headers returns :ok", %{bypass: bypass, config: config} do
@@ -239,10 +260,13 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
 
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
   test "delivery/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
@@ -290,9 +314,12 @@ defmodule Swoosh.Adapters.SendgridTest do
       assert body_params == conn.body_params
       assert "/mail/send" == conn.request_path
       assert "POST" == conn.method
-      Plug.Conn.resp(conn, 200, "{\"message\":\"success\"}")
+
+      conn
+      |> Plug.Conn.put_resp_header("X-Message-Id", "123-xyz")
+      |> Plug.Conn.resp(200, "{\"message\":\"success\"}")
     end
-    assert Sendgrid.deliver(email, config) == {:ok, %{}}
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
 end


### PR DESCRIPTION
See
https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html#-Response-Example
for the description of the different headers.