### PR TITLE
sendgrid - handlebar substitutions with dynamic_template_data

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -85,6 +85,7 @@ defmodule Swoosh.Adapters.Sendgrid do
       |> prepare_bcc(email)
       |> prepare_custom_vars(email)
       |> prepare_substitutions(email)
+      |> prepare_dynamic_template_data(email)
 
     Map.put(body, :personalizations, [personalizations])
   end
@@ -119,6 +120,14 @@ defmodule Swoosh.Adapters.Sendgrid do
   end
 
   defp prepare_substitutions(personalizations, _email), do: personalizations
+
+  defp prepare_dynamic_template_data(personalizations, %{
+         provider_options: %{dynamic_template_data: dynamic_template_data}
+       }) do
+    Map.put(personalizations, :dynamic_template_data, dynamic_template_data)
+  end
+
+  defp prepare_dynamic_template_data(personalizations, _email), do: personalizations
 
   defp prepare_subject(body, %{subject: subject}), do: Map.put(body, :subject, subject)
 

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -223,6 +223,35 @@ defmodule Swoosh.Adapters.SendgridTest do
     assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
+  test "delivery/1 with dynamic_template_data returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> put_provider_option(:dynamic_template_data, %{"name" => "Steve Rogers"})
+
+    Bypass.expect bypass, fn conn ->
+      conn = parse(conn)
+      body_params = %{"from" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
+                      "personalizations" => [%{
+                        "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}],
+                        "dynamic_template_data" => %{"name" => "Steve Rogers"}
+                      }],
+                      "content" => [%{"type" => "text/plain", "value" => "Hello"}, %{"type" => "text/html", "value" => "<h1>Hello</h1>"}],
+                      "subject" => "Hello, Avengers!"
+                    }
+      assert body_params == conn.body_params
+      assert "/mail/send" == conn.request_path
+      assert "POST" == conn.method
+
+      respond_with(conn, body: "{\"message\":\"success\"}", id: "123-xyz")
+    end
+    assert Sendgrid.deliver(email, config) == {:ok, %{id: "123-xyz"}}
+  end
+
   test "delivery/1 with custom headers returns :ok", %{bypass: bypass, config: config} do
     email =
       new()


### PR DESCRIPTION
## Intention
- according to [sendgrid api doc](https://dynamic-templates.api-docs.io/3.0/mail-send-with-dynamic-transactional-templates/v3-mail-send), for handlebar substitutions, request body should contain `dynamic_template_data` inside `personalizations` object