### PR TITLE
bump gen_smtp version to work with erlang 21, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ end
     def deps do
       [
         {:swoosh, "~> 0.23"},
-        {:gen_smtp, "~> 0.12"}
+        {:gen_smtp, "~> 0.13"}
       ]
     end
     ```

--- a/lib/swoosh/adapters/amazon_ses.ex
+++ b/lib/swoosh/adapters/amazon_ses.ex
@@ -17,7 +17,7 @@ defmodule Swoosh.Adapters.AmazonSES do
 
       def deps do
         [{:swoosh, "~> 0.10.0"},
-         {:gen_smtp, "~> 0.12.0"}]
+         {:gen_smtp, "~> 0.13.0"}]
       end
 
   See Also:

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Swoosh.Mixfile do
       {:hackney, "~> 1.9"},
       {:mime, "~> 1.1"},
       {:jason, "~> 1.0"},
-      {:gen_smtp, "~> 0.12", optional: true},
+      {:gen_smtp, "~> 0.13", optional: true},
       {:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", optional: true},
       {:plug_cowboy, ">= 1.0.0", optional: true},
       {:bypass, "~> 1.0", only: :test},


### PR DESCRIPTION
#314 
