### PR TITLE
Link to pre-1.0/changelog.md instead of readme.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,4 +140,4 @@ Swoosh has been very stable for a very long time. It's about time, v1.0 is here.
 - Fixed return value for `Sendmail` [#483](https://github.com/swoosh/swoosh/pull/483)
   - before the fix its `deliver` implementation returns `:ok` but the Mailer behaviour requires it to return `{:ok, something}`, now it returns `{:ok, %{}}`
 
-[Pre-1.0 changelogs](https://github.com/swoosh/swoosh/blob/pre-1.0/README.md)
+[Pre-1.0 changelogs](https://github.com/swoosh/swoosh/blob/pre-1.0/CHANGELOG.md)


### PR DESCRIPTION
Thanks for your work! Only a minor thing, but from the link title this is the intended linking, I guess? At least this is what I would have expected.