### PR TITLE
Added support for template_alias in Postmark adapter

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -56,6 +56,9 @@ defmodule Swoosh.Adapters.Postmark do
   defp api_endpoint(%{provider_options: %{template_id: _, template_model: _}}),
     do: @api_endpoint <> "/withTemplate"
 
+  defp api_endpoint(%{provider_options: %{template_alias: _, template_model: _}}),
+    do: @api_endpoint <> "/withTemplate"
+
   defp api_endpoint(_email), do: @api_endpoint
 
   defp prepare_body(email) do
@@ -125,6 +128,13 @@ defmodule Swoosh.Adapters.Postmark do
   #   "template_id"    => 123,
   #   "template_model" => %{"name": 1, "company": 2}
   # }
+  #
+  # Or, using template_alias
+  #
+  # %{
+  #   "template_alias" => "welcome",
+  #   "template_model" => %{"name": 1, "company": 2}
+  # }
   defp prepare_template(body, %{provider_options: provider_options}),
     do: Enum.reduce(provider_options, body, &put_in_body/2)
 
@@ -132,6 +142,7 @@ defmodule Swoosh.Adapters.Postmark do
 
   defp put_in_body({:template_model, val}, body_acc), do: Map.put(body_acc, "TemplateModel", val)
   defp put_in_body({:template_id, val}, body_acc), do: Map.put(body_acc, "TemplateId", val)
+  defp put_in_body({:template_alias, val}, body_acc), do: Map.put(body_acc, "TemplateAlias", val)
   defp put_in_body(_, body_acc), do: body_acc
 
   defp prepare_custom_headers(body, %{headers: headers}) when map_size(headers) == 0, do: body

--- a/test/integration/adapters/postmark_test.exs
+++ b/test/integration/adapters/postmark_test.exs
@@ -28,7 +28,7 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
     assert_ok_response(email, config)
   end
 
-  test "template deliver", %{valid_email: valid_email, config: config} do
+  test "template id deliver", %{valid_email: valid_email, config: config} do
     config = Keyword.put_new(config, :template, true)
     template_model = %{
       name: "Swoosh",
@@ -37,6 +37,20 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
     email =
       valid_email
       |> put_provider_option(:template_id, 990321)
+      |> put_provider_option(:template_model, template_model)
+
+    assert_ok_response(email, config)
+  end
+
+  test "template alias deliver", %{valid_email: valid_email, config: config} do
+    config = Keyword.put_new(config, :template, true)
+    template_model = %{
+      name: "Swoosh",
+      action_url: "Postmark",
+    }
+    email =
+      valid_email
+      |> put_provider_option(:template_alias, "welcome")
       |> put_provider_option(:template_model, template_model)
 
     assert_ok_response(email, config)

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -83,7 +83,7 @@ defmodule Swoosh.Adapters.PostmarkTest do
     assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
   end
 
-  test "delivery/1 with all fields for template returns :ok", %{bypass: bypass, config: config} do
+  test "delivery/1 with all fields for template id returns :ok", %{bypass: bypass, config: config} do
     config         = Keyword.merge(config, template: true)
     template_model = %{
       name:    "Tony Stark",
@@ -102,6 +102,41 @@ defmodule Swoosh.Adapters.PostmarkTest do
         "To"            => "avengers@example.com",
         "From"          => "\"T Stark\" <tony.stark@example.com>",
         "TemplateId"    => 1,
+        "TemplateModel" => %{
+          "company" => "Avengers",
+          "name"    => "Tony Stark",
+        }
+      }
+
+      assert body_params == conn.body_params
+      assert "/email/withTemplate" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end
+
+    assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
+  end
+
+  test "delivery/1 with all fields for template alias returns :ok", %{bypass: bypass, config: config} do
+    config         = Keyword.merge(config, template: true)
+    template_model = %{
+      name:    "Tony Stark",
+      company: "Avengers",
+    }
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to("avengers@example.com")
+      |> put_provider_option(:template_alias, "welcome")
+      |> put_provider_option(:template_model, template_model)
+
+    Bypass.expect bypass, fn conn ->
+      conn = parse(conn)
+      body_params = %{
+        "To"            => "avengers@example.com",
+        "From"          => "\"T Stark\" <tony.stark@example.com>",
+        "TemplateAlias" => "welcome",
         "TemplateModel" => %{
           "company" => "Avengers",
           "name"    => "Tony Stark",


### PR DESCRIPTION
Thanks for Swoosh!

I'd like to use Postmark's [TemplateAlias](https://postmarkapp.com/developer/api/templates-api#email-with-template) feature in order to use the same alias across different Postmark servers for different Mix environments (one server for dev, one server for prod for example).