### PR TITLE
Require plug cowboy to start mailbox server

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,13 @@ config :swoosh, serve_mailbox: true
 config :swoosh, serve_mailbox: true, preview_port: 4001
 ```
 
+When using `serve_mailbox: true` make sure to have `plug_cowboy` as a
+dependency of your app.
+
+```elixir
+{:plug_cowboy, ">= 1.0.0"}
+```
+
 In your Phoenix project you can `forward` directly to the plug
 without spinning up a separate webserver, like this:
 

--- a/lib/swoosh/application.ex
+++ b/lib/swoosh/application.ex
@@ -7,46 +7,63 @@ defmodule Swoosh.Application do
     Swoosh.ApiClient.init()
 
     children =
-      if Application.get_env(:swoosh, :local, true) do
-        [Swoosh.Adapters.Local.Storage.Memory]
-      else
-        []
-      end
-
-    children =
-      if Application.get_env(:swoosh, :serve_mailbox) do
-        cowboy = Application.ensure_all_started(:cowboy)
-        plug = Application.ensure_all_started(:plug)
-        port = Application.get_env(:swoosh, :preview_port, 4000)
-
-        case {cowboy, plug} do
-          {{:ok, _}, {:ok, _}} ->
-            Logger.info(
-              "Running Swoosh mailbox preview server with Cowboy using http on port #{port}"
-            )
-
-            [
-              Plug.Cowboy.child_spec(
-                scheme: :http,
-                plug: Plug.Swoosh.MailboxPreview,
-                options: [port: port]
-              )
-              | children
-            ]
-
-          _ ->
-            Logger.warn(
-              "Could not start preview server on port #{port}. Please ensure plug and cowboy" <>
-                " are in your dependency list."
-            )
-
-            children
-        end
-      else
-        children
-      end
+      []
+      |> runtime_children(:local)
+      |> runtime_children(:serve_mailbox)
 
     opts = [strategy: :one_for_one, name: Swoosh.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp runtime_children(children, :local) do
+    if Application.get_env(:swoosh, :local, true) do
+      [Swoosh.Adapters.Local.Storage.Memory | children]
+    else
+      children
+    end
+  end
+
+  if Code.ensure_loaded?(Plug.Cowboy) do
+    defp runtime_children(children, :serve_mailbox) do
+      if Application.get_env(:swoosh, :serve_mailbox) do
+        {:ok, _} = Application.ensure_all_started(:plug_cowboy)
+
+        port = Application.get_env(:swoosh, :preview_port, 4000)
+
+        Logger.info(
+          "Running Swoosh mailbox preview server with Cowboy using http on port #{port}"
+        )
+
+        [
+          Plug.Cowboy.child_spec(
+            scheme: :http,
+            plug: Plug.Swoosh.MailboxPreview,
+            options: [port: port]
+          )
+          | children
+        ]
+      else
+        children
+      end
+    end
+  else
+    defp runtime_children(children, :serve_mailbox) do
+      if Application.get_env(:swoosh, :serve_mailbox) do
+        Logger.warn("""
+        Could not start preview server.
+
+        Please add :plug_cowboy to your dependencies:
+          {:plug_cowboy, ">= 1.0.0"}
+
+        And then recompile swoosh:
+
+          mix deps.get
+          mix deps.clean --build swoosh
+          mix deps.compile swoosh
+        """)
+      end
+
+      children
+    end
   end
 end


### PR DESCRIPTION
## Motivation

I getting the following error sometimes when the mailbox server is been started.

```
19:15:50.639 [info] Running Swoosh mailbox preview server with Cowboy using http on port 4001
19:15:50.643 [info] Application swoosh exited: exited in: Swoosh.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Plug.Swoosh.MailboxPreview.init/1 is undefined (module Plug.Swoosh.MailboxPreview is not available)
            Plug.Swoosh.MailboxPreview.init([])
            (plug_cowboy 2.5.0) lib/plug/cowboy.ex:371: Plug.Cowboy.dispatch_for/2
            (plug_cowboy 2.5.0) lib/plug/cowboy.ex:319: Plug.Cowboy.to_args/5
            (plug_cowboy 2.5.0) lib/plug/cowboy.ex:228: Plug.Cowboy.child_spec/1
            (swoosh 1.3.10) lib/swoosh/application.ex:29: Swoosh.Application.start/2
            (kernel 7.3) application_master.erl:277: :application_master.start_it_old/4
** (Mix) Could not start application swoosh: exited in: Swoosh.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Plug.Swoosh.MailboxPreview.init/1 is undefined (module Plug.Swoosh.MailboxPreview is not available)
            Plug.Swoosh.MailboxPreview.init([])
            (plug_cowboy 2.5.0) lib/plug/cowboy.ex:371: Plug.Cowboy.dispatch_for/2
            (plug_cowboy 2.5.0) lib/plug/cowboy.ex:319: Plug.Cowboy.to_args/5
            (plug_cowboy 2.5.0) lib/plug/cowboy.ex:228: Plug.Cowboy.child_spec/1
            (swoosh 1.3.10) lib/swoosh/application.ex:29: Swoosh.Application.start/2
            (kernel 7.3) application_master.erl:277: :application_master.start_it_old/4
```

My app is a umbrella application. I believe the error is happening because the application where swoosh was added as a dependency, doesn't depend explicit on plug/cowboy. But another application in the app has plug/cowboy as dependencies. So depending on the order taken by the compiler, swoosh is compiled before plug, and because of the compile check https://github.com/swoosh/swoosh/blob/v1.3.10/lib/plug/mailbox_preview.ex#L1, the mailbox preview plug is not compiled. 
Then when the application starts, plug/cowboy are available at runtime, but the mailbox preview plug was not compiled, causing the error. And as it depends on the order of the compilation, the error becomes intermittent.

## Proposed solution

In order to avoid this kind of error, we could move the check for `Plug.Cowboy` dependency into compile-time, the same way the check for `Plug` in the mailbox happen. And explicit instruct the developer to add plug_cowboy to its dependencies.