### PR TITLE
Fix recompilation (potential) issue

### DIFF
--- a/lib/swoosh.ex
+++ b/lib/swoosh.ex
@@ -6,8 +6,6 @@ defmodule Swoosh do
   @doc false
   def version, do: @version
 
-  @json_library Application.get_env(:swoosh, :json_library, Jason)
-
   @doc false
-  def json_library, do: @json_library
+  def json_library, do: Application.get_env(:swoosh, :json_library, Jason)
 end


### PR DESCRIPTION
Because module attributes requires to recompile the deps to be
able to pick up the change. It is better to not use it for
configuration.

If somebody compiles the swoosh package with Jason and later on
decides to change it to Poison it will require to recompile the
swoosh deps.

Elixir do not recompile the deps unless it detects a change and
since change the config value is not change it will still have
the old value of the configuration.