### PR TITLE
Display provider_options in mailbox_viewer

### DIFF
--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -115,7 +115,13 @@
               <div class="header-content">
                 <dl class="dl-horizontal headers">
                   <dt class="col-sm-2">Subject</dt>
-                  <dd class="col-sm-10"><%= @email.subject %></dd>
+                  <dd class="col-sm-10">
+                    <%= if @email.subject == "" do %>
+                      <i>No subject</i>
+                    <% else %>
+                      <%= @email.subject %>
+                    <% end %>
+                  </dd>
 
                   <dt class="col-sm-2">From</dt>
                   <dd class="col-sm-10"><%= render_recipient(@email.from) %></dd>
@@ -135,6 +141,11 @@
                   <%= for {name, value} <- @email.headers do %>
                     <dt class="col-sm-2"><%= name %></dt>
                     <dd class="col-sm-10"><%= value %></dd>
+                  <% end %>
+
+                  <%= for {name, value} <- @email.provider_options do %>
+                    <dt class="col-sm-2"><%= name %></dt>
+                    <dd class="col-sm-10"><%= inspect(value) %></dd>
                   <% end %>
                 </dl>
               </div>


### PR DESCRIPTION
Also made sure that _some_ content renders for Subject. Without it, the `.col-sm-10` element will have zero height and the whole layout is broken.

This is how it looks now:

<img width="1043" alt="screen shot 2018-04-27 at 12 23 08 pm" src="https://user-images.githubusercontent.com/744493/39381152-f95202ae-4a15-11e8-84bd-e336aa85400c.png">
