### PR TITLE
Add no_mx_lookups to smtp config

### DIFF
--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -18,13 +18,16 @@ if Code.ensure_loaded?(:gen_smtp_client) do
           relay: "smtp.avengers.com",
           username: "tonystark",
           password: "ilovepepperpotts",
+          ssl: true,
           tls: :always,
           auth: :always,
           port: 1025,
           dkim: [
             s: "default", d: "domain.com",
             private_key: {:pem_plain, File.read!("priv/keys/domain.private")}
-          ]
+          ],
+          retries: 2,
+          no_mx_lookups: false
 
         # lib/sample/mailer.ex
         defmodule Sample.Mailer do
@@ -57,7 +60,8 @@ if Code.ensure_loaded?(:gen_smtp_client) do
       retries: &String.to_integer/1,
       ssl: {&String.to_atom/1, [true, false]},
       tls: {&String.to_atom/1, [:always, :never, :if_available]},
-      auth: {&String.to_atom/1, [:always, :if_available]}
+      auth: {&String.to_atom/1, [:always, :if_available]},
+      no_mx_lookups: {&String.to_atom/1, [true, false]}
     }
     @config_keys Map.keys(@config_transformations)
 


### PR DESCRIPTION
Hello,

I added `no_mx_lookups` option to `smtp` config.
This option can help when you don't want to connect to the returned mx's of relay.

The `no_mx_lookups` is not mentioned in the `gen_smtp` README, but see https://github.com/Vagabond/gen_smtp/blob/master/src/gen_smtp_client.erl#L136 for more details.

It's now possible to pass this option, but making it clearer in the documentation can help other people.

What do you think? Would it be valid?

Thanks.