### PR TITLE
Suppress warning caused by `Mail.Message.put_header`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule Swoosh.Mixfile do
           Plug.Conn.Query,
           Plug.Cowboy,
           Mail,
+          Mail.Message,
           Mail.Renderers.RFC2822,
           {IEx, :started?, 0}
         ]


### PR DESCRIPTION
close #596 