### PR TITLE
Add support for AWS SES tags

### DIFF
--- a/test/swoosh/adapters/amazonses_test.exs
+++ b/test/swoosh/adapters/amazonses_test.exs
@@ -127,7 +127,7 @@ defmodule Swoosh.Adapters.AmazonSESTest do
       }
 
       assert body_params["Action"] == conn.body_params["Action"]
-      assert body_params["Version"] == conn.body_params[" Version"]
+      assert body_params["Version"] == conn.body_params["Version"]
       assert expected_path == conn.request_path
       assert "POST" == conn.method
 

--- a/test/swoosh/adapters/amazonses_test.exs
+++ b/test/swoosh/adapters/amazonses_test.exs
@@ -60,8 +60,8 @@ defmodule Swoosh.Adapters.AmazonSESTest do
         "Action" => "SendRawEmail",
         "Version" => "2010-12-01",
       }
-      assert body_params[:Action] == conn.body_params[:Action]
-      assert body_params[:Version] == conn.body_params[:Version]
+      assert body_params["Action"] == conn.body_params["Action"]
+      assert body_params["Version"] == conn.body_params["Version"]
       assert expected_path == conn.request_path
       assert "POST" == conn.method
 
@@ -92,9 +92,9 @@ defmodule Swoosh.Adapters.AmazonSESTest do
         "Version" => "2010-12-01",
         "ConfigurationSetName" => "configuration_set_name1"
       }
-      assert body_params[:Action] == conn.body_params[:Action]
-      assert body_params[:Version] == conn.body_params[:Version]
-      assert body_params[:ConfigurationSetName] == conn.body_params[:ConfigurationSetName]
+      assert body_params["Action"] == conn.body_params["Action"]
+      assert body_params["Version"] == conn.body_params["Version"]
+      assert body_params["ConfigurationSetName"] == conn.body_params["ConfigurationSetName"]
       assert expected_path == conn.request_path
       assert "POST" == conn.method
 
@@ -126,8 +126,8 @@ defmodule Swoosh.Adapters.AmazonSESTest do
         "Version" => "2010-12-01",
       }
 
-      assert body_params[:Action] == conn.body_params[:Action]
-      assert body_params[:Version] == conn.body_params[:Version]
+      assert body_params["Action"] == conn.body_params["Action"]
+      assert body_params["Version"] == conn.body_params[" Version"]
       assert expected_path == conn.request_path
       assert "POST" == conn.method
 

--- a/test/swoosh/adapters/amazonses_test.exs
+++ b/test/swoosh/adapters/amazonses_test.exs
@@ -72,7 +72,6 @@ defmodule Swoosh.Adapters.AmazonSESTest do
   end
 
   test "a sent email with tags results in :ok", %{bypass: bypass, config: config} do
-
     email =
       new()
       |> from("guybrush.threepwood@pirates.grog")

--- a/test/swoosh/adapters/amazonses_test.exs
+++ b/test/swoosh/adapters/amazonses_test.exs
@@ -85,15 +85,19 @@ defmodule Swoosh.Adapters.AmazonSESTest do
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
       expected_path = "/"
-
       body_params = %{
         "Action" => "SendRawEmail",
         "Version" => "2010-12-01",
-        "ConfigurationSetName" => "configuration_set_name1"
+        "ConfigurationSetName" => "configuration_set_name1",
+        "Tags.member.1.Name" => "name1",
+        "Tags.member.1.Value" => "test1"
       }
+
       assert body_params["Action"] == conn.body_params["Action"]
       assert body_params["Version"] == conn.body_params["Version"]
       assert body_params["ConfigurationSetName"] == conn.body_params["ConfigurationSetName"]
+      assert body_params["Tags.member.1.Name"] == conn.body_params["Tags.member.1.Name"]
+      assert body_params["Tags.member.1.Value"] == conn.body_params["Tags.member.1.Value"]
       assert expected_path == conn.request_path
       assert "POST" == conn.method
 

--- a/test/swoosh/adapters/amazonses_test.exs
+++ b/test/swoosh/adapters/amazonses_test.exs
@@ -71,6 +71,39 @@ defmodule Swoosh.Adapters.AmazonSESTest do
     assert AmazonSES.deliver(email, config) == {:ok, %{id: "messageId", request_id: "requestId"}}
   end
 
+  test "a sent email with tags results in :ok", %{bypass: bypass, config: config} do
+
+    email =
+      new()
+      |> from("guybrush.threepwood@pirates.grog")
+      |> to("elaine.marley@triisland.gov")
+      |> subject("Mighty Pirate Newsletter")
+      |> text_body("Hello")
+      |> html_body("<h1>Hello</h1>")
+      |> put_provider_option(:tags, [%{name: "name1", value: "test1"}])
+      |> put_provider_option(:configuration_set_name, "configuration_set_name1")
+
+    Bypass.expect bypass, fn conn ->
+      conn = parse(conn)
+      expected_path = "/"
+
+      body_params = %{
+        "Action" => "SendRawEmail",
+        "Version" => "2010-12-01",
+        "ConfigurationSetName" => "configuration_set_name1"
+      }
+      assert body_params[:Action] == conn.body_params[:Action]
+      assert body_params[:Version] == conn.body_params[:Version]
+      assert body_params[:ConfigurationSetName] == conn.body_params[:ConfigurationSetName]
+      assert expected_path == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end
+
+    assert AmazonSES.deliver(email, config) == {:ok, %{id: "messageId", request_id: "requestId"}}
+  end
+
   test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
     email =
       new()


### PR DESCRIPTION
See: https://docs.aws.amazon.com/ses/latest/APIReference/API_MessageTag.html

Closed: https://github.com/swoosh/swoosh/issues/282