### PR TITLE
Multi-server support for local adapter

### DIFF
--- a/lib/swoosh/adapters/local/storage/memory.ex
+++ b/lib/swoosh/adapters/local/storage/memory.ex
@@ -13,14 +13,14 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
   Starts the server
   """
   def start_link() do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    GenServer.start_link(__MODULE__, [], name: {:global, __MODULE__})
   end
 
   @doc """
   Stops the server
   """
   def stop() do
-    GenServer.stop(__MODULE__)
+    GenServer.stop({:global, __MODULE__})
   end
 
   @doc ~S"""
@@ -37,7 +37,7 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
       %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
   """
   def push(email) do
-    GenServer.call(__MODULE__, {:push, email})
+    GenServer.call({:global, __MODULE__}, {:push, email})
   end
 
   @doc ~S"""
@@ -57,7 +57,7 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
       0
   """
   def pop() do
-    GenServer.call(__MODULE__, :pop)
+    GenServer.call({:global, __MODULE__}, :pop)
   end
 
   @doc ~S"""
@@ -73,7 +73,7 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
       %Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}
   """
   def get(id) do
-    GenServer.call(__MODULE__, {:get, id})
+    GenServer.call({:global, __MODULE__}, {:get, id})
   end
 
   @doc ~S"""
@@ -89,7 +89,7 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
       [%Swoosh.Email{from: {"", "tony.stark@example.com"}, headers: %{"Message-ID": "a1b2c3"}, [...]}]
   """
   def all() do
-    GenServer.call(__MODULE__, :all)
+    GenServer.call({:global, __MODULE__}, :all)
   end
 
   @doc ~S"""
@@ -107,7 +107,7 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
       []
   """
   def delete_all() do
-    GenServer.call(__MODULE__, :delete_all)
+    GenServer.call({:global, __MODULE__}, :delete_all)
   end
 
   # Callbacks

--- a/lib/swoosh/adapters/local/storage/memory.ex
+++ b/lib/swoosh/adapters/local/storage/memory.ex
@@ -13,7 +13,13 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
   Starts the server
   """
   def start_link() do
-    GenServer.start_link(__MODULE__, [], name: {:global, __MODULE__})
+    case GenServer.start_link(__MODULE__, [], name: {:global, __MODULE__}) do
+      {:ok, pid} ->
+        {:ok, pid}
+      {:error, {:already_started, pid}} ->
+        Process.link(pid)
+        {:ok, pid}
+    end
   end
 
   @doc """


### PR DESCRIPTION
Thought it would be most clear to just show the diff for the best solution we came up with for a problem we are encountering to see if it could be merged. To my knowledge there is not much downside to doing this but would enable supporting development environments that have multiple app instances running (like ours in order to closely match our multi-server production environment).

The problem is in a two server environment there will be two instances of `Swoosh.Adapters.Local.Storage.Memory` and viewing the dev mailbox there will not list the full list of emails and when click on an email to view it there's a 50% it will go to the wrong server and not show the email.

Some other things we tried to avoid changes to Swoosh:

- **Direct all /dev/mailbox traffic to one app server** - Any app server can deliver emails so half of emails would be missed
- **Provide our own Adapter.Local** - This alone is not sufficient it seems since `mailbox_preview.ex` directly uses the `storage_driver || Local.Storage.Memory` so any adapter we provide in the configuration would also have to interact with this. Also since Memory generates a random ID we can't just have an Adapter.Local that merely calls all nodes' Local.Storage.Memory.push().
- **Provide our own `storage_driver`** - There are a few API calls to support (push, delete_all, get, all, not sure if pop() is actually used) but most of them are straightforward except push. Push seems to have some logic around ID headers and attachments that I'm not sure it would be great to just copy/paste.