### PR TITLE
Add SendGrid asm field

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -58,6 +58,7 @@ defmodule Swoosh.Adapters.Sendgrid do
     |> prepare_reply_to(email)
     |> prepare_template_id(email)
     |> prepare_categories(email)
+    |> prepare_asm(email)
     |> prepare_custom_headers(email)
   end
 
@@ -143,6 +144,11 @@ defmodule Swoosh.Adapters.Sendgrid do
     Map.put(body, :categories, categories)
   end
   defp prepare_categories(body, _email), do: body
+
+  defp prepare_asm(body, %{provider_options: %{asm: asm}}) do
+    Map.put(body, :asm, asm)
+  end
+  defp prepare_asm(body, _email), do: body
 
   defp prepare_custom_headers(body, %{headers: headers}) when map_size(headers) == 0, do: body
   defp prepare_custom_headers(body, %{headers: headers}) do

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -310,4 +310,36 @@ defmodule Swoosh.Adapters.SendgridTest do
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
+  test "delivery/1 with asm returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> put_provider_option(:asm, %{"group_id" => 1, "groups_to_display" => [1, 2, 3]})
+
+    Bypass.expect bypass, fn conn ->
+      conn = parse(conn)
+      body_params = %{"from" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
+                      "asm" => %{
+                        "group_id" => 1,
+                        "groups_to_display" => [1, 2, 3]
+                      },
+                      "personalizations" => [%{
+                        "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}]
+                      }],
+                      "content" => [%{"type" => "text/plain", "value" => "Hello"}, %{"type" => "text/html", "value" => "<h1>Hello</h1>"}],
+                      "subject" => "Hello, Avengers!"
+                    }
+      assert body_params == conn.body_params
+      assert "/mail/send" == conn.request_path
+      assert "POST" == conn.method
+
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
+    end
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
+  end
+
 end


### PR DESCRIPTION
Thanks for the great library!

This PR adds support for the `asm` field in the SendGrid adapter ([unsubscribe groups behaviour](https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html))