### PR TITLE
Templates

### DIFF
--- a/lib/swoosh/template.ex
+++ b/lib/swoosh/template.ex
@@ -1,0 +1,100 @@
+defmodule Swoosh.Template do
+  @default_engines [ eex: Swoosh.Template.EExEngine ]
+  @default_pattern "*"
+
+  defmacro __before_compile__(env) do
+    root = Module.get_attribute(env.module, :swoosh_root)
+    pattern = Module.get_attribute(env.module, :swoosh_pattern)
+
+    codes =
+      for path <- find_all(root, pattern) do
+        compile(path, root)
+      end
+
+    quote do
+      unquote(codes)
+
+      def render(template), do: render(template, %{})
+    end
+  end
+
+  defmacro __using__(opts) do
+    quote bind_quoted: [ opts: opts ], unquote: true do
+      root = Keyword.fetch!(opts, :root)
+
+      @swoosh_root Path.relative_to_cwd(root)
+      @swoosh_pattern Keyword.get(opts, :pattern, unquote(@default_pattern))
+
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  @doc """
+  Returns a keyword list of all template engines identified by their extensions.
+  """
+  @spec engines() :: %{ atom => module }
+  def engines() do
+    @default_engines
+    |> Keyword.merge(Application.get_env(:swoosh, :template_engines, []))
+    |> Enum.into(%{})
+  end
+
+  @doc """
+  Returns all template paths in a given template root.
+  """
+  @spec find_all(binary, binary) :: binary
+  def find_all(root, pattern \\ @default_pattern) do
+    root
+    |> Path.join(pattern <> ".#{extensions_pattern()}")
+    |> Path.wildcard()
+  end
+
+  @doc """
+  Converts the template path into the template name.
+
+  ## Examples
+
+      iex> Swoosh.Template.template_path_to_name(
+      ...>   "lib/templates/users/welcome.html.eex",
+      ...>   "lib/templates")
+      "users/welcome.html"
+  """
+  @spec template_path_to_name(binary, binary) :: binary
+  def template_path_to_name(path, root) do
+    path
+    |> Path.rootname()
+    |> Path.relative_to(root)
+  end
+
+  defp compile(path, root) do
+    engine = engine_for(path)
+    name = template_path_to_name(path, root)
+    quoted = engine.compile(path)
+
+    quote do
+      def render(unquote(name), var!(assigns)) do
+        _ = var!(assigns)
+
+        unquote(quoted)
+      end
+    end
+  end
+
+  defp engine_for(path) do
+    engines()
+    |> Map.fetch!(extension(path))
+  end
+
+  defp extension(path) do
+    path
+    |> Path.extname()
+    |> String.trim_leading(".")
+    |> String.to_atom()
+  end
+
+  defp extensions_pattern() do
+    engines()
+    |> Map.keys()
+    |> Enum.join(",")
+  end
+end

--- a/lib/swoosh/template/eex_engine.ex
+++ b/lib/swoosh/template/eex_engine.ex
@@ -1,0 +1,11 @@
+defmodule Swoosh.Template.EExEngine do
+  @moduledoc """
+  Template engine implementation for EEx.
+  """
+
+  @behaviour Swoosh.Template.Engine
+
+  def compile(template_path) do
+    EEx.compile_file(template_path, trim: true)
+  end
+end

--- a/lib/swoosh/template/engine.ex
+++ b/lib/swoosh/template/engine.ex
@@ -1,0 +1,7 @@
+defmodule Swoosh.Template.Engine do
+  @moduledoc """
+  Specifies the API for adding custom template engines to Swoosh.
+  """
+
+  @callback compile(template_path :: binary) :: Macro.t
+end

--- a/lib/swoosh/view.ex
+++ b/lib/swoosh/view.ex
@@ -1,0 +1,64 @@
+defmodule Swoosh.View do
+  defmacro __using__(opts) do
+    quote do
+      use Swoosh.Template, unquote(opts)
+
+      import Swoosh.View
+    end
+  end
+
+  @doc """
+  Renders a template.
+
+  It expects the view module, the template as a string, and a
+  set of assigns.
+
+  ## Examples
+
+      Swoosh.View.render(YourApp.EmailView, "index.html", name: "John Doe")
+      #=> "Hello John Doe"
+
+  ## Assigns
+
+  Assigns are meant to be user data that will be available in templates.
+  However, there are keys under assigns that are specially handled by
+  Swoosh, they are:
+
+    * `:layout` - tells Swoosh to wrap the rendered result in the
+      given layout. See next section.
+
+  The following assigns are reserved, and cannot be set directly:
+
+    * `@view_module` - The view module being rendered
+    * `@view_template` - The `@view_module`'s template being rendered
+
+  ## Layouts
+
+  Templates can be rendered within other templates using the `:layout`
+  option. `:layout` accepts a tuple of the form
+  `{LayoutModule, "template.extension"}`.
+
+  To render the template within the layout, simply call `render/3`
+  using the `@view_module` and `@view_template` assign:
+
+      <%= render @view_module, @view_template, assigns %>
+  """
+  def render(module, template, assigns) do
+    assigns
+    |> Enum.into(%{})
+    |> Map.pop(:layout, false)
+    |> render_within(module, template)
+  end
+
+  defp render_within({ { layout_mod, layout_tpl }, assigns }, inner_mod, inner_tpl) do
+    assigns = Map.merge(assigns, %{ view_module: inner_mod, view_template: inner_tpl })
+
+    layout_mod.render(layout_tpl, assigns)
+  end
+
+  defp render_within({ false, assigns }, module, template) do
+    assigns = Map.merge(assigns, %{ view_module: module, view_template: template })
+
+    module.render(template, assigns)
+  end
+end

--- a/test/support/fixtures/templates/layout/layout.eex
+++ b/test/support/fixtures/templates/layout/layout.eex
@@ -1,0 +1,3 @@
+This is a layout!
+
+<%= render(@view_module, @view_template, assigns) %>

--- a/test/support/fixtures/templates/template_1.eex
+++ b/test/support/fixtures/templates/template_1.eex
@@ -1,0 +1,1 @@
+Hello, world!

--- a/test/support/fixtures/templates/template_2.eex
+++ b/test/support/fixtures/templates/template_2.eex
@@ -1,0 +1,1 @@
+Hello, <%= @subject %>!

--- a/test/support/fixtures/views.exs
+++ b/test/support/fixtures/views.exs
@@ -1,0 +1,7 @@
+defmodule MyApp.FakeView do
+  use Swoosh.View, root: "test/support/fixtures/templates"
+end
+
+defmodule MyApp.FakeLayout do
+  use Swoosh.View, root: "test/support/fixtures/templates/layout"
+end

--- a/test/swoosh/email_test.exs
+++ b/test/swoosh/email_test.exs
@@ -1,3 +1,5 @@
+Code.require_file "../support/fixtures/views.exs", __DIR__
+
 defmodule Swoosh.EmailTest do
   use ExUnit.Case, async: true
   doctest Swoosh.Email, import: true
@@ -287,5 +289,105 @@ defmodule Swoosh.EmailTest do
       """, fn ->
       new() |> to([{"Bruce Banner", nil}, "thor.odinson@example.com"])
     end
+  end
+
+  test "layout/1 returns false when no layout is set" do
+    email = new()
+    assert layout(email) == false
+  end
+
+  test "layout/2 reutrns the layout when a layout is set" do
+    email = new() |> put_layout({ MyApp.FakeLayout, "template_1" })
+    assert layout(email) == { MyApp.FakeLayout, "template_1" }
+  end
+
+  test "put_view/2" do
+    email = new() |> put_view(MyApp.FakeView)
+    assert %Email{ private: %{ swoosh_view: MyApp.FakeView } } = email
+  end
+
+  test "put_layout/2" do
+    email = new() |> put_layout({ MyApp.FakeLayout, "layout" })
+    assert %Email{ private: %{ swoosh_layout: { MyApp.FakeLayout, "layout" } } } = email
+  end
+
+  test "render_to_html/3 renders a template" do
+    email =
+      new()
+      |> put_view(MyApp.FakeView)
+      |> render_to_html("template_1")
+
+    assert %Email{ html_body: "Hello, world!\n" } = email
+  end
+
+  test "render_to_html/3 renders a template with layout" do
+    email =
+      new()
+      |> put_view(MyApp.FakeView)
+      |> put_layout({ MyApp.FakeLayout, "layout" })
+      |> render_to_html("template_1")
+
+    assert %Email{ html_body: "This is a layout!\n\nHello, world!\n" } = email
+  end
+
+  test "render_to_html/3 renders template with assigns" do
+    email =
+      new()
+      |> put_view(MyApp.FakeView)
+      |> put_layout({ MyApp.FakeLayout, "layout" })
+      |> assign(:subject, "world")
+      |> render_to_html("template_2")
+
+    assert %Email{ html_body: "This is a layout!\n\nHello, world!\n" } = email
+  end
+
+  test "render_to_html/3 renders template with passed in assigns" do
+    email =
+      new()
+      |> put_view(MyApp.FakeView)
+      |> put_layout({ MyApp.FakeLayout, "layout" })
+      |> render_to_html("template_2", subject: "world")
+
+    assert %Email{ html_body: "This is a layout!\n\nHello, world!\n" } = email
+  end
+
+  test "render_to_text/3 renders a template" do
+    email =
+      new()
+      |> put_view(MyApp.FakeView)
+      |> render_to_text("template_1")
+
+    assert %Email{ text_body: "Hello, world!\n" } = email
+  end
+
+  test "render_to_text/3 renders a template with layout" do
+    email =
+      new()
+      |> put_view(MyApp.FakeView)
+      |> put_layout({ MyApp.FakeLayout, "layout" })
+      |> render_to_text("template_1")
+
+    assert %Email{ text_body: "This is a layout!\n\nHello, world!\n" } = email
+  end
+
+  test "render_to_text/3 renders template with assigns" do
+    email =
+      new()
+      |> put_view(MyApp.FakeView)
+      |> put_layout({ MyApp.FakeLayout, "layout" })
+      |> assign(:subject, "world")
+      |> render_to_text("template_2")
+
+    assert %Email{ text_body: "This is a layout!\n\nHello, world!\n" } = email
+  end
+
+  test "render_to_text/3 renders template with passed in assigns" do
+    email =
+      new()
+      |> put_view(MyApp.FakeView)
+      |> put_layout({ MyApp.FakeLayout, "layout" })
+      |> render_to_text("template_2", subject: "world")
+
+    assert %Email{ text_body: "This is a layout!\n\nHello, world!\n" } = email
   end
 end

--- a/test/swoosh/template_test.exs
+++ b/test/swoosh/template_test.exs
@@ -1,0 +1,19 @@
+defmodule Swoosh.TemplateTest do
+  use ExUnit.Case, async: true
+
+  defmodule FakeTemplate do
+    use Swoosh.Template, root: Path.join(__DIR__, "../support/fixtures/templates")
+  end
+
+  describe "render/1" do
+    test "renders template" do
+      assert FakeTemplate.render("template_1") == "Hello, world!\n"
+    end
+  end
+
+  describe "render/2" do
+    test "renders template" do
+      assert FakeTemplate.render("template_2", %{ subject: "world" }) == "Hello, world!\n"
+    end
+  end
+end

--- a/test/swoosh/view_test.exs
+++ b/test/swoosh/view_test.exs
@@ -1,0 +1,22 @@
+Code.require_file "../support/fixtures/views.exs", __DIR__
+
+defmodule Swoosh.ViewTest do
+  use ExUnit.Case, async: true
+
+  describe "render/3" do
+    test "renders template" do
+      assert Swoosh.View.render(MyApp.FakeView, "template_1", %{}) ==
+        "Hello, world!\n"
+    end
+
+    test "renders layout" do
+      assert Swoosh.View.render(MyApp.FakeView, "template_1", layout: { MyApp.FakeLayout, "layout" }) ==
+        "This is a layout!\n\nHello, world!\n"
+    end
+
+    test "assigns variables" do
+      assert Swoosh.View.render(MyApp.FakeView, "template_2", subject: "world") ==
+        "Hello, world!\n"
+    end
+  end
+end


### PR DESCRIPTION
Originally #163

* Added Swoosh.Template.Engine behaviour
* Removed template_name from compile callback
* Added EEx engine implementation
* Added template test fixtures
* Added templating
* Made assigns argument for render/2 optional
* Fixed tests
* Added render_to_html/3 and render_to_text/3; cleanup
* Removed docker-compose.yml
* Added :template_engines config
* Removed render_to_text and render_to_html
* Added view layer with layout support
* Moved test views into fixtures directory
* Added put_view/2 on Swoosh.Email
* Added functions to Swoosh.Email for managing views

---------

New by Po

- 