### PR TITLE
Decode SendGrid adapter 4xx response

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -38,7 +38,10 @@ defmodule Swoosh.Adapters.Sendgrid do
       {:ok, code, headers, _body} when code >= 200 and code <= 399 ->
         {:ok, %{id: extract_id(headers)}}
 
-      {:ok, code, _headers, body} when code > 399 ->
+      {:ok, code, _headers, body} when code > 399 and code <= 499 ->
+        {:error, {code, Swoosh.json_library().decode!(body)}}
+
+      {:ok, code, _headers, body} when code > 499 ->
         {:error, {code, body}}
 
       {:error, reason} ->


### PR DESCRIPTION
👋 Thanks for the library, it's very well put together.

In the [SendGrid API](https://sendgrid.com/docs/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/errors.html#-Failed-Requests) it provides error messages for fields, or even general messages but this is not decoded.
This pull request adds decoding for 4xx responses, so that when using the Sendgrid adapter, you can easily use the body from the response.