### PR TITLE
Update smtp.ex

### DIFF
--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -59,7 +59,7 @@ defmodule Swoosh.Adapters.SMTP do
     retries: &String.to_integer/1,
     ssl: {&String.to_atom/1, [true, false]},
     tls: {&String.to_atom/1, [:always, :never, :if_available]},
-    auth: {&String.to_atom/1, [:always, :if_available]},
+    auth: {&String.to_atom/1, [:always, :never, :if_available]},
     no_mx_lookups: {&String.to_atom/1, [true, false]}
   }
   @config_keys Map.keys(@config_transformations)

--- a/test/swoosh/adapters/smtp_test.exs
+++ b/test/swoosh/adapters/smtp_test.exs
@@ -59,7 +59,7 @@ defmodule Swoosh.Adapters.SMTPTest do
     assert_raise ArgumentError, """
     auth is not configured properly,
     got: INVALID, expected one of the followings:
-    :always, :if_available
+    :always, :never, :if_available
     """, fn ->
       SMTP.deliver(@email, [auth: "INVALID"])
     end


### PR DESCRIPTION
https://github.com/Vagabond/gen_smtp/blob/master/src/gen_smtp_client.erl#L363

Indeed `:auth` can be `:never`.

close #364 

@h4cc would simply removing the username and password in the config work for you as a solution to the other half of the issue?