### PR TITLE
Remove base_path in favor of using script_name from Plug.Conn

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ if Mix.env == :dev do
   scope "/dev" do
     pipe_through [:browser]
 
-    forward "/mailbox", Plug.Swoosh.MailboxPreview, [base_path: "/dev/mailbox"]
+    forward "/mailbox", Plug.Swoosh.MailboxPreview
   end
 end
 ```
@@ -313,7 +313,6 @@ $ mix swoosh.mailbox.server
 If you are curious, this is how it looks:
 
 ![Plug.Swoosh.MailboxPreview](https://github.com/swoosh/swoosh/raw/main/images/mailbox-preview.png)
-
 
 The preview is also available as a JSON endpoint.
 

--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -37,7 +37,7 @@ if Code.ensure_loaded?(Plug) do
     def call(conn, opts) do
       conn =
         conn
-        |> assign(:base_path, opts[:base_path] || Enum.join(["/" | conn.script_name]))
+        |> assign(:base_path, opts[:base_path] || Path.join(["/" | conn.script_name]))
         |> assign(:storage_driver, opts[:storage_driver] || Memory)
 
       super(conn, opts)

--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -3,11 +3,6 @@ if Code.ensure_loaded?(Plug) do
     @moduledoc """
     Plug that serves pages useful for previewing emails in development.
 
-    It takes one optional configuration at initialization:
-
-      * `base_path` - sets the base URL path where this module is plugged. Defaults
-        to `conn.script_name`.
-
     ## Examples
 
         # in a Phoenix router
@@ -37,7 +32,7 @@ if Code.ensure_loaded?(Plug) do
     def call(conn, opts) do
       conn =
         conn
-        |> assign(:base_path, opts[:base_path] || Path.join(["/" | conn.script_name]))
+        |> assign(:base_path, Path.join(["/" | conn.script_name]))
         |> assign(:storage_driver, opts[:storage_driver] || Memory)
 
       super(conn, opts)

--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -3,10 +3,10 @@ if Code.ensure_loaded?(Plug) do
     @moduledoc """
     Plug that serves pages useful for previewing emails in development.
 
-    It takes one option at initialization:
+    It takes one optional configuration at initialization:
 
       * `base_path` - sets the base URL path where this module is plugged. Defaults
-        to `/`.
+        to `conn.script_name`.
 
     ## Examples
 
@@ -14,7 +14,7 @@ if Code.ensure_loaded?(Plug) do
         defmodule Sample.Router do
           scope "/dev" do
             pipe_through [:browser]
-            forward "/mailbox", Plug.Swoosh.MailboxPreview, [base_path: "/dev/mailbox"]
+            forward "/mailbox", Plug.Swoosh.MailboxPreview
           end
         end
     """
@@ -37,7 +37,7 @@ if Code.ensure_loaded?(Plug) do
     def call(conn, opts) do
       conn =
         conn
-        |> assign(:base_path, opts[:base_path] || "/")
+        |> assign(:base_path, opts[:base_path] || Enum.join(["/" | conn.script_name]))
         |> assign(:storage_driver, opts[:storage_driver] || Memory)
 
       super(conn, opts)


### PR DESCRIPTION
close #569 
cc @LostKobrakai 

I'm keeping the config because I haven't checked how it works under multiple forward. If you have more information, maybe we can remove it altogether.