### PR TITLE
Store attachment content in Memory when using local adapter

### DIFF
--- a/lib/swoosh/adapters/local/storage/memory.ex
+++ b/lib/swoosh/adapters/local/storage/memory.ex
@@ -120,9 +120,10 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
     id = :crypto.strong_rand_bytes(16) |> Base.encode16() |> String.downcase()
     email = email |> Swoosh.Email.header("Message-ID", id)
 
-    attachments_with_data = email.attachments |> Enum.map(fn(attachment) -> 
-      %{attachment | data: Swoosh.Attachment.get_content(attachment)}
-    end)
+    attachments_with_data =
+      Enum.map(email.attachments, fn attachment -> 
+        %{attachment | data: Swoosh.Attachment.get_content(attachment)}
+      end)
     
     email = %{email | attachments: attachments_with_data}
     {:reply, email, [email | emails]}

--- a/lib/swoosh/adapters/local/storage/memory.ex
+++ b/lib/swoosh/adapters/local/storage/memory.ex
@@ -119,6 +119,12 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
   def handle_call({:push, email}, _from, emails) do
     id = :crypto.strong_rand_bytes(16) |> Base.encode16() |> String.downcase()
     email = email |> Swoosh.Email.header("Message-ID", id)
+
+    attachments_with_data = email.attachments |> Enum.map(fn(attachment) -> 
+      %{attachment | data: Swoosh.Attachment.get_content(attachment)}
+    end)
+    
+    email = %{email | attachments: attachments_with_data}
     {:reply, email, [email | emails]}
   end
 


### PR DESCRIPTION
I've been playing with the Test adapter and found this issue #258.

This should resolve it, by embedding the raw data of the attachment in the `Genserver` "storage".
I didn't convert to `:base64` to keep compatible with the rendering side where it doesn't decode: https://github.com/swoosh/swoosh/blob/e3beba436797850ceb664ceee8d5178487a82617/lib/plug/mailbox_preview.ex#L73-L76

Please let me know if you need any changes made.