### PR TITLE
Add regex email body test assertions

### DIFF
--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -63,6 +63,14 @@ defmodule Swoosh.TestAssertions do
   defp assert_equal(email, {:text_body, value}), do: assert(email.text_body == value)
   defp assert_equal(email, {:html_body, value}), do: assert(email.html_body == value)
 
+  defp assert_equal(email, {:regex, regex}) do
+    assert_equal(email, {:regex_html, regex})
+    assert_equal(email, {:regex_text, regex})
+  end
+
+  defp assert_equal(email, {:regex_html, regex}), do: assert(email.html_body =~ regex)
+  defp assert_equal(email, {:regex_text, regex}), do: assert(email.text_body =~ regex)
+
   @doc ~S"""
   Asserts `email` was not sent.
   """

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -60,16 +60,10 @@ defmodule Swoosh.TestAssertions do
     do: assert(email.bcc == Enum.map(value, &format_recipient/1))
 
   defp assert_equal(email, {:bcc, value}), do: assert(format_recipient(value) in email.bcc)
+  defp assert_equal(email, {:text_body, %Regex{} = value}), do: assert(email.text_body =~ value)
   defp assert_equal(email, {:text_body, value}), do: assert(email.text_body == value)
+  defp assert_equal(email, {:html_body, %Regex{} = value}), do: assert(email.html_body =~ value)
   defp assert_equal(email, {:html_body, value}), do: assert(email.html_body == value)
-
-  defp assert_equal(email, {:regex, regex}) do
-    assert_equal(email, {:regex_html, regex})
-    assert_equal(email, {:regex_text, regex})
-  end
-
-  defp assert_equal(email, {:regex_html, regex}), do: assert(email.html_body =~ regex)
-  defp assert_equal(email, {:regex_text, regex}), do: assert(email.text_body =~ regex)
 
   @doc ~S"""
   Asserts `email` was not sent.

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -10,6 +10,8 @@ defmodule Swoosh.TestAssertionsTest do
       |> from("tony.stark@example.com")
       |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
+      |> html_body("some html")
+      |> text_body("some text")
 
     Swoosh.Adapters.Test.deliver(email, nil)
     {:ok, email: email}
@@ -17,6 +19,10 @@ defmodule Swoosh.TestAssertionsTest do
 
   test "assert email sent with correct email", %{email: email} do
     assert_email_sent email
+  end
+
+  test "assert email sent with some content matched by a regex" do
+    assert_email_sent text_body: ~r/some text/, html_body: ~r/html$/
   end
 
   test "assert email sent with specific params" do

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -10,6 +10,7 @@ defmodule Swoosh.TestAssertionsTest do
       |> from("tony.stark@example.com")
       |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
+
     Swoosh.Adapters.Test.deliver(email, nil)
     {:ok, email: email}
   end
@@ -27,7 +28,7 @@ defmodule Swoosh.TestAssertionsTest do
   end
 
   test "assert email sent with wrong subject" do
-    assert_raise ExUnit.AssertionError, fn -> 
+    assert_raise ExUnit.AssertionError, fn ->
       assert_email_sent [subject: "Hello, X-Men!"]
     end
   end
@@ -62,18 +63,25 @@ defmodule Swoosh.TestAssertionsTest do
     end
   end
 
-  test "assert email sent with wrong email" do
+  test "assert email sent with wrong email", %{email: email} do
+    wrong_email = new() |> subject("Wrong, Avengers!")
+
+    message =
+      String.trim(
+        """
+        No message matching {:email, ^email} after 0ms.
+        The following variables were pinned:
+          email = #{inspect(wrong_email)}
+        Process mailbox:
+          {:email, #{inspect(email)}}
+        """
+      )
+
     try do
-      wrong_email = new() |> subject("Wrong, Avengers!")
       assert_email_sent wrong_email
     rescue
       error in [ExUnit.AssertionError] ->
-        "No message matching {:email, ^email} after 0ms.\n" <>
-        "The following variables were pinned:\n" <>
-        "  email = %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: nil, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Wrong, Avengers!\", text_body: nil, to: []}\n" <>
-        "Process mailbox:\n" <>
-        "  {:email, %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}}"
-        = error.message
+        assert message == error.message
     end
   end
 
@@ -83,12 +91,13 @@ defmodule Swoosh.TestAssertionsTest do
   end
 
   test "assert email not sent with expected email", %{email: email} do
+    message = "Unexpectedly received message {:email, #{inspect(email)}} (which matched {:email, ^email})"
+
     try do
       assert_email_not_sent email
     rescue
       error in [ExUnit.AssertionError] ->
-        "Unexpectedly received message {:email, %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}} " <>
-        "(which matched {:email, ^email})" = error.message
+        assert message, error.message
     end
   end
 
@@ -99,13 +108,14 @@ defmodule Swoosh.TestAssertionsTest do
     assert_no_email_sent()
   end
 
-  test "assert no email sent when sending an email" do
+  test "assert no email sent when sending an email", %{email: email} do
+    message = "Unexpectedly received message {:email, #{inspect(email)} (which matched {:email, _})"
+
     try do
       assert_no_email_sent()
     rescue
       error in [ExUnit.AssertionError] ->
-        "Unexpectedly received message {:email, %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: {\"\", \"tony.stark@example.com\"}, headers: %{}, html_body: nil, private: %{}, provider_options: %{}, reply_to: nil, subject: \"Hello, Avengers!\", text_body: nil, to: [{\"\", \"steve.rogers@example.com\"}]}} " <>
-        "(which matched {:email, _})" = error.message
+        assert message, error.message
     end
   end
 end


### PR DESCRIPTION
While using swoosh I wanted to assert with a regex that a particular string was being sent in the html_body. Currently the only way I could make it work is:

```
    assert_received({:email, email})
    assert email.html_body =~ regex
```

While it kind of works it doesn't read so well so I'm proposing adding regexp support
so we will be able to do things like:

```
assert_email_sent(to: {"Bob", "example@example.com"}, text_body: ~r/Hi Bob!/)
```
edit: I updated the PR so it no longer has three new options and pattern matches the value on regex struct type instead