### PR TITLE
Add mailjet error delivery config

### DIFF
--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -79,7 +79,7 @@ defmodule Swoosh.Adapters.Mailjet do
     |> prepare_reply_to(email)
     |> prepare_attachments(email)
     |> prepare_variables(email)
-    |> prepare_template_id(email)
+    |> prepare_template(email)
     |> prepare_custom_headers(email)
     |> wrap_into_messages
     |> Swoosh.json_library.encode!()
@@ -139,13 +139,13 @@ defmodule Swoosh.Adapters.Mailjet do
 
   defp prepare_variables(body, _email), do: body
 
-  defp prepare_template_id(body, %{provider_options: %{template_id: template_id} = provider_options}) do
+  defp prepare_template(body, %{provider_options: %{template_id: template_id} = provider_options}) do
     body
     |> Map.put("TemplateID", template_id)
     |> Map.put("TemplateLanguage", true)
-    |> Map.put("TemplateErrorDeliver", provider_options[:template_error_deliver])
+    |> Map.put("TemplateErrorDeliver", !!provider_options[:template_error_deliver])
     |> Map.put("TemplateErrorReporting", provider_options[:template_error_reporting])
   end
 
-  defp prepare_template_id(body, _email), do: body
+  defp prepare_template(body, _email), do: body
 end

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -139,10 +139,12 @@ defmodule Swoosh.Adapters.Mailjet do
 
   defp prepare_variables(body, _email), do: body
 
-  defp prepare_template_id(body, %{provider_options: %{template_id: template_id}}) do
+  defp prepare_template_id(body, %{provider_options: %{template_id: template_id} = provider_options}) do
     body
     |> Map.put("TemplateID", template_id)
     |> Map.put("TemplateLanguage", true)
+    |> Map.put("TemplateErrorDeliver", provider_options.template_error_deliver)
+    |> Map.put("TemplateErrorReporting", provider_options.template_error_reporting)
   end
 
   defp prepare_template_id(body, _email), do: body

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -144,7 +144,9 @@ defmodule Swoosh.Adapters.Mailjet do
     |> Map.put("TemplateID", template_id)
     |> Map.put("TemplateLanguage", true)
     |> Map.put("TemplateErrorDeliver", !!provider_options[:template_error_deliver])
-    |> Map.put("TemplateErrorReporting", Swoosh.Email.Format.format_recipient(provider_options[:template_error_reporting]))
+    |> Map.put("TemplateErrorReporting", prepare_recipient(
+      Swoosh.Email.Format.format_recipient(provider_options[:template_error_reporting]))
+    )
   end
 
   defp prepare_template(body, _email), do: body

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -143,8 +143,8 @@ defmodule Swoosh.Adapters.Mailjet do
     body
     |> Map.put("TemplateID", template_id)
     |> Map.put("TemplateLanguage", true)
-    |> Map.put("TemplateErrorDeliver", provider_options.template_error_deliver)
-    |> Map.put("TemplateErrorReporting", provider_options.template_error_reporting)
+    |> Map.put("TemplateErrorDeliver", provider_options[:template_error_deliver])
+    |> Map.put("TemplateErrorReporting", provider_options[:template_error_reporting])
   end
 
   defp prepare_template_id(body, _email), do: body

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -144,7 +144,7 @@ defmodule Swoosh.Adapters.Mailjet do
     |> Map.put("TemplateID", template_id)
     |> Map.put("TemplateLanguage", true)
     |> Map.put("TemplateErrorDeliver", !!provider_options[:template_error_deliver])
-    |> Map.put("TemplateErrorReporting", provider_options[:template_error_reporting])
+    |> Map.put("TemplateErrorReporting", Swoosh.Email.Format.format_recipient(provider_options[:template_error_reporting]))
   end
 
   defp prepare_template(body, _email), do: body

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -144,9 +144,10 @@ defmodule Swoosh.Adapters.Mailjet do
     |> Map.put("TemplateID", template_id)
     |> Map.put("TemplateLanguage", true)
     |> Map.put("TemplateErrorDeliver", !!provider_options[:template_error_deliver])
-    |> Map.put("TemplateErrorReporting", prepare_recipient(
-      Swoosh.Email.Format.format_recipient(provider_options[:template_error_reporting]))
-    )
+    |> Map.put("TemplateErrorReporting", if provider_options[:template_error_reporting], do:
+      prepare_recipient(
+        Swoosh.Email.Format.format_recipient(provider_options[:template_error_reporting]))
+      )
   end
 
   defp prepare_template(body, _email), do: body

--- a/test/swoosh/adapters/mailjet_test.exs
+++ b/test/swoosh/adapters/mailjet_test.exs
@@ -112,6 +112,11 @@ defmodule Swoosh.Adapters.MailjetTest do
             "Subject" => "Hello, world!",
             "TemplateID" => "template id",
             "TemplateLanguage" => true,
+            "TemplateErrorDeliver" => true,
+            "TemplateErrorReporting" => %{
+              "Email" => "developer@example.com",
+              "Name" => ""
+            },
             "Variables" => %{
               "firstname" => "Pan",
               "lastname" => "Michal"
@@ -132,6 +137,8 @@ defmodule Swoosh.Adapters.MailjetTest do
       email
       |> put_provider_option(:variables, %{firstname: "Pan", lastname: "Michal"})
       |> put_provider_option(:template_id, "template id")
+      |> put_provider_option(:template_error_deliver, true)
+      |> put_provider_option(:template_error_reporting, "developer@example.com")
 
     assert Mailjet.deliver(email, config) == {:ok, %{id: 123_456_789}}
   end


### PR DESCRIPTION
Add `TemplateErrorDeliver` and `TemplateErrorReporting` `provider_options` to mailjet