### PR TITLE
Improve TestAssertions

### DIFF
--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -78,14 +78,11 @@ defmodule Swoosh.TestAssertions do
   @doc ~S"""
   Asserts no emails were sent.
   """
-  @spec refute_email_sent() :: false | no_return
   defmacro refute_email_sent() do
     quote do
       refute_received {:email, _}
     end
   end
-
-  @spec refute_email_sent(keyword | Email.t() | map) :: false | no_return
 
   @doc ~S"""
   Asserts email with `attributes` was not sent.

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -13,6 +13,16 @@ defmodule Swoosh.TestAssertions do
   alias Swoosh.Email
 
   @doc ~S"""
+  Asserts any email was sent.
+  """
+  @spec assert_email_sent() :: true | no_return
+  def assert_email_sent do
+    assert_received {:email, _}
+  end
+
+  @spec assert_email_sent(Email.t() | map) :: true | no_return
+
+  @doc ~S"""
   Asserts `email` was sent.
 
   You pass a keyword list to match on specific params.
@@ -37,7 +47,7 @@ defmodule Swoosh.TestAssertions do
 
   def assert_email_sent(params) when is_list(params) do
     assert_received {:email, email}
-    Enum.each(params, fn param -> assert_equal(email, param) end)
+    Enum.each(params, &assert_equal(email, &1))
   end
 
   defp assert_equal(email, {:subject, value}), do: assert(email.subject == value)
@@ -66,16 +76,82 @@ defmodule Swoosh.TestAssertions do
   defp assert_equal(email, {:html_body, value}), do: assert(email.html_body == value)
 
   @doc ~S"""
-  Asserts `email` was not sent.
+  Asserts no emails were sent.
   """
-  def assert_email_not_sent(email) do
-    refute_received {:email, ^email}
+  @spec refute_email_sent() :: false | no_return
+  defmacro refute_email_sent() do
+    quote do
+      refute_received {:email, _}
+    end
+  end
+
+  @spec refute_email_sent(keyword | Email.t() | map) :: false | no_return
+
+  @doc ~S"""
+  Asserts email with `attributes` was not sent.
+
+  It will convert list fields (`:to`, `:cc`, `:bcc`) to a single element list if a single value is
+  given (`to: "email@example.com"` => `to: ["email@example.com"]`).
+
+  After conversion, performs pattern matching using a map of email attributes, similar to
+  `%{attributes...} = email`.
+  """
+  defmacro refute_email_sent(attributes) when is_list(attributes) do
+    expr = attributes |> email_pattern() |> Macro.escape()
+
+    quote do
+      refute_email_sent(unquote(expr))
+    end
+  end
+
+  @doc ~S"""
+  Asserts email matching `pattern` was not sent.
+
+  Performs pattern matching using the given pattern, equivalent to `pattern = email`.
+  """
+  defmacro refute_email_sent(pattern) do
+    quote do
+      refute_received {:email, unquote(pattern)}
+    end
+  end
+
+  defp email_pattern(attributes) when is_list(attributes) do
+    Enum.reduce(attributes, %{}, &email_pattern(&2, &1))
+  end
+
+  defp email_pattern(%{} = pattern, {key, value}) when key in [:from, :reply_to] do
+    Map.put(pattern, key, format_recipient(value))
+  end
+
+  defp email_pattern(%{} = pattern, {key, value}) when key in [:to, :cc, :bcc] do
+    value =
+      case value do
+        addresses when is_list(addresses) -> value
+        address -> [address]
+      end
+
+    Map.put(pattern, key, Enum.map(value, &format_recipient/1))
+  end
+
+  defp email_pattern(%{} = pattern, {key, value}) do
+    Map.put(pattern, key, value)
   end
 
   @doc ~S"""
   Asserts no emails were sent.
   """
+  @spec assert_no_email_sent() :: false | no_return
   def assert_no_email_sent() do
-    refute_received {:email, _}
+    refute_email_sent()
+  end
+
+  @doc ~S"""
+  Asserts `email` was not sent.
+
+  Performs exact matching of the email struct.
+  """
+  @spec assert_email_not_sent(Email.t()) :: false | no_return
+  def assert_email_not_sent(%Email{} = email) do
+    refute_email_sent(^email)
   end
 end

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -124,13 +124,7 @@ defmodule Swoosh.TestAssertions do
   end
 
   defp email_pattern(%{} = pattern, {key, value}) when key in [:to, :cc, :bcc] do
-    value =
-      case value do
-        addresses when is_list(addresses) -> value
-        address -> [address]
-      end
-
-    Map.put(pattern, key, Enum.map(value, &format_recipient/1))
+    Map.put(pattern, key, value |> List.wrap() |> Enum.map(&format_recipient/1))
   end
 
   defp email_pattern(%{} = pattern, {key, value}) do

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -4,68 +4,90 @@ defmodule Swoosh.TestAssertionsTest do
   import Swoosh.Email
   import Swoosh.TestAssertions
 
+  defp deliver(%Swoosh.Email{} = email) do
+    {:ok, _} = Swoosh.Adapters.Test.deliver(email, nil)
+    email
+  end
+
   setup do
     email =
       new()
       |> from("tony.stark@example.com")
-      |> to("steve.rogers@example.com")
+      |> reply_to("bruce.banner@example.com")
+      |> to(["steve.rogers@example.com", "bruce.banner@example.com"])
+      |> cc(["natasha.romanoff@example.com", "stephen.strange@example.com"])
+      |> bcc("loki.odinson@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("some html")
       |> text_body("some text")
+      |> deliver()
 
-    Swoosh.Adapters.Test.deliver(email, nil)
     {:ok, email: email}
   end
 
+  test "assert any email sent" do
+    assert_email_sent()
+  end
+
+  test "assert any email sent with no emails sent" do
+    receive do
+      _ -> nil
+    end
+
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_email_sent()
+    end
+  end
+
   test "assert email sent with correct email", %{email: email} do
-    assert_email_sent email
+    assert_email_sent(email)
   end
 
   test "assert email sent with some content matched by a regex" do
-    assert_email_sent text_body: ~r/some text/, html_body: ~r/html$/
+    assert_email_sent(text_body: ~r/some text/, html_body: ~r/html$/)
   end
 
   test "assert email sent with specific params" do
-    assert_email_sent [subject: "Hello, Avengers!", to: "steve.rogers@example.com"]
+    assert_email_sent(subject: "Hello, Avengers!", to: "steve.rogers@example.com")
   end
 
   test "assert email sent with specific to (list)" do
-    assert_email_sent [to: ["steve.rogers@example.com"]]
+    assert_email_sent(to: ["steve.rogers@example.com", "bruce.banner@example.com"])
   end
 
   test "assert email sent with wrong subject" do
     assert_raise ExUnit.AssertionError, fn ->
-      assert_email_sent [subject: "Hello, X-Men!"]
+      assert_email_sent(subject: "Hello, X-Men!")
     end
   end
 
   test "assert email sent with wrong from" do
     assert_raise ExUnit.AssertionError, fn ->
-      assert_email_sent [from: "thor.odinson@example.com"]
+      assert_email_sent(from: "thor.odinson@example.com")
     end
   end
 
   test "assert email sent with wrong to" do
     assert_raise ExUnit.AssertionError, fn ->
-      assert_email_sent [to: "bruce.banner@example.com"]
+      assert_email_sent(to: "loki.odinson@example.com")
     end
   end
 
   test "assert email sent with wrong to (list)" do
     assert_raise ExUnit.AssertionError, fn ->
-      assert_email_sent [to: ["bruce.banner@example.com"]]
+      assert_email_sent(to: ["steve.rogers@example.com"])
     end
   end
 
   test "assert email sent with wrong cc" do
     assert_raise ExUnit.AssertionError, fn ->
-      assert_email_sent [cc: "bruce.banner@example.com"]
+      assert_email_sent(cc: "bruce.banner@example.com")
     end
   end
 
   test "assert email sent with wrong bcc" do
     assert_raise ExUnit.AssertionError, fn ->
-      assert_email_sent [bcc: "bruce.banner@example.com"]
+      assert_email_sent(bcc: "bruce.banner@example.com")
     end
   end
 
@@ -73,18 +95,16 @@ defmodule Swoosh.TestAssertionsTest do
     wrong_email = new() |> subject("Wrong, Avengers!")
 
     message =
-      String.trim(
-        """
-        No message matching {:email, ^email} after 0ms.
-        The following variables were pinned:
-          email = #{inspect(wrong_email)}
-        Process mailbox:
-          {:email, #{inspect(email)}}
-        """
-      )
+      String.trim("""
+      No message matching {:email, ^email} after 0ms.
+      The following variables were pinned:
+        email = #{inspect(wrong_email)}
+      Process mailbox:
+        {:email, #{inspect(email)}}
+      """)
 
     try do
-      assert_email_sent wrong_email
+      assert_email_sent(wrong_email)
     rescue
       error in [ExUnit.AssertionError] ->
         assert message == error.message
@@ -93,14 +113,15 @@ defmodule Swoosh.TestAssertionsTest do
 
   test "assert email not sent with unexpected email" do
     unexpected_email = new() |> subject("Testing Avenger")
-    assert_email_not_sent unexpected_email
+    assert_email_not_sent(unexpected_email)
   end
 
   test "assert email not sent with expected email", %{email: email} do
-    message = "Unexpectedly received message {:email, #{inspect(email)}} (which matched {:email, ^email})"
+    message =
+      "Unexpectedly received message {:email, #{inspect(email)}} (which matched {:email, ^email})"
 
     try do
-      assert_email_not_sent email
+      assert_email_not_sent(email)
     rescue
       error in [ExUnit.AssertionError] ->
         assert message, error.message
@@ -111,17 +132,187 @@ defmodule Swoosh.TestAssertionsTest do
     receive do
       _ -> nil
     end
+
     assert_no_email_sent()
   end
 
+  test "assert no email sent with email sent" do
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_no_email_sent()
+    end
+  end
+
   test "assert no email sent when sending an email", %{email: email} do
-    message = "Unexpectedly received message {:email, #{inspect(email)} (which matched {:email, _})"
+    message =
+      "Unexpectedly received message {:email, #{inspect(email)} (which matched {:email, _})"
 
     try do
       assert_no_email_sent()
     rescue
       error in [ExUnit.AssertionError] ->
         assert message, error.message
+    end
+  end
+
+  test "refute email sent" do
+    receive do
+      _ -> nil
+    end
+
+    refute_email_sent()
+  end
+
+  test "refute email sent with email sent" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent()
+    end
+  end
+
+  test "refute email sent with unexpected email" do
+    unexpected_email = new() |> subject("Testing Avenger")
+    refute_email_sent(^unexpected_email)
+  end
+
+  test "refute email sent with expected email", %{email: email} do
+    message =
+      "Unexpectedly received message {:email, #{inspect(email)}} (which matched {:email, ^email})"
+
+    try do
+      refute_email_sent(^email)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert message, error.message
+    end
+  end
+
+  test "refute email sent with specific params" do
+    refute_email_sent(subject: "Good bye, Avengers!", to: "steve.rogers@example.com")
+  end
+
+  test "refute email sent with expected params" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(
+        subject: "Hello, Avengers!",
+        to: ["steve.rogers@example.com", "bruce.banner@example.com"]
+      )
+    end
+  end
+
+  test "refute email sent with specific from" do
+    refute_email_sent(from: "steve.rogers@example.com")
+  end
+
+  test "refute email sent with expected from" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(from: "tony.stark@example.com")
+    end
+  end
+
+  test "refute email sent with specific reply to" do
+    refute_email_sent(reply_to: "steve.rogers@example.com")
+  end
+
+  test "refute email sent with expected reply to" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(reply_to: "bruce.banner@example.com")
+    end
+  end
+
+  test "refute email sent with specific to" do
+    refute_email_sent(to: "steve.rogers@example.com")
+  end
+
+  test "refute email sent with specific to (list)" do
+    refute_email_sent(to: ["steve.rogers@example.com"])
+  end
+
+  test "refute email sent with expected to" do
+    assert_email_sent(to: ["steve.rogers@example.com", "bruce.banner@example.com"])
+
+    deliver(new(to: "steve.rogers@example.com"))
+
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(to: "steve.rogers@example.com")
+    end
+  end
+
+  test "refute email sent with expected to (list)" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(to: ["steve.rogers@example.com", "bruce.banner@example.com"])
+    end
+  end
+
+  test "refute email sent with specific cc" do
+    refute_email_sent(cc: "natasha.romanoff@example.com")
+  end
+
+  test "refute email sent with specific cc (list)" do
+    refute_email_sent(cc: ["natasha.romanoff@example.com"])
+  end
+
+  test "refute email sent with expected cc" do
+    assert_email_sent(cc: ["natasha.romanoff@example.com", "stephen.strange@example.com"])
+
+    deliver(new(cc: "natasha.romanoff@example.com"))
+
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(cc: "natasha.romanoff@example.com")
+    end
+  end
+
+  test "refute email sent with expected cc (list)" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(cc: ["natasha.romanoff@example.com", "stephen.strange@example.com"])
+    end
+  end
+
+  test "refute email sent with specific bcc" do
+    refute_email_sent(bcc: "steve.rogers@example.com")
+  end
+
+  test "refute email sent with specific bcc (list)" do
+    refute_email_sent(bcc: ["steve.rogers@example.com"])
+  end
+
+  test "refute email sent with expected bcc" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(bcc: "loki.odinson@example.com")
+    end
+  end
+
+  test "refute email sent with expected bcc (list)" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(bcc: ["loki.odinson@example.com"])
+    end
+  end
+
+  test "refute email sent with specific subject" do
+    refute_email_sent(subject: "Hello, League!")
+  end
+
+  test "refute email sent with expected subject" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(subject: "Hello, Avengers!")
+    end
+  end
+
+  test "refute email sent with specific text body" do
+    refute_email_sent(text_body: "some html")
+  end
+
+  test "refute email sent with expected text body" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(text_body: "some text")
+    end
+  end
+
+  test "refute email sent with specific html body" do
+    refute_email_sent(html_body: "some text")
+  end
+
+  test "refute email sent with expected html body" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(html_body: "some html")
     end
   end
 end


### PR DESCRIPTION
This fixes #274.

Changes:

* added `assert_email_sent/0` that asserts any email was sent
* added `refute_email_sent/0` (macro) that asserts no email was sent ("alias" of `assert_no_email_sent/0`)
* added `refute_email_sent/1` (macro)

Besides implementing the simple pattern matching with `refute_email_sent(pattern)` - which requires exact matching on inner data structures - I took the opportunity to also add a `refute_email_sent(attributes)` version that creates a pattern (a Map) that automatically converts single values to single element lists while formatting the addresses (`to: "email@example.com"` becomes `to: [{"", "email@example.com"}]`).

Some notes:

* `mix format` changed several lines
* added `@spec`s
* added a stricter pattern matching on `assert_email_not_sent/1` (since it pins the `email` variable, it only works with actual `Email` structs - any other value can be a false positive - so it seems clearer if it accepts only `Email` structs)
* added more test cases for `assert_no_email_sent/0`