### PR TITLE
Change to use extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Swoosh.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :hackney, :mime], mod: {Swoosh.Application, []}]
+    [extra_applications: [:logger], mod: {Swoosh.Application, []}]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
#242 

This feature was introduced in Elixir 1.4
And Swoosh does require "~> 1.4" 😄 