### PR TITLE
Allow passing an anonymous function to assert_email_sent

### DIFF
--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -51,7 +51,6 @@ defmodule Swoosh.TestAssertions do
     end
   end
 
-
   @doc ~S"""
   Asserts any email was sent.
   """
@@ -60,12 +59,13 @@ defmodule Swoosh.TestAssertions do
     assert_received {:email, _}
   end
 
-  @spec assert_email_sent(Email.t() | Keyword.t()) :: :ok | tuple | no_return
+  @spec assert_email_sent(Email.t() | Keyword.t() | (Email.t() -> boolean())) :: :ok | tuple | no_return
 
   @doc ~S"""
   Asserts `email` was sent.
 
-  You pass a keyword list to match on specific params.
+  You can pass a keyword list to match on specific params
+  or an anonymous function that returns a boolean.
 
   ## Examples
 
@@ -80,6 +80,9 @@ defmodule Swoosh.TestAssertions do
 
       # assert an email with specific field(s) was sent
       iex> assert_email_sent subject: "Hello, Avengers!"
+
+      # assert an email that satisfies a condition
+      iex> assert_email_sent fn email -> length(email.to) == 2 end
   """
   def assert_email_sent(%Email{} = email) do
     assert_received {:email, ^email}
@@ -88,6 +91,11 @@ defmodule Swoosh.TestAssertions do
   def assert_email_sent(params) when is_list(params) do
     assert_received {:email, email}
     Enum.each(params, &assert_equal(email, &1))
+  end
+
+  def assert_email_sent(fun) when is_function(fun, 1) do
+    assert_received {:email, email}
+    assert fun.(email)
   end
 
   defp assert_equal(email, {:subject, value}),

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -60,6 +60,12 @@ defmodule Swoosh.TestAssertionsTest do
     )
   end
 
+  test "assert email sent with condition" do
+    assert_email_sent(fn email ->
+      length(email.cc) == 2
+    end)
+  end
+
   test "assert email sent with wrong subject" do
     assert_raise ExUnit.AssertionError, fn ->
       assert_email_sent(subject: "Hello, X-Men!")
@@ -99,6 +105,14 @@ defmodule Swoosh.TestAssertionsTest do
   test "assert email sent with wrong email", %{email: email} do
     assert_raise ExUnit.AssertionError, fn ->
       assert_email_sent(email |> subject("Wrong"))
+    end
+  end
+
+  test "assert email sent with wrong condition" do
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_email_sent(fn email ->
+        email.to == "loki.odinson@example.com"
+      end)
     end
   end
 


### PR DESCRIPTION
Closes #573.

The function allows setting expectation on any condition, most notably on provider options.

The function is not supported for `assert_email_not_sent` nor `refute_email_sent` because they translate to pattern matching inside a `receive do ... end` block.
