### PR TITLE
Allow preview server to start when using plug cowboy version 2

### DIFF
--- a/lib/swoosh/application.ex
+++ b/lib/swoosh/application.ex
@@ -19,7 +19,7 @@ defmodule Swoosh.Application do
         case {cowboy, plug} do
           {{:ok, _}, {:ok, _}} ->
             Logger.info("Running Swoosh mailbox preview server with Cowboy using http on port #{port}")
-            [Plug.Adapters.Cowboy.child_spec(scheme: :http, plug: Plug.Swoosh.MailboxPreview, options: [port: port]) | children]
+            [Plug.Cowboy.child_spec(scheme: :http, plug: Plug.Swoosh.MailboxPreview, options: [port: port]) | children]
           _ ->
             Logger.warn("Could not start preview server on port #{port}. Please ensure plug and cowboy" <>
               " are in your dependency list.")

--- a/lib/swoosh/application.ex
+++ b/lib/swoosh/application.ex
@@ -19,7 +19,7 @@ defmodule Swoosh.Application do
         case {cowboy, plug} do
           {{:ok, _}, {:ok, _}} ->
             Logger.info("Running Swoosh mailbox preview server with Cowboy using http on port #{port}")
-            [Plug.Adapters.Cowboy.child_spec(:http, Plug.Swoosh.MailboxPreview, [], port: port) | children]
+            [Plug.Adapters.Cowboy.child_spec(scheme: :http, plug: Plug.Swoosh.MailboxPreview, options: [port: port]) | children]
           _ ->
             Logger.warn("Could not start preview server on port #{port}. Please ensure plug and cowboy" <>
               " are in your dependency list.")

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Swoosh.Mixfile do
       {:jason, "~> 1.0"},
       {:gen_smtp, "~> 0.12", optional: true},
       {:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", optional: true},
-      {:plug, "~> 1.4", optional: true},
+      {:plug_cowboy, ">= 1.0.0", optional: true},
       {:bypass, "~> 1.0", only: :test},
       {:ex_doc, "~> 0.16", only: :docs, runtime: false},
       {:inch_ex, ">= 0.0.0", only: :docs}


### PR DESCRIPTION
`Plug.Adapters.Cowboy` has been deprecated and replaces with the `plug_cowboy` package.

If `plug_cowboy` version 2.0.0 or higher is installed, the preview server will not start because `child_spec/4` has been removed.

This changes the optional dependency to use the `plug_cowboy` package (which will indirectly require plug), and changes to using the `child_spec/1` function which is available in both versions 1 and 2 of `plug_cowboy`