### PR TITLE
Add CSRF token to dev preview mailbox (fixes #381)

### DIFF
--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -104,6 +104,7 @@
               </div>
             <% else %>
               <form method="POST" action="<%= to_absolute_url(@conn, "clear") %>">
+                <input name="_csrf_token" type="hidden" value="<%= Plug.CSRFProtection.get_csrf_token() %>">
                 <button class="btn btn-primary btn-block" type="submit">Delete Message Queue</button>
               </form>
               <%= for email <- @emails do %>


### PR DESCRIPTION
When used in a router pipeline that includes the :protect_from_forgery plug, a CSRF token is required for the "Delete Message Queue" functionality to work.