### PR TITLE
Fix behaviour of test adapter

### DIFF
--- a/lib/swoosh/adapters/test.ex
+++ b/lib/swoosh/adapters/test.ex
@@ -24,7 +24,7 @@ defmodule Swoosh.Adapters.Test do
       send(pid, {:email, email})
     end
 
-    {:ok, %{}}
+    {:ok, email}
   end
 
   defp pids do


### PR DESCRIPTION
The test adapter's deliver implementation should still return the sent email like the other adapters do.