### PR TITLE
Make a default of "" in subject to prevent really hard to debug errors

### DIFF
--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -37,7 +37,7 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
     |> prepare_from(email)
   end
 
-  defp prepare_subject(headers, %{subject: subject}), do: [{"Subject", subject || ""} | headers]
+  defp prepare_subject(headers, %{subject: subject}) when is_binary(subject), do: [{"Subject", subject} | headers]
 
   defp prepare_from(headers, %{from: from}), do: [{"From", render_recipient(from)} | headers]
 

--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -37,7 +37,7 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
     |> prepare_from(email)
   end
 
-  defp prepare_subject(headers, %{subject: subject}), do: [{"Subject", subject} | headers]
+  defp prepare_subject(headers, %{subject: subject}), do: [{"Subject", subject || ""} | headers]
 
   defp prepare_from(headers, %{from: from}), do: [{"From", render_recipient(from)} | headers]
 


### PR DESCRIPTION
Using a struct to enforce defaults isn't enough, in our application it made it's way through here somehow with a nil (due to bad cache syncing for translations) that and I ended up with a super helpful error of `(FunctionClauseError) no function clause matching in :mimemail.rfc2047_utf8_encode/4`

Digging into that:
```
    The following arguments were given to :mimemail.rfc2047_utf8_encode/4:

        # 1
        nil

        # 2
        '?Q?8-FTU?='

        # 3
        10

        # 4
        []
```

This is useless, would anyone of guessed this was from subject being nil?!