### PR TITLE
Sendgrid: accept personalizations directly as provider_options

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -86,7 +86,8 @@ defmodule Swoosh.Adapters.Sendgrid do
   defp prepare_from(body, %{from: from}),
     do: Map.put(body, :from, from |> email_item)
 
-  defp prepare_personalizations(body, %{provider_options: %{personalizations: personalizations}}) do
+  defp prepare_personalizations(body, %{provider_options: %{personalizations: personalizations}})
+       when is_list(personalizations) do
     Map.put(body, :personalizations, personalizations)
   end
 

--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -86,6 +86,10 @@ defmodule Swoosh.Adapters.Sendgrid do
   defp prepare_from(body, %{from: from}),
     do: Map.put(body, :from, from |> email_item)
 
+  defp prepare_personalizations(body, %{provider_options: %{personalizations: personalizations}}) do
+    Map.put(body, :personalizations, personalizations)
+  end
+
   defp prepare_personalizations(body, email) do
     personalizations =
       %{}


### PR DESCRIPTION
This allows to easily configure personalizations directly through `provider_options`, was useful for us in order to send transactional email with different emails without each recipient seeing the full list.