### PR TITLE
Utilize Enum.map_join/3

### DIFF
--- a/lib/swoosh/adapters/logger.ex
+++ b/lib/swoosh/adapters/logger.ex
@@ -60,13 +60,17 @@ defmodule Swoosh.Adapters.Logger do
       {_key, value} when is_list(value) -> !Enum.empty?(value)
       {_key, value} -> value
     end)
-    |> Enum.map(fn {key, value} -> String.capitalize(key) <> ": " <> render_recipient(value) end)
-    |> Enum.join("\n")
+    |> Enum.map_join("\n", fn {key, value} ->
+      String.capitalize(key) <> ": " <> render_recipient(value)
+    end)
   end
 
   defp render_headers(email) do
-    Enum.map(email.headers, fn {key, value} -> "#{key}: #{value}" end)
-    |> Enum.join("\n")
+    Enum.map_join(
+      email.headers,
+      "\n",
+      fn {key, value} -> "#{key}: #{value}" end
+    )
   end
 
   defp render_bodies(email) do

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -82,7 +82,7 @@ defmodule Swoosh.Adapters.SMTP do
           raise ArgumentError, """
           #{key} is not configured properly,
           got: #{value}, expected one of the followings:
-          #{valid_values |> Enum.map(&inspect/1) |> Enum.join(", ")}
+          #{valid_values |> Enum.map_join(", ", &inspect/1)}
           """
         end
 

--- a/lib/swoosh/adapters/sparkpost.ex
+++ b/lib/swoosh/adapters/sparkpost.ex
@@ -157,7 +157,7 @@ defmodule Swoosh.Adapters.SparkPost do
   end
 
   defp raw_email_addresses(mailboxes) do
-    mailboxes |> Enum.map(fn {_name, address} -> address end) |> Enum.join(",")
+    mailboxes |> Enum.map_join(",", fn {_name, address} -> address end)
   end
 
   defp prepare_attachments(body, %{attachments: []}), do: body

--- a/lib/swoosh/email/render.ex
+++ b/lib/swoosh/email/render.ex
@@ -9,7 +9,6 @@ defmodule Swoosh.Email.Render do
 
   def render_recipient(list) when is_list(list) do
     list
-    |> Enum.map(&render_recipient/1)
-    |> Enum.join(", ")
+    |> Enum.map_join(", ", &render_recipient/1)
   end
 end


### PR DESCRIPTION
I noticed one place where the code is mapping over lists, then joining them (two iterations), so I did a search and found a few more. While they are small and the performance gain is probably negligible, any little bit helps? I don't think it's any more difficult to reason about and I think it's also good to promote Enum.map_join/3 as a "best practice". Thanks for Swoosh! 