### PR TITLE
Fix Mailbox Viewer

### DIFF
--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -120,7 +120,7 @@
           </div>
         </div>
 
-        <div class="col-sm-offset-3 col-sm-9 content">
+        <div class="col-sm-3 offset-sm-3 col-sm-9 content">
           <%= if @email do %>
             <div class="header">
               <div class="header-content">


### PR DESCRIPTION
I think in the [new version of bootstrap](https://github.com/swoosh/swoosh/commit/854fcc09a6a4892280e4bafe83468270704f0ba2) the offset class was changed, because of that the preview in the new version is breaking. 

References:

- https://getbootstrap.com/docs/4.6/layout/grid/#offsetting-columns