### PR TITLE
deliver_many/2 callback and implementation for Mailjet

### DIFF
--- a/lib/swoosh/adapter.ex
+++ b/lib/swoosh/adapter.ex
@@ -27,12 +27,16 @@ defmodule Swoosh.Adapter do
   @doc """
   Delivers an email with the given config.
   """
-  @callback deliver(email, config) :: {:ok, term} | {:error, term}
+  @callback deliver(%Swoosh.Email{}, config) :: {:ok, term} | {:error, term}
+  @doc """
+  Delivers multiple emails with the given config
+  """
+  @callback deliver_many(list(%Swoosh.Email{}), config) :: {:ok, term} | {:error, term}
 
   @callback validate_config(config) :: :ok | no_return
   @callback validate_dependency() :: :ok | [module | {atom, module}]
 
-  @optional_callbacks validate_dependency: 0
+  @optional_callbacks validate_dependency: 0, deliver_many: 2
 
   @spec validate_config([atom], Keyword.t()) :: :ok | no_return
   def validate_config(required_config, config) do
@@ -63,5 +67,9 @@ defmodule Swoosh.Adapter do
        end),
        do: :ok,
        else: {:error, required_deps}
+  end
+
+  def deliver_many(_, _) do
+    {:error, :not_implemented}
   end
 end

--- a/lib/swoosh/adapter.ex
+++ b/lib/swoosh/adapter.ex
@@ -68,8 +68,4 @@ defmodule Swoosh.Adapter do
        do: :ok,
        else: {:error, required_deps}
   end
-
-  def deliver_many(_, _) do
-    {:error, :not_implemented}
-  end
 end

--- a/lib/swoosh/adapter.ex
+++ b/lib/swoosh/adapter.ex
@@ -28,10 +28,12 @@ defmodule Swoosh.Adapter do
   Delivers an email with the given config.
   """
   @callback deliver(%Swoosh.Email{}, config) :: {:ok, term} | {:error, term}
+
   @doc """
   Delivers multiple emails with the given config
   """
-  @callback deliver_many(list(%Swoosh.Email{}), config) :: {:ok, term} | {:error, term}
+  @callback deliver_many(list(%Swoosh.Email{}), config) ::
+              {:ok, term} | {:error, term}
 
   @callback validate_config(config) :: :ok | no_return
   @callback validate_dependency() :: :ok | [module | {atom, module}]

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -32,26 +32,18 @@ defmodule Swoosh.Adapters.Mailjet do
   @api_endpoint "send"
 
   def deliver(%Email{} = email, config \\ []) do
-    headers = prepare_headers(config)
-    url = [base_url(config), "/", @api_endpoint]
-
-    case :hackney.post(url, headers, prepare_body(email), [:with_body]) do
-      {:ok, 200, _headers, body} ->
-        {:ok, parse_results(body)}
-
-      {:ok, error_code, _headers, body} when error_code >= 400 ->
-        {:error, {error_code, parse_results(body)}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    send_request(prepare_body(email), config)
   end
 
   def deliver_many(emails, config \\ []) when is_list(emails) do
+    send_request(prepare_body(emails), config)
+  end
+
+  defp send_request(body, config) do
     headers = prepare_headers(config)
     url = [base_url(config), "/", @api_endpoint]
 
-    case :hackney.post(url, headers, prepare_body(emails), [:with_body]) do
+    case :hackney.post(url, headers, body, [:with_body]) do
       {:ok, 200, _headers, body} ->
         {:ok, parse_results(body)}
 

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -101,17 +101,11 @@ defmodule Swoosh.Adapters.Mailjet do
 
   defp auth(config), do: Base.encode64("#{config[:api_key]}:#{config[:secret]}")
 
-  defp prepare_body(emails) when is_list(emails) do
+  defp prepare_body(emails) do
     emails
+    |> List.wrap()
     |> Enum.map(&prepare_message/1)
-    |> wrap_into_messages()
-    |> Swoosh.json_library().encode!()
-  end
-
-  defp prepare_body(email) do
-    email
-    |> prepare_message
-    |> wrap_into_messages
+    |> wrap_messages()
     |> Swoosh.json_library().encode!()
   end
 
@@ -132,8 +126,7 @@ defmodule Swoosh.Adapters.Mailjet do
     |> prepare_custom_id(email)
   end
 
-  defp wrap_into_messages(body) when is_list(body), do: %{Messages: body}
-  defp wrap_into_messages(body), do: %{Messages: [body]}
+  defp wrap_messages(body) when is_list(body), do: %{Messages: body}
 
   defp prepare_custom_id(body, %{provider_options: %{custom_id: custom_id}}),
     do: Map.put(body, "CustomID", custom_id)

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -63,15 +63,15 @@ defmodule Swoosh.Adapters.Mailjet do
     end
   end
 
-  # MessageHref: https://api.mailjet.com/v3/REST/message/#{message_id}
-  defp get_message_id(%{
-         "Messages" => [%{"To" => [%{"MessageID" => message_id}]}]
-       }) do
-    message_id
+  defp get_message_id(%{"Messages" => messages}) do
+    case Enum.map(messages, &get_message_id(&1)) do
+      [single_message_id] -> single_message_id
+      message_ids -> message_ids
+    end
   end
 
-  defp get_message_id(%{"Messages" => [%{"To" => messages}]}) do
-    Enum.map(messages, fn %{"MessageID" => message_id} -> message_id end)
+  defp get_message_id(%{"To" => [%{"MessageID" => message_id}]}) do
+    message_id
   end
 
   defp get_message_id(body) when is_binary(body) do
@@ -96,6 +96,7 @@ defmodule Swoosh.Adapters.Mailjet do
     emails
     |> Enum.map(&prepare_message/1)
     |> wrap_into_messages()
+    |> Swoosh.json_library().encode!()
   end
 
   defp prepare_body(email) do

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -83,6 +83,18 @@ defmodule Swoosh.Adapters.Mailjet do
     %{id: message_id}
   end
 
+  defp get_message_id(%{"To" => multiple_receivers}) do
+    %{
+      id:
+        Enum.map(
+          multiple_receivers,
+          fn %{"MessageID" => message_id} ->
+            message_id
+          end
+        )
+    }
+  end
+
   defp get_message_id(body) when is_binary(body) do
     body
     |> Swoosh.json_library().decode!

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -55,18 +55,17 @@ defmodule Swoosh.Adapters.Mailjet do
     end
   end
 
-  defp parse_results(%{"Messages" => [%{"Status" => "error"}]} = single_error) do
-    single_error
-  end
-
   defp parse_results(%{"Messages" => results}) do
     results =
       Enum.map(results, fn
         %{"Status" => "success"} = result -> get_message_id(result)
-        result -> result
+        per_message_error -> per_message_error
       end)
 
-    if length(results) === 1, do: Enum.at(results, 0), else: results
+    case results do
+      [single] -> single
+      multiple -> multiple
+    end
   end
 
   defp parse_results(body) when is_binary(body) do

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -88,6 +88,13 @@ defmodule Swoosh.Mailer do
         end
       end
 
+      @spec deliver_many(list(%Swoosh.Email{}), Keyword.t()) :: {:ok, term} | {:error, term}
+      def deliver_many(emails, config \\ [])
+
+      def deliver_many(emails, config) do
+        Mailer.deliver_many(emails, parse_config(config))
+      end
+
       @on_load :validate_dependency
 
       @doc false
@@ -116,6 +123,13 @@ defmodule Swoosh.Mailer do
 
     :ok = adapter.validate_config(config)
     adapter.deliver(email, config)
+  end
+
+  def deliver_many(emails, config) do
+    adapter = Keyword.fetch!(config, :adapter)
+
+    :ok = adapter.validate_config(config)
+    adapter.deliver_many(emails, config)
   end
 
   @doc """

--- a/test/swoosh/adapters/mailjet_test.exs
+++ b/test/swoosh/adapters/mailjet_test.exs
@@ -382,17 +382,6 @@ defmodule Swoosh.Adapters.MailjetTest do
               }
             ],
             "Subject" => @subject,
-            "TemplateID" => @template_id,
-            "TemplateLanguage" => true,
-            "TemplateErrorDeliver" => true,
-            "TemplateErrorReporting" => %{
-              "Email" => @developer,
-              "Name" => ""
-            },
-            "Variables" => %{
-              "firstname" => @firstname,
-              "lastname" => @lastname
-            },
             "Headers" => %{}
           },
           %{
@@ -431,11 +420,7 @@ defmodule Swoosh.Adapters.MailjetTest do
     end)
 
     emails = [
-      email
-      |> put_provider_option(:variables, %{firstname: @firstname, lastname: @lastname})
-      |> put_provider_option(:template_id, @template_id)
-      |> put_provider_option(:template_error_deliver, true)
-      |> put_provider_option(:template_error_reporting, @developer),
+      email,
       email
       |> put_provider_option(:variables, %{firstname: @firstname, lastname: @lastname})
       |> put_provider_option(:template_id, @template_id)

--- a/test/swoosh/adapters/mailjet_test.exs
+++ b/test/swoosh/adapters/mailjet_test.exs
@@ -119,11 +119,12 @@ defmodule Swoosh.Adapters.MailjetTest do
     {:ok, bypass: bypass, valid_email: valid_email, config: config}
   end
 
-  test "delivery/1 - valid email with html and text body results in message ID", %{
-    bypass: bypass,
-    config: config,
-    valid_email: email
-  } do
+  test "delivery/1 - valid email with html and text body results in message ID",
+       %{
+         bypass: bypass,
+         config: config,
+         valid_email: email
+       } do
     Bypass.expect(bypass, fn conn ->
       conn = parse(conn)
 
@@ -211,7 +212,10 @@ defmodule Swoosh.Adapters.MailjetTest do
 
     email =
       email
-      |> put_provider_option(:variables, %{firstname: @firstname, lastname: @lastname})
+      |> put_provider_option(:variables, %{
+        firstname: @firstname,
+        lastname: @lastname
+      })
       |> put_provider_option(:template_id, @template_id)
       |> put_provider_option(:template_error_deliver, true)
       |> put_provider_option(:template_error_reporting, @developer)
@@ -294,18 +298,14 @@ defmodule Swoosh.Adapters.MailjetTest do
     end)
 
     error_result = %{
-      "Messages" => [
+      "Status" => "error",
+      "Errors" => [
         %{
-          "Status" => "error",
-          "Errors" => [
-            %{
-              "ErrorIdentifier" => "error id",
-              "ErrorCode" => "mj-0004",
-              "StatusCode" => 400,
-              "ErrorMessage" => ~s(Type mismatch. Expected type "array of emails".),
-              "ErrorRelatedTo" => ["HTMLPart", "TemplateID"]
-            }
-          ]
+          "ErrorIdentifier" => "error id",
+          "ErrorCode" => "mj-0004",
+          "StatusCode" => 400,
+          "ErrorMessage" => ~s(Type mismatch. Expected type "array of emails".),
+          "ErrorRelatedTo" => ["HTMLPart", "TemplateID"]
         }
       ]
     }
@@ -324,8 +324,7 @@ defmodule Swoosh.Adapters.MailjetTest do
         "ErrorIdentifier":"error id",
         "ErrorCode":"mj-0002",
         "StatusCode":400,
-        "ErrorMessage":
-        "Malformed JSON, please review the syntax and properties types."
+        "ErrorMessage": "Malformed JSON, please review the syntax and properties types."
       }
       """
 
@@ -336,7 +335,8 @@ defmodule Swoosh.Adapters.MailjetTest do
       "ErrorIdentifier" => "error id",
       "ErrorCode" => "mj-0002",
       "StatusCode" => 400,
-      "ErrorMessage" => "Malformed JSON, please review the syntax and properties types."
+      "ErrorMessage" =>
+        "Malformed JSON, please review the syntax and properties types."
     }
 
     assert Mailjet.deliver(email, config) == {:error, {400, error_result}}
@@ -422,7 +422,10 @@ defmodule Swoosh.Adapters.MailjetTest do
     emails = [
       email,
       email
-      |> put_provider_option(:variables, %{firstname: @firstname, lastname: @lastname})
+      |> put_provider_option(:variables, %{
+        firstname: @firstname,
+        lastname: @lastname
+      })
       |> put_provider_option(:template_id, @template_id)
       |> put_provider_option(:template_error_deliver, true)
       |> put_provider_option(:template_error_reporting, @developer)
@@ -498,8 +501,10 @@ defmodule Swoosh.Adapters.MailjetTest do
                    "Errors" => [
                      %{
                        "ErrorCode" => "mj-0013",
-                       "ErrorIdentifier" => "2978b962-32be-4007-a96e-0388451f1b7a",
-                       "ErrorMessage" => "\"brokenemail\" is an invalid email address.",
+                       "ErrorIdentifier" =>
+                         "2978b962-32be-4007-a96e-0388451f1b7a",
+                       "ErrorMessage" =>
+                         "\"brokenemail\" is an invalid email address.",
                        "ErrorRelatedTo" => ["To[0].Email"],
                        "StatusCode" => 400
                      }


### PR DESCRIPTION
As discussed in https://github.com/swoosh/swoosh/issues/436

Return values for `deliver/2` are left unchanged, for both success response and errors.
In `deliver/2` messages was a one-element list and I've made it a bit more generic so most of the logic is shared between those 2 functions.