### PR TITLE
v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+## 1.0.5
+
+### Changes
+
+Allow `:gen_smtp` 1.0
+
 ## 1.0.4
 
 ### 🚀 Features
@@ -18,7 +24,6 @@
 ### Changes
 
 - Add CSRF token to dev preview mailbox (fixes #381) @DanielDent (#513)
-
 
 ## 1.0.2
 

--- a/lib/swoosh.ex
+++ b/lib/swoosh.ex
@@ -1,7 +1,7 @@
 defmodule Swoosh do
   @moduledoc File.read!("README.md") |> String.replace("# Swoosh\n\n", "", global: false)
 
-  @version "1.0.4"
+  @version "1.0.5"
 
   @doc false
   def version, do: @version

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Swoosh.Mixfile do
   use Mix.Project
 
-  @version "1.0.4"
+  @version "1.0.5"
 
   def project do
     [


### PR DESCRIPTION
close #526 

However, if you have `:cowboy` in your project, you are likely not going to be able to use `:gen_smtp` 1.0. They have different version of `:ranch` in dependency, hence are conflicted.