### PR TITLE
Add documentation for :preview_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ config :sample, Mailer,
   adapter: Swoosh.Adapters.Local
   
 # to change the preview server port
-# config :swoosh, preview_port: 4001
+config :swoosh, preview_port: 4001
 ```
 
 Then, use the Mix task to start the mailbox preview server

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ For email to reach this mailbox you will need to set your `Mailer` adapter to `S
 # in config/dev.exs
 config :sample, Mailer,
   adapter: Swoosh.Adapters.Local
+  
+# to change the preview server port
+# config :swoosh, preview_port: 4001
 ```
 
 Then, use the Mix task to start the mailbox preview server


### PR DESCRIPTION
Changing the preview port is not mentioned in any of the swoosh documentation here or on hex. This took me a while to dig up. Hopefully it will save others time in the future.