### PR TITLE
Add sendinblue adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,20 +105,21 @@ Swoosh supports the most popular transactional email providers out of the box
 and also has a SMTP adapter. Below is the list of the adapters currently
 included:
 
-| Provider   | Swoosh adapter                                                                                |
-| ---------- | --------------------------------------------------------------------------------------------- |
-| SMTP       | [Swoosh.Adapters.SMTP](https://hexdocs.pm/swoosh/Swoosh.Adapters.SMTP.html#content)           |
-| SendGrid   | [Swoosh.Adapters.Sendgrid](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendgrid.html#content)   |
-| Sendmail   | [Swoosh.Adapters.Sendmail](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendmail.html#content)   |
-| Mandrill   | [Swoosh.Adapters.Mandrill](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mandrill.html#content)   |
-| Mailgun    | [Swoosh.Adapters.Mailgun](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mailgun.html#content)     |
-| Mailjet    | [Swoosh.Adapters.Mailjet](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mailjet.html#content)     |
-| Postmark   | [Swoosh.Adapters.Postmark](https://hexdocs.pm/swoosh/Swoosh.Adapters.Postmark.html#content)   |
-| SparkPost  | [Swoosh.Adapters.SparkPost](https://hexdocs.pm/swoosh/Swoosh.Adapters.SparkPost.html#content) |
-| Amazon SES | [Swoosh.Adapters.AmazonSES](https://hexdocs.pm/swoosh/Swoosh.Adapters.AmazonSES.html#content) |
-| Dyn        | [Swoosh.Adapters.Dyn](https://hexdocs.pm/swoosh/Swoosh.Adapters.Dyn.html#content)             |
-| SocketLabs | [Swoosh.Adapters.SocketLabs](https://hexdocs.pm/swoosh/Swoosh.Adapters.SocketLabs.html#content)             |
-| Gmail      | [Swoosh.Adapters.Gmail](https://hexdocs.pm/swoosh/Swoosh.Adapters.Gmail.html#content)             |
+| Provider   | Swoosh adapter                                                                                   |
+| ---------- | ---------------------------------------------------------------------------------------------    |
+| SMTP       | [Swoosh.Adapters.SMTP](https://hexdocs.pm/swoosh/Swoosh.Adapters.SMTP.html#content)              |
+| SendGrid   | [Swoosh.Adapters.Sendgrid](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendgrid.html#content)      |
+| Sendinblue | [Swoosh.Adapters.Sendinblue](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendinblue.html#content)  |
+| Sendmail   | [Swoosh.Adapters.Sendmail](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendmail.html#content)      |
+| Mandrill   | [Swoosh.Adapters.Mandrill](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mandrill.html#content)      |
+| Mailgun    | [Swoosh.Adapters.Mailgun](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mailgun.html#content)        |
+| Mailjet    | [Swoosh.Adapters.Mailjet](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mailjet.html#content)        |
+| Postmark   | [Swoosh.Adapters.Postmark](https://hexdocs.pm/swoosh/Swoosh.Adapters.Postmark.html#content)      |
+| SparkPost  | [Swoosh.Adapters.SparkPost](https://hexdocs.pm/swoosh/Swoosh.Adapters.SparkPost.html#content)    |
+| Amazon SES | [Swoosh.Adapters.AmazonSES](https://hexdocs.pm/swoosh/Swoosh.Adapters.AmazonSES.html#content)    |
+| Dyn        | [Swoosh.Adapters.Dyn](https://hexdocs.pm/swoosh/Swoosh.Adapters.Dyn.html#content)                |
+| SocketLabs | [Swoosh.Adapters.SocketLabs](https://hexdocs.pm/swoosh/Swoosh.Adapters.SocketLabs.html#content)  |
+| Gmail      | [Swoosh.Adapters.Gmail](https://hexdocs.pm/swoosh/Swoosh.Adapters.Gmail.html#content)            |
 
 Configure which adapter you want to use by updating your `config/config.exs`
 file:

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -65,6 +65,7 @@ defmodule Swoosh.Adapters.Sendinblue do
     |> prepare_to(email)
     |> prepare_cc(email)
     |> prepare_bcc(email)
+    |> prepare_reply_to(email)
     |> prepare_text_content(email)
     |> prepare_html_content(email)
     |> prepare_template_id(email)
@@ -81,6 +82,12 @@ defmodule Swoosh.Adapters.Sendinblue do
     do: Map.put(body, "sender", %{name: name, email: email})
 
   defp prepare_from(body, _), do: body
+
+  defp prepare_reply_to(body, %{reply_to: {name, email}}),
+    do: Map.put(body, "replyTo", %{name: name, email: email})
+
+  defp prepare_reply_to(body, %{reply_to: nil}),
+    do: body
 
   defp prepare_subject(body, %{subject: subject}),
     do: Map.put(body, "subject", subject)

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -2,7 +2,7 @@ defmodule Swoosh.Adapters.Sendinblue do
   @moduledoc ~S"""
   An adapter that sends email using the Sendinblue API (Transactional emails only).
 
-  For reference: [Sendinblue API docs](https://developers.sendinblue.com/docs/send-a-transactional-email)
+  For reference: [Sendinblue API docs](https://developers.sendinblue.com/reference#transactional-emails)
 
   ## Example
 

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -66,6 +66,7 @@ defmodule Swoosh.Adapters.Sendinblue do
     |> prepare_text_content(email)
     |> prepare_html_content(email)
     |> prepare_template_id(email)
+    |> prepare_headers(email)
     |> prepare_params(email)
     |> prepare_tags(email)
     |> prepare_attachments(email)
@@ -105,6 +106,12 @@ defmodule Swoosh.Adapters.Sendinblue do
   end
 
   defp prepare_template_id(body, _), do: body
+
+  defp prepare_headers(body, %{headers: map}) when map_size(map) == 0, do: body
+
+  defp prepare_headers(body, %{headers: headers}) do
+    Map.put(body, "headers", headers)
+  end
 
   defp prepare_params(body, %{provider_options: %{params: params}}) when is_map(params) do
     Map.put(body, "params", params)

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -57,6 +57,7 @@ defmodule Swoosh.Adapters.Sendinblue do
     |> prepare_to(email)
     |> prepare_template_id(email)
     |> prepare_params(email)
+    |> prepare_attachments(email)
   end
 
   defp prepare_from(body, %{from: {name, email}}),
@@ -90,4 +91,18 @@ defmodule Swoosh.Adapters.Sendinblue do
   end
 
   defp prepare_params(body, _), do: body
+
+  defp prepare_attachments(body, %{attachments: []}), do: body
+
+  defp prepare_attachments(body, %{attachments: attachments}) do
+    attachments =
+      Enum.map(attachments, fn attachment ->
+        %{
+          name: attachment.filename,
+          content: Swoosh.Attachment.get_content(attachment, :base64)
+        }
+      end)
+
+    Map.put(body, :attachment, attachments)
+  end
 end

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -15,6 +15,12 @@ defmodule Swoosh.Adapters.Sendinblue do
       defmodule Sample.Mailer do
         use Swoosh.Mailer, otp_app: :sample
       end
+
+  ## Provider Options
+
+  - `template_id`
+  - `params` (map)
+  - `tags` (list)
   """
 
   use Swoosh.Adapter, required_config: [:api_key]

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -61,6 +61,7 @@ defmodule Swoosh.Adapters.Sendinblue do
   defp prepare_payload(email) do
     %{}
     |> prepare_from(email)
+    |> prepare_subject(email)
     |> prepare_to(email)
     |> prepare_cc(email)
     |> prepare_bcc(email)
@@ -80,6 +81,9 @@ defmodule Swoosh.Adapters.Sendinblue do
     do: Map.put(body, "sender", %{name: name, email: email})
 
   defp prepare_from(body, _), do: body
+
+  defp prepare_subject(body, %{subject: subject}),
+    do: Map.put(body, "subject", subject)
 
   defp prepare_to(body, %{to: to}) do
     Map.put(body, "to", Enum.map(to, &prepare_recipient/1))

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -67,11 +67,11 @@ defmodule Swoosh.Adapters.Sendinblue do
   defp prepare_payload(email) do
     %{}
     |> prepare_from(email)
-    |> prepare_subject(email)
+    |> prepare_reply_to(email)
     |> prepare_to(email)
     |> prepare_cc(email)
     |> prepare_bcc(email)
-    |> prepare_reply_to(email)
+    |> prepare_subject(email)
     |> prepare_text_content(email)
     |> prepare_html_content(email)
     |> prepare_template_id(email)
@@ -84,19 +84,16 @@ defmodule Swoosh.Adapters.Sendinblue do
   defp prepare_from(body, %{from: {_name, email}, provider_options: %{sender_id: sender_id}}),
     do: Map.put(body, "sender", %{id: sender_id, email: email})
 
-  defp prepare_from(body, %{from: {name, email}}),
-    do: Map.put(body, "sender", %{name: name, email: email})
-
   defp prepare_from(body, %{from: {_, "TEMPLATE"}}), do: body
 
-  defp prepare_reply_to(body, %{reply_to: {name, email}}),
-    do: Map.put(body, "replyTo", %{name: name, email: email})
+  defp prepare_from(body, %{from: from}),
+    do: Map.put(body, "sender", prepare_recipient(from))
 
   defp prepare_reply_to(body, %{reply_to: nil}),
     do: body
 
-  defp prepare_subject(body, %{subject: subject}),
-    do: Map.put(body, "subject", subject)
+  defp prepare_reply_to(body, %{reply_to: reply_to}),
+    do: Map.put(body, "replyTo", prepare_recipient(reply_to))
 
   defp prepare_to(body, %{to: to}) do
     Map.put(body, "to", Enum.map(to, &prepare_recipient/1))
@@ -109,6 +106,11 @@ defmodule Swoosh.Adapters.Sendinblue do
   defp prepare_bcc(body, %{bcc: bcc}) do
     Map.put(body, "bcc", Enum.map(bcc, &prepare_recipient/1))
   end
+
+  defp prepare_subject(body, %{subject: subject}),
+    do: Map.put(body, "subject", subject)
+
+  defp prepare_subject(body, _), do: body
 
   defp prepare_text_content(body, %{text_body: nil}), do: body
 

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -81,7 +81,7 @@ defmodule Swoosh.Adapters.Sendinblue do
   defp prepare_from(body, %{from: {name, email}}),
     do: Map.put(body, "sender", %{name: name, email: email})
 
-  defp prepare_from(body, _), do: body
+  defp prepare_from(body, %{from: {_, "TEMPLATE"}}), do: body
 
   defp prepare_reply_to(body, %{reply_to: {name, email}}),
     do: Map.put(body, "replyTo", %{name: name, email: email})

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -16,6 +16,12 @@ defmodule Swoosh.Adapters.Sendinblue do
         use Swoosh.Mailer, otp_app: :sample
       end
 
+  ## Using sender from template
+
+      YOUR_EMAIL
+      |> from("TEMPLATE")  # literally "TEMPLATE"
+      |> put_provider_option(:template_id, YOUR_TEMPLATE_ID)
+
   ## Provider Options
 
   - `sender_id` (integer)

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -18,7 +18,8 @@ defmodule Swoosh.Adapters.Sendinblue do
 
   ## Provider Options
 
-  - `template_id`
+  - `sender_id` (integer)
+  - `template_id` (integer)
   - `params` (map)
   - `tags` (list)
   """
@@ -71,6 +72,9 @@ defmodule Swoosh.Adapters.Sendinblue do
     |> prepare_tags(email)
     |> prepare_attachments(email)
   end
+
+  defp prepare_from(body, %{from: {_name, email}, provider_options: %{sender_id: sender_id}}),
+    do: Map.put(body, "sender", %{id: sender_id, email: email})
 
   defp prepare_from(body, %{from: {name, email}}),
     do: Map.put(body, "sender", %{name: name, email: email})

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -81,78 +81,78 @@ defmodule Swoosh.Adapters.Sendinblue do
     |> prepare_attachments(email)
   end
 
-  defp prepare_from(body, %{from: {_name, email}, provider_options: %{sender_id: sender_id}}),
-    do: Map.put(body, "sender", %{id: sender_id, email: email})
+  defp prepare_from(payload, %{from: {_name, email}, provider_options: %{sender_id: sender_id}}),
+    do: Map.put(payload, "sender", %{id: sender_id, email: email})
 
-  defp prepare_from(body, %{from: {_, "TEMPLATE"}}), do: body
+  defp prepare_from(payload, %{from: {_, "TEMPLATE"}}), do: payload
 
-  defp prepare_from(body, %{from: from}),
-    do: Map.put(body, "sender", prepare_recipient(from))
+  defp prepare_from(payload, %{from: from}),
+    do: Map.put(payload, "sender", prepare_recipient(from))
 
-  defp prepare_reply_to(body, %{reply_to: nil}),
-    do: body
+  defp prepare_reply_to(payload, %{reply_to: nil}),
+    do: payload
 
-  defp prepare_reply_to(body, %{reply_to: reply_to}),
-    do: Map.put(body, "replyTo", prepare_recipient(reply_to))
+  defp prepare_reply_to(payload, %{reply_to: reply_to}),
+    do: Map.put(payload, "replyTo", prepare_recipient(reply_to))
 
-  defp prepare_to(body, %{to: to}) do
-    Map.put(body, "to", Enum.map(to, &prepare_recipient/1))
+  defp prepare_to(payload, %{to: to}) do
+    Map.put(payload, "to", Enum.map(to, &prepare_recipient/1))
   end
 
-  defp prepare_cc(body, %{cc: cc}) do
-    Map.put(body, "cc", Enum.map(cc, &prepare_recipient/1))
+  defp prepare_cc(payload, %{cc: cc}) do
+    Map.put(payload, "cc", Enum.map(cc, &prepare_recipient/1))
   end
 
-  defp prepare_bcc(body, %{bcc: bcc}) do
-    Map.put(body, "bcc", Enum.map(bcc, &prepare_recipient/1))
+  defp prepare_bcc(payload, %{bcc: bcc}) do
+    Map.put(payload, "bcc", Enum.map(bcc, &prepare_recipient/1))
   end
 
-  defp prepare_subject(body, %{subject: subject}),
-    do: Map.put(body, "subject", subject)
+  defp prepare_subject(payload, %{subject: subject}),
+    do: Map.put(payload, "subject", subject)
 
-  defp prepare_subject(body, _), do: body
+  defp prepare_subject(payload, _), do: payload
 
-  defp prepare_text_content(body, %{text_body: nil}), do: body
+  defp prepare_text_content(payload, %{text_body: nil}), do: payload
 
-  defp prepare_text_content(body, %{text_body: text_content}) do
-    Map.put(body, "textContent", text_content)
+  defp prepare_text_content(payload, %{text_body: text_content}) do
+    Map.put(payload, "textContent", text_content)
   end
 
-  defp prepare_html_content(body, %{html_body: nil}), do: body
+  defp prepare_html_content(payload, %{html_body: nil}), do: payload
 
-  defp prepare_html_content(body, %{html_body: html_content}) do
-    Map.put(body, "htmlContent", html_content)
+  defp prepare_html_content(payload, %{html_body: html_content}) do
+    Map.put(payload, "htmlContent", html_content)
   end
 
-  defp prepare_template_id(body, %{provider_options: %{template_id: template_id}}) do
-    Map.put(body, "templateId", template_id)
+  defp prepare_template_id(payload, %{provider_options: %{template_id: template_id}}) do
+    Map.put(payload, "templateId", template_id)
   end
 
-  defp prepare_template_id(body, _), do: body
+  defp prepare_template_id(payload, _), do: payload
 
-  defp prepare_headers(body, %{headers: map}) when map_size(map) == 0, do: body
+  defp prepare_headers(payload, %{headers: map}) when map_size(map) == 0, do: payload
 
-  defp prepare_headers(body, %{headers: headers}) do
-    Map.put(body, "headers", headers)
+  defp prepare_headers(payload, %{headers: headers}) do
+    Map.put(payload, "headers", headers)
   end
 
-  defp prepare_params(body, %{provider_options: %{params: params}}) when is_map(params) do
-    Map.put(body, "params", params)
+  defp prepare_params(payload, %{provider_options: %{params: params}}) when is_map(params) do
+    Map.put(payload, "params", params)
   end
 
-  defp prepare_params(body, _), do: body
+  defp prepare_params(payload, _), do: payload
 
-  defp prepare_tags(body, %{provider_options: %{tags: tags}}) when is_list(tags) do
-    Map.put(body, "tags", tags)
+  defp prepare_tags(payload, %{provider_options: %{tags: tags}}) when is_list(tags) do
+    Map.put(payload, "tags", tags)
   end
 
-  defp prepare_tags(body, _), do: body
+  defp prepare_tags(payload, _), do: payload
 
-  defp prepare_attachments(body, %{attachments: []}), do: body
+  defp prepare_attachments(payload, %{attachments: []}), do: payload
 
-  defp prepare_attachments(body, %{attachments: attachments}) do
+  defp prepare_attachments(payload, %{attachments: attachments}) do
     Map.put(
-      body,
+      payload,
       "attachment",
       Enum.map(
         attachments,

--- a/lib/swoosh/adapters/sendinblue.ex
+++ b/lib/swoosh/adapters/sendinblue.ex
@@ -1,0 +1,93 @@
+defmodule Swoosh.Adapters.Sendinblue do
+  @moduledoc ~S"""
+  An adapter that sends email using the Sendinblue API (Transactional emails only).
+
+  For reference: [Sendinblue API docs](https://developers.sendinblue.com/docs/send-a-transactional-email)
+
+  ## Example
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.Sendinblue,
+        api_key: "my-api-key"
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample
+      end
+  """
+
+  use Swoosh.Adapter, required_config: [:api_key]
+
+  alias Swoosh.Email
+
+  @base_url "https://api.sendinblue.com/v3"
+  @api_endpoint "/smtp/email"
+
+  @impl true
+  def deliver(%Email{} = email, config \\ []) do
+    headers = [
+      {"Accept", "application/json"},
+      {"Content-Type", "application/json"},
+      {"User-Agent", "swoosh/#{Swoosh.version()}"},
+      {"Api-Key", config[:api_key]}
+    ]
+
+    body = email |> prepare_payload() |> Swoosh.json_library().encode!
+    url = [@base_url, @api_endpoint]
+
+    case Swoosh.ApiClient.post(url, headers, body, email) do
+      {:ok, code, _headers, body} when code >= 200 and code <= 399 ->
+        {:ok, body}
+
+      {:ok, code, _headers, body} when code >= 400 ->
+        case Swoosh.json_library().decode(body) do
+          {:ok, error} -> {:error, {code, error}}
+          {:error, _} -> {:error, {code, body}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp prepare_payload(email) do
+    %{}
+    |> prepare_from(email)
+    |> prepare_to(email)
+    |> prepare_template_id(email)
+    |> prepare_params(email)
+  end
+
+  defp prepare_from(body, %{from: {name, email}}),
+    do: Map.put(body, :sender, %{name: name, email: email})
+
+  defp prepare_from(body, _), do: body
+
+  defp prepare_to(body, %{to: to}) when is_list(to),
+    do: Enum.reduce(to, body, &prepare_to(&2, &1))
+
+  defp prepare_to(body, {name, email}) when name in [nil, ""] and not is_map_key(body, :to),
+    do: Map.put(body, :to, [%{email: email}])
+
+  defp prepare_to(body, {name, email}) when not is_map_key(body, :to),
+    do: Map.put(body, :to, [%{name: name, email: email}])
+
+  defp prepare_to(body, {name, email}) when name in [nil, ""],
+    do: Map.update!(body, :to, &[%{email: email} | &1])
+
+  defp prepare_to(body, {name, email}),
+    do: Map.update!(body, :to, &[%{name: name, email: email} | &1])
+
+  defp prepare_template_id(body, %{provider_options: %{template_id: template_id}}) do
+    Map.put(body, :templateId, template_id)
+  end
+
+  defp prepare_template_id(body, _), do: body
+
+  defp prepare_params(body, %{provider_options: %{params: params}}) do
+    Map.put(body, :params, params)
+  end
+
+  defp prepare_params(body, _), do: body
+end

--- a/test/integration/adapters/sendinblue_test.exs
+++ b/test/integration/adapters/sendinblue_test.exs
@@ -25,6 +25,6 @@ defmodule Swoosh.Integration.Adapters.SendinblueTest do
       |> text_body("This email was sent by the Swoosh library automation testing")
       |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")
 
-    assert {:ok, %{"messageId": _}} = Swoosh.Adapters.Sendinblue.deliver(email, config)
+    assert {:ok, %{id: _}} = Swoosh.Adapters.Sendinblue.deliver(email, config)
   end
 end

--- a/test/integration/adapters/sendinblue_test.exs
+++ b/test/integration/adapters/sendinblue_test.exs
@@ -1,0 +1,30 @@
+defmodule Swoosh.Integration.Adapters.SendinblueTest do
+  use ExUnit.Case, async: true
+
+  import Swoosh.Email
+
+  @moduletag integration: true
+
+  setup_all do
+    config = [
+      api_key: System.get_env("SENDINBLUE_API_KEY"),
+      domain: System.get_env("SENDINBLUE_DOMAIN")
+    ]
+    {:ok, config: config}
+  end
+
+  test "simple deliver", %{config: config} do
+    email =
+      new()
+      |> from({"Swoosh Sendinblue", "swoosh+sendinblue@#{config[:domain]}"})
+      |> reply_to("swoosh+replyto@#{config[:domain]}")
+      |> to("swoosh+to@#{config[:domain]}")
+      |> cc("swoosh+cc@#{config[:domain]}")
+      |> bcc("swoosh+bcc@#{config[:domain]}")
+      |> subject("Swoosh - Sendinblue integration test")
+      |> text_body("This email was sent by the Swoosh library automation testing")
+      |> html_body("<p>This email was sent by the Swoosh library automation testing</p>")
+
+    assert {:ok, %{"messageId": _}} = Swoosh.Adapters.Sendinblue.deliver(email, config)
+  end
+end

--- a/test/swoosh/adapters/sendinblue_test.exs
+++ b/test/swoosh/adapters/sendinblue_test.exs
@@ -1,0 +1,291 @@
+defmodule Swoosh.Adapters.SendinblueTest do
+  use Swoosh.AdapterCase, async: true
+
+  import Swoosh.Email
+  alias Swoosh.Adapters.Sendinblue
+
+  @example_message_id "<42.11@relay.example.com>"
+
+  setup do
+    bypass = Bypass.open()
+
+    config = [
+      api_key: "123",
+      base_url: "http://localhost:#{bypass.port}/v3"
+    ]
+
+    valid_email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+
+    {:ok, bypass: bypass, config: config, valid_email: valid_email}
+  end
+
+  defp assert_request_is_valid(conn, body_params) do
+    assert body_params == conn.body_params
+    assert "/v3/smtp/email" == conn.request_path
+    assert "POST" == conn.method
+  end
+
+  defp make_response(conn) do
+    conn
+    |> Plug.Conn.resp(200, "{\"messageId\": \"#{@example_message_id}\"}")
+  end
+
+  test "successful delivery returns :ok", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect_once(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "sender" => %{"email" => "tony.stark@example.com"},
+        "to" => [%{"email" => "steve.rogers@example.com"}],
+        "htmlContent" => "<h1>Hello</h1>",
+        "textContent" => "Hello",
+        "subject" => "Hello, Avengers!"
+      }
+
+      assert_request_is_valid(conn, body_params)
+      make_response(conn)
+    end)
+
+    assert Sendinblue.deliver(email, config) == {:ok, %{id: "#{@example_message_id}"}}
+  end
+
+  test "text-only delivery returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "sender" => %{"email" => "tony.stark@example.com"},
+        "to" => [%{"email" => "steve.rogers@example.com"}],
+        "textContent" => "Hello",
+        "subject" => "Hello, Avengers!"
+      }
+
+      assert_request_is_valid(conn, body_params)
+      make_response(conn)
+    end)
+
+    assert Sendinblue.deliver(email, config) == {:ok, %{id: "#{@example_message_id}"}}
+  end
+
+  test "html-only delivery returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+
+    Bypass.expect_once(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "sender" => %{"email" => "tony.stark@example.com"},
+        "to" => [%{"email" => "steve.rogers@example.com"}],
+        "htmlContent" => "<h1>Hello</h1>",
+        "subject" => "Hello, Avengers!"
+      }
+
+      assert_request_is_valid(conn, body_params)
+      make_response(conn)
+    end)
+
+    assert Sendinblue.deliver(email, config) == {:ok, %{id: "#{@example_message_id}"}}
+  end
+
+  test "delivery/1 with all fields returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> reply_to("hulk.smash@example.com")
+      |> cc("hulk.smash@example.com")
+      |> cc({"Janet Pym", "wasp.avengers@example.com"})
+      |> bcc("thor.odinson@example.com")
+      |> bcc({"Henry McCoy", "beast.avengers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "sender" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
+        "replyTo" => %{"email" => "hulk.smash@example.com"},
+        "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}],
+        "cc" => [
+          %{"name" => "Janet Pym", "email" => "wasp.avengers@example.com"},
+          %{"email" => "hulk.smash@example.com"}
+        ],
+        "bcc" => [
+          %{"name" => "Henry McCoy", "email" => "beast.avengers@example.com"},
+          %{"email" => "thor.odinson@example.com"}
+        ],
+        "textContent" => "Hello",
+        "htmlContent" => "<h1>Hello</h1>",
+        "subject" => "Hello, Avengers!"
+      }
+
+      assert_request_is_valid(conn, body_params)
+      make_response(conn)
+    end)
+
+    assert Sendinblue.deliver(email, config) == {:ok, %{id: "#{@example_message_id}"}}
+  end
+
+  test "delivery/1 with template_id returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> put_provider_option(:template_id, 42)
+
+    Bypass.expect_once(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "sender" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
+        "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}],
+        "subject" => "Hello, Avengers!",
+        "templateId" => 42
+      }
+
+      assert_request_is_valid(conn, body_params)
+      make_response(conn)
+    end)
+
+    assert Sendinblue.deliver(email, config) == {:ok, %{id: "#{@example_message_id}"}}
+  end
+
+  test "delivery/1 with template_id and params returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+        |> from("tony.stark@example.com")
+        |> to("steve.rogers@example.com")
+        |> subject("Hello, Avengers!")
+        |> text_body("Hello")
+        |> put_provider_option(:template_id, 42)
+        |> put_provider_option(:params, %{
+          sample_template_param: "sample value",
+          another_one: 99
+        })
+
+    Bypass.expect_once(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "sender" => %{"email" => "tony.stark@example.com"},
+        "to" => [%{"email" => "steve.rogers@example.com"}],
+        "textContent" => "Hello",
+        "subject" => "Hello, Avengers!",
+        "templateId" => 42,
+        "params" => %{
+          "sample_template_param" => "sample value",
+          "another_one" => 99
+        },
+      }
+
+      assert_request_is_valid(conn, body_params)
+      make_response(conn)
+    end)
+
+    assert Sendinblue.deliver(email, config) == {:ok, %{id: "#{@example_message_id}"}}
+  end
+
+  test "delivery/1 with template_id using template's from returns :ok", %{
+    bypass: bypass,
+    config: config
+  } do
+    email =
+      new()
+      |> from("TEMPLATE")
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> put_provider_option(:template_id, "Welcome")
+
+    Bypass.expect_once(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}],
+        "textContent" => "Hello",
+        "htmlContent" => "<h1>Hello</h1>",
+        "subject" => "Hello, Avengers!",
+        "templateId" => "Welcome"
+      }
+
+      assert_request_is_valid(conn, body_params)
+      make_response(conn)
+    end)
+
+    assert Sendinblue.deliver(email, config) == {:ok, %{id: "#{@example_message_id}"}}
+  end
+
+  test "delivery/1 with 429 response", %{bypass: bypass, config: config, valid_email: email} do
+    error = "{ \"code\": \"too_many_requests\", \"message\": \"The expected rate limit is exceeded.\"}"
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 429, error))
+
+    response =
+      {:error, {429, %{
+        "code" => "too_many_requests",
+        "message" => "The expected rate limit is exceeded.",
+      }}}
+
+    assert Sendinblue.deliver(email, config) == response
+  end
+
+  test "delivery/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do
+    error = "{ \"code\": \"invalid_parameter\", \"message\": \"error message explained.\"}"
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 400, error))
+
+    response =
+        {:error, {400, %{
+          "code" => "invalid_parameter",
+          "message" => "error message explained.",
+        }}}
+
+    assert Sendinblue.deliver(email, config) == response
+  end
+
+  test "delivery/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect_once(bypass, fn conn ->
+      assert "/v3/smtp/email" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 500, "")
+    end)
+
+    assert Sendinblue.deliver(email, config) == {:error, {500, ""}}
+  end
+
+  test "validate_config/1 with valid config", %{config: config} do
+    assert Sendinblue.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise ArgumentError,
+                 """
+                 expected [:api_key] to be set, got: []
+                 """,
+                 fn ->
+                   Sendinblue.validate_config([])
+                 end
+  end
+end

--- a/test/swoosh/adapters/sendinblue_test.exs
+++ b/test/swoosh/adapters/sendinblue_test.exs
@@ -25,30 +25,23 @@ defmodule Swoosh.Adapters.SendinblueTest do
     {:ok, bypass: bypass, config: config, valid_email: valid_email}
   end
 
-  defp assert_request_is_valid(conn, body_params) do
-    assert body_params == conn.body_params
-    assert "/v3/smtp/email" == conn.request_path
-    assert "POST" == conn.method
-  end
-
   defp make_response(conn) do
     conn
     |> Plug.Conn.resp(200, "{\"messageId\": \"#{@example_message_id}\"}")
   end
 
   test "successful delivery returns :ok", %{bypass: bypass, config: config, valid_email: email} do
-    Bypass.expect_once(bypass, fn conn ->
+    Bypass.expect_once(bypass, "POST", "/v3/smtp/email", fn conn ->
       conn = parse(conn)
 
-      body_params = %{
-        "sender" => %{"email" => "tony.stark@example.com"},
-        "to" => [%{"email" => "steve.rogers@example.com"}],
-        "htmlContent" => "<h1>Hello</h1>",
-        "textContent" => "Hello",
-        "subject" => "Hello, Avengers!"
-      }
+      assert conn.body_params == %{
+          "sender" => %{"email" => "tony.stark@example.com"},
+          "to" => [%{"email" => "steve.rogers@example.com"}],
+          "htmlContent" => "<h1>Hello</h1>",
+          "textContent" => "Hello",
+          "subject" => "Hello, Avengers!"
+        }
 
-      assert_request_is_valid(conn, body_params)
       make_response(conn)
     end)
 
@@ -63,17 +56,16 @@ defmodule Swoosh.Adapters.SendinblueTest do
       |> subject("Hello, Avengers!")
       |> text_body("Hello")
 
-    Bypass.expect_once(bypass, fn conn ->
+    Bypass.expect_once(bypass, "POST", "/v3/smtp/email", fn conn ->
       conn = parse(conn)
 
-      body_params = %{
-        "sender" => %{"email" => "tony.stark@example.com"},
-        "to" => [%{"email" => "steve.rogers@example.com"}],
-        "textContent" => "Hello",
-        "subject" => "Hello, Avengers!"
-      }
+      assert conn.body_params == %{
+          "sender" => %{"email" => "tony.stark@example.com"},
+          "to" => [%{"email" => "steve.rogers@example.com"}],
+          "textContent" => "Hello",
+          "subject" => "Hello, Avengers!"
+        }
 
-      assert_request_is_valid(conn, body_params)
       make_response(conn)
     end)
 
@@ -88,17 +80,16 @@ defmodule Swoosh.Adapters.SendinblueTest do
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
 
-    Bypass.expect_once(bypass, fn conn ->
+    Bypass.expect_once(bypass, "POST", "/v3/smtp/email", fn conn ->
       conn = parse(conn)
 
-      body_params = %{
+      assert conn.body_params == %{
         "sender" => %{"email" => "tony.stark@example.com"},
         "to" => [%{"email" => "steve.rogers@example.com"}],
         "htmlContent" => "<h1>Hello</h1>",
         "subject" => "Hello, Avengers!"
       }
 
-      assert_request_is_valid(conn, body_params)
       make_response(conn)
     end)
 
@@ -119,10 +110,10 @@ defmodule Swoosh.Adapters.SendinblueTest do
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
 
-    Bypass.expect_once(bypass, fn conn ->
+    Bypass.expect_once(bypass, "POST", "/v3/smtp/email", fn conn ->
       conn = parse(conn)
 
-      body_params = %{
+      assert conn.body_params == %{
         "sender" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
         "replyTo" => %{"email" => "hulk.smash@example.com"},
         "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}],
@@ -139,7 +130,6 @@ defmodule Swoosh.Adapters.SendinblueTest do
         "subject" => "Hello, Avengers!"
       }
 
-      assert_request_is_valid(conn, body_params)
       make_response(conn)
     end)
 
@@ -154,17 +144,16 @@ defmodule Swoosh.Adapters.SendinblueTest do
       |> subject("Hello, Avengers!")
       |> put_provider_option(:template_id, 42)
 
-    Bypass.expect_once(bypass, fn conn ->
+    Bypass.expect_once(bypass, "POST", "/v3/smtp/email", fn conn ->
       conn = parse(conn)
 
-      body_params = %{
+      assert conn.body_params == %{
         "sender" => %{"name" => "T Stark", "email" => "tony.stark@example.com"},
         "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}],
         "subject" => "Hello, Avengers!",
         "templateId" => 42
       }
 
-      assert_request_is_valid(conn, body_params)
       make_response(conn)
     end)
 
@@ -184,10 +173,10 @@ defmodule Swoosh.Adapters.SendinblueTest do
           another_one: 99
         })
 
-    Bypass.expect_once(bypass, fn conn ->
+    Bypass.expect_once(bypass, "POST", "/v3/smtp/email", fn conn ->
       conn = parse(conn)
 
-      body_params = %{
+      assert conn.body_params == %{
         "sender" => %{"email" => "tony.stark@example.com"},
         "to" => [%{"email" => "steve.rogers@example.com"}],
         "textContent" => "Hello",
@@ -199,7 +188,6 @@ defmodule Swoosh.Adapters.SendinblueTest do
         },
       }
 
-      assert_request_is_valid(conn, body_params)
       make_response(conn)
     end)
 
@@ -219,10 +207,10 @@ defmodule Swoosh.Adapters.SendinblueTest do
       |> text_body("Hello")
       |> put_provider_option(:template_id, "Welcome")
 
-    Bypass.expect_once(bypass, fn conn ->
+    Bypass.expect_once(bypass, "POST", "/v3/smtp/email", fn conn ->
       conn = parse(conn)
 
-      body_params = %{
+      assert conn.body_params == %{
         "to" => [%{"name" => "Steve Rogers", "email" => "steve.rogers@example.com"}],
         "textContent" => "Hello",
         "htmlContent" => "<h1>Hello</h1>",
@@ -230,7 +218,6 @@ defmodule Swoosh.Adapters.SendinblueTest do
         "templateId" => "Welcome"
       }
 
-      assert_request_is_valid(conn, body_params)
       make_response(conn)
     end)
 
@@ -266,7 +253,7 @@ defmodule Swoosh.Adapters.SendinblueTest do
   end
 
   test "delivery/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
-    Bypass.expect_once(bypass, fn conn ->
+    Bypass.expect_once(bypass, "POST", "/v3/smtp/email", fn conn ->
       assert "/v3/smtp/email" == conn.request_path
       assert "POST" == conn.method
       Plug.Conn.resp(conn, 500, "")
@@ -280,12 +267,14 @@ defmodule Swoosh.Adapters.SendinblueTest do
   end
 
   test "validate_config/1 with invalid config" do
-    assert_raise ArgumentError,
-                 """
-                 expected [:api_key] to be set, got: []
-                 """,
-                 fn ->
-                   Sendinblue.validate_config([])
-                 end
+    assert_raise(
+      ArgumentError,
+      """
+      expected [:api_key] to be set, got: []
+      """,
+      fn ->
+        Sendinblue.validate_config([])
+      end
+    )
   end
 end

--- a/test/swoosh/adapters/sendinblue_test.exs
+++ b/test/swoosh/adapters/sendinblue_test.exs
@@ -225,7 +225,7 @@ defmodule Swoosh.Adapters.SendinblueTest do
   end
 
   test "delivery/1 with 429 response", %{bypass: bypass, config: config, valid_email: email} do
-    error = "{ \"code\": \"too_many_requests\", \"message\": \"The expected rate limit is exceeded.\"}"
+    error = ~s/{"code": "too_many_requests", "message": "The expected rate limit is exceeded."}/
 
     Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 429, error))
 
@@ -239,7 +239,7 @@ defmodule Swoosh.Adapters.SendinblueTest do
   end
 
   test "delivery/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do
-    error = "{ \"code\": \"invalid_parameter\", \"message\": \"error message explained.\"}"
+    error = ~s/{"code": "invalid_parameter", "message": "error message explained."}/
 
     Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 400, error))
 


### PR DESCRIPTION
DRAFT

This PR adds an adapter for sendinblue (transactional emails only).
Related to #537

Todo:

- [x] solve the mandatory `from` problem
- [x] add attachments support
- [x] update documentation to include the new adapter
- [x] fix ` when name in [nil, ""] and not is_map_key(body, :to)`
- [x] Add tests

@princemaple Can you help here?