### PR TITLE
Support integration tests

### DIFF
--- a/lib/swoosh/adapters/test.ex
+++ b/lib/swoosh/adapters/test.ex
@@ -40,6 +40,10 @@ defmodule Swoosh.Adapters.Test do
   # Essentially finds all of the processes that tried to send an email (in the test)
   # and sends an email to that process.
   defp pids do
-    Enum.uniq([self() | List.wrap(Process.get(:"$callers"))])
+    if pid = Application.get_env(:swoosh, :shared_test_process) do
+      [pid]
+    else
+      Enum.uniq([self() | List.wrap(Process.get(:"$callers"))])
+    end
   end
 end

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -12,6 +12,34 @@ defmodule Swoosh.TestAssertions do
   alias Swoosh.Email
   alias Swoosh.Email.Recipient
 
+  @doc """
+  Sets Swoosh test adapter to global mode.
+
+  In global mode, emails can be consumed by any process.
+
+  An ExUnit case where tests use Swoosh in global mode cannot be `async: true`.
+
+  ## Examples
+
+      setup :set_swoosh_global
+
+  """
+  def set_swoosh_global(context \\ %{}) do
+    if Map.get(context, :async) do
+      raise "Swoosh cannot be set to global mode when the ExUnit case is async. " <>
+              "If you want to use Swoosh in global mode, remove \"async: true\" when using ExUnit.Case"
+    else
+      Application.put_env(:swoosh, :shared_test_process, self())
+
+      ExUnit.Callbacks.on_exit(fn ->
+        Application.delete_env(:swoosh, :shared_test_process)
+      end)
+
+      :ok
+    end
+  end
+
+
   @doc ~S"""
   Asserts any email was sent.
   """

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -15,7 +15,8 @@ defmodule Swoosh.TestAssertions do
   @doc """
   Sets Swoosh test adapter to global mode.
 
-  In global mode, emails can be consumed by any process.
+  In global mode, emails are consumed by the current test process,
+  doesn't matter which process sent it.
 
   An ExUnit case where tests use Swoosh in global mode cannot be `async: true`.
 

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -21,8 +21,19 @@ defmodule Swoosh.TestAssertions do
 
   ## Examples
 
-      setup :set_swoosh_global
+      defmodule MyTest do
+        use ExUnit.Case, async: false
 
+        import Swoosh.Email
+        import Swoosh.TestAssertions
+
+        setup :set_swoosh_global
+
+        test "it sends email" do
+          # ...
+          assert_email_sent(subject: "Hi Avengers!")
+        end
+      end
   """
   def set_swoosh_global(context \\ %{}) do
     if Map.get(context, :async) do

--- a/test/swoosh/adapters/global_test_test.exs
+++ b/test/swoosh/adapters/global_test_test.exs
@@ -1,0 +1,41 @@
+defmodule Swoosh.Adapters.GlobalTestTest do
+  use ExUnit.Case
+
+  import Swoosh.Email
+  import Swoosh.TestAssertions
+
+  defmodule Mailer do
+    use GenServer
+
+    @impl true
+    def init([]) do
+      {:ok, []}
+    end
+
+    def deliver(pid, %Swoosh.Email{} = email) do
+      GenServer.call(pid, {:deliver, email})
+    end
+
+    @impl true
+    def handle_call({:deliver, email}, _from, state) do
+      {:ok, _} = Swoosh.Adapters.Test.deliver(email, nil)
+      {:reply, email, state}
+    end
+  end
+
+  setup :set_swoosh_global
+
+  test "global deliver" do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Global async Avengers!")
+
+    {:ok, pid} = GenServer.start_link(Mailer, [])
+
+    Mailer.deliver(pid, email)
+
+    assert_email_sent(subject: "Global async Avengers!")
+  end
+end


### PR DESCRIPTION
Closes  #66

The approach took is really similar to one [suggested in the issue](https://github.com/swoosh/swoosh/issues/66#issuecomment-387516542).
I also considered a allowance mechanism similar to what ecto and mox do, but IMO we can accomplish a similar result with a much simpler solution. For the use case of swoosh, just making sure that the messages are sent to the test process seems to be enough to allow users to do integration tests.