### PR TITLE
Support gen_smtp 1.0

### DIFF
--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -17,14 +17,15 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
     {encoding_config, _config} = Keyword.split(config, [:dkim])
     mime_encode(type, subtype, headers, parts, encoding_config)
   end
-  
-  gen_smtp_major =
-    :gen_smtp |> Application.spec(:vsn) |> to_string() |> Version.parse!() |> Map.get(:major)
-
-  @parameters if(gen_smtp_major >= 1, do: %{}, else: [])
 
   defp mime_encode(type, subtype, headers, parts, encoding_config) do
-    :mimemail.encode({type, subtype, headers, @parameters, parts}, encoding_config)
+    parameters =
+      case Application.spec(:gen_smtp, :vsn) do
+        [?1 | _] -> %{}
+        [?0 | _] -> []
+      end
+
+    :mimemail.encode({type, subtype, headers, parameters, parts}, encoding_config)
   end
 
   @doc false

--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -18,7 +18,7 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
     mime_encode(type, subtype, headers, parts, encoding_config)
   end
 
-  :application.load(:gen_smtp)
+  Application.load(:gen_smtp)
   gen_smtp_major =
     :gen_smtp |> Application.spec(:vsn) |> to_string() |> Version.parse!() |> Map.get(:major)
 

--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -19,6 +19,7 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
   end
 
   defp mime_encode(type, subtype, headers, parts, encoding_config) do
+    :ok = Application.ensure_loaded(:gen_smtp)
     parameters =
       case Application.spec(:gen_smtp, :vsn) do
         [?1 | _] -> %{}

--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -15,7 +15,16 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
     {message_config, config} = Keyword.split(config, [:transfer_encoding])
     {type, subtype, headers, parts} = prepare_message(email, message_config)
     {encoding_config, _config} = Keyword.split(config, [:dkim])
-    :mimemail.encode({type, subtype, headers, %{}, parts}, encoding_config)
+    mime_encode(type, subtype, headers, parts, encoding_config)
+  end
+  
+  gen_smtp_major =
+    :gen_smtp |> Application.spec(:vsn) |> to_string() |> Version.parse!() |> Map.get(:major)
+
+  @parameters if(gen_smtp_major >= 1, do: %{}, else: [])
+
+  defp mime_encode(type, subtype, headers, parts, encoding_config) do
+    :mimemail.encode({type, subtype, headers, @parameters, parts}, encoding_config)
   end
 
   @doc false

--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -18,15 +18,14 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
     mime_encode(type, subtype, headers, parts, encoding_config)
   end
 
-  defp mime_encode(type, subtype, headers, parts, encoding_config) do
-    :ok = Application.ensure_loaded(:gen_smtp)
-    parameters =
-      case Application.spec(:gen_smtp, :vsn) do
-        [?1 | _] -> %{}
-        [?0 | _] -> []
-      end
+  :application.load(:gen_smtp)
+  gen_smtp_major =
+    :gen_smtp |> Application.spec(:vsn) |> to_string() |> Version.parse!() |> Map.get(:major)
 
-    :mimemail.encode({type, subtype, headers, parameters, parts}, encoding_config)
+  @parameters if(gen_smtp_major >= 1, do: %{}, else: [])
+
+  defp mime_encode(type, subtype, headers, parts, encoding_config) do
+    :mimemail.encode({type, subtype, headers, @parameters, parts}, encoding_config)
   end
 
   @doc false

--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -15,7 +15,7 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
     {message_config, config} = Keyword.split(config, [:transfer_encoding])
     {type, subtype, headers, parts} = prepare_message(email, message_config)
     {encoding_config, _config} = Keyword.split(config, [:dkim])
-    :mimemail.encode({type, subtype, headers, [], parts}, encoding_config)
+    :mimemail.encode({type, subtype, headers, %{}, parts}, encoding_config)
   end
 
   @doc false


### PR DESCRIPTION
Support gen_smtp 1.0, which was [released](https://github.com/gen-smtp/gen_smtp/releases/tag/1.0.0) recently. The changelog for release contains a breaking change for `mimemail:parameters()`.

In https://github.com/gen-smtp/gen_smtp/pull/190/files#diff-8c203e5d2065d87650bec83bac9032a9ca7b14e6ae74fe3eac1c92cc00923ce7R706, the signature of `:mimemail.encode/2` function got changed by replacing a keyword list with map.

This commit follows the change in gen_smtp.