### PR TITLE
Ensure local storage adapter is started if enabled

### DIFF
--- a/lib/swoosh/application.ex
+++ b/lib/swoosh/application.ex
@@ -21,10 +21,11 @@ defmodule Swoosh.Application do
           {{:ok, _}, {:ok, _}} ->
             Logger.info("Running Swoosh mailbox preview server with Cowboy using http on port #{port}")
             [Plug.Cowboy.child_spec(scheme: :http, plug: Plug.Swoosh.MailboxPreview, options: [port: port]) | children]
+
           _ ->
             Logger.warn("Could not start preview server on port #{port}. Please ensure plug and cowboy" <>
               " are in your dependency list.")
-            []
+            children
         end
       else
         children


### PR DESCRIPTION
Before this patch it may not have been started e.g. in an umbrella:
say you correctly configured with `local: true`, but because a domain
app may not depend on plug & cowboy, we returned empty children instead
of the local adapter (if configured)