### PR TITLE
Add postmark tag

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -32,6 +32,18 @@ defmodule Swoosh.Adapters.Postmark do
   You can also use `template_alias` instead of `template_id`, if you use Postmark's
   [TemplateAlias](https://postmarkapp.com/developer/api/templates-api#email-with-template)
   feature.
+
+  ## Example of sending emails with a tag
+
+  This will add a tag to the sent Postmark's email.
+
+      import Swoosh.Email
+
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> put_provider_option(:tag, "some tag")
   """
 
   use Swoosh.Adapter, required_config: [:api_key]
@@ -91,6 +103,7 @@ defmodule Swoosh.Adapters.Postmark do
     |> prepare_reply_to(email)
     |> prepare_template(email)
     |> prepare_custom_headers(email)
+    |> prepare_tag(email)
   end
 
   defp prepare_from(body, %{from: from}), do: Map.put(body, "From", render_recipient(from))
@@ -168,4 +181,10 @@ defmodule Swoosh.Adapters.Postmark do
     custom_headers = Enum.map(headers, fn {k, v} -> %{"Name" => k, "Value" => v} end)
     Map.put(body, "Headers", custom_headers)
   end
+
+  defp prepare_tag(body, %{provider_options: %{tag: tag_value}}) do
+    Map.put(body, "Tag", tag_value)
+  end
+
+  defp prepare_tag(body, _), do: body
 end

--- a/test/integration/adapters/postmark_test.exs
+++ b/test/integration/adapters/postmark_test.exs
@@ -56,6 +56,14 @@ defmodule Swoosh.Integration.Adapters.PostmarkTest do
     assert_ok_response(email, config)
   end
 
+  test "tagging deliver", %{valid_email: valid_email, config: config} do
+    email =
+      valid_email
+      |> put_provider_option(:tag, "test-tag")
+
+    assert_ok_response(email, config)
+  end
+
   defp assert_ok_response(email, config),
     do: assert {:ok, _response} = Swoosh.Adapters.Postmark.deliver(email, config)
 end


### PR DESCRIPTION
You can now add a tag to postmark emails.