### PR TITLE
Updates readme instructions for setting up layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Taking the example from above the "Getting Started" section, your code would loo
     <title><%= @email.subject %></title>
   </head>
   <body>
-    <%= render @view_module, @view_template, assigns %>
+    <%= @inner_content %>
   </body>
 </html>
 


### PR DESCRIPTION
Updates the instructions in the Readme for setting up layout. It removes a deprecation warning.


Phoenix logs:

```
.warning: Rendering the child template from layouts is deprecated. Instead of:

    <%= render(@view_module, @view_template, assigns) %>

You should do:

    <%= @inner_content %>
```
