### PR TITLE
Remove misleading Swoosh.Adapters.Gmail clause about omitting `from` while building email

### DIFF
--- a/lib/swoosh/adapters/gmail.ex
+++ b/lib/swoosh/adapters/gmail.ex
@@ -18,6 +18,10 @@ defmodule Swoosh.Adapters.Gmail do
         adapter: Swoosh.Adapters.Gmail,
         access_token: {:system, GMAIL_API_ACCESS_TOKEN}
 
+      # To deal with token refresh, it could be a better idea to pass the access token
+      # in via deliver config explicitly, if you don't update the environment variable
+      # periodically. e.g.
+      MyMailer.deliver(my_email, access_token: my_access_token)
 
       # lib/sample/mailer.ex
       defmodule Sample.Mailer do

--- a/lib/swoosh/adapters/gmail.ex
+++ b/lib/swoosh/adapters/gmail.ex
@@ -4,10 +4,6 @@ defmodule Swoosh.Adapters.Gmail do
 
   For reference [Gmail API docs](https://developers.google.com/gmail/api)
 
-  You don't need to set `from` address as google will set it for you.
-  If you still want to include it, make sure it matches the account or
-  it will be ignored.
-
   ## Dependency
 
   Gmail adapter requires `Mail` dependency to format message as RFC 2822 message.
@@ -20,6 +16,7 @@ defmodule Swoosh.Adapters.Gmail do
       # config/congig.exs
       config :sample, Smaple.Mailer
         adapter: Swoosh.Adapters.Gmail,
+        access_token: {:system, GMAIL_API_ACCESS_TOKEN}
 
 
       # lib/sample/mailer.ex


### PR DESCRIPTION
Closes #489

Also adding `access_token` existence to config looks helpful