### PR TITLE
Disable travis CI for branches other than master, in favor of PR tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ cache:
   directories:
     - _build
     - deps
+branches:
+  only:
+    - master
 elixir:
   - 1.4
   - 1.5


### PR DESCRIPTION
~Since we have this config turned on:~

~> **Require branches to be up to date before merging**~
~> This ensures the branch has been tested with the latest code on master.~

~It's redundant to test both a branch and a PR.~

Actually the above don't really relate.

This change has no effect on external contributors whatsoever, as their branches don't trick a branch test, only a PR test.
This only saves us maintainers from having to wait for twice (or more) the time on new PRs because of concurrent build limit.

caveat: this does mean that you have to send a WIP PR to kick off CI for you branches, but we test locally anyways.