### PR TITLE
Adds telemetry to Mailer.deliver & Mailer.deliver_many

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ The following events are emitted:
 - `[:swoosh, :deliver_many, :stop]`: occurs when `Mailer.deliver_many/2` completes.
 - `[:swoosh, :deliver_many, :exception]`: occurs when `Mailer.deliver_many/2` throws an exception.
 
+View [example in docs](https://hexdocs.pm/swoosh/Swoosh.Mailer.html#module-telemetry)
+
 ## Documentation
 
 Documentation is written into the library, you will find it in the source code,

--- a/README.md
+++ b/README.md
@@ -371,6 +371,17 @@ problems, or you don't like having it around, it can be disabled like so:
 config :swoosh, local: false
 ```
 
+## Telemetry
+
+The following events are emitted:
+
+- `[:swoosh, :deliver, :start]`: occurs when `Mailer.deliver/2` begins.
+- `[:swoosh, :deliver, :stop]`: occurs when `Mailer.deliver/2` completes.
+- `[:swoosh, :deliver, :exception]`: occurs when `Mailer.deliver/2` throws an exception.
+- `[:swoosh, :deliver_many, :start]`: occurs when `Mailer.deliver_many/2` begins.
+- `[:swoosh, :deliver_many, :stop]`: occurs when `Mailer.deliver_many/2` completes.
+- `[:swoosh, :deliver_many, :exception]`: occurs when `Mailer.deliver_many/2` throws an exception.
+
 ## Documentation
 
 Documentation is written into the library, you will find it in the source code,

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -76,33 +76,33 @@ defmodule Swoosh.Mailer do
 
   You can capture events by calling `:telemetry.attach/4` or `:telemetry.attach_many/4`. Here's an example:
 
-  ```
-  # tracks the number of emails sent successfully/errored
-  defmodule MyHandler do
-    def handle_event([:swoosh, :deliver, :stop], _measurements, metadata, _config) do
-      StatsD.increment("mail.sent.success", 1, %{mailer: metadata.mailer})
-    end
+      # tracks the number of emails sent successfully/errored
+      defmodule MyHandler do
+        def handle_event([:swoosh, :deliver, :stop], _measurements, metadata, _config) do
+          StatsD.increment("mail.sent.success", 1, %{mailer: metadata.mailer})
+        end
 
-    def handle_event([:swoosh, :deliver, :exception], _measurements, metadata, _config) do
-      StatsD.increment("mail.sent.failure", 1, %{mailer: metadata.mailer})
-    end
+        def handle_event([:swoosh, :deliver, :exception], _measurements, metadata, _config) do
+          StatsD.increment("mail.sent.failure", 1, %{mailer: metadata.mailer})
+        end
 
-    def handle_event([:swoosh, :deliver_many, :stop], _measurements, metadata, _config) do
-      StatsD.increment("mail.sent.success", length(metadata.emails), %{mailer: metadata.mailer})
-    end
+        def handle_event([:swoosh, :deliver_many, :stop], _measurements, metadata, _config) do
+          StatsD.increment("mail.sent.success", length(metadata.emails), %{mailer: metadata.mailer})
+        end
 
-    def handle_event([:swoosh, :deliver_many, :exception], _measurements, metadata, _config) do
-      StatsD.increment("mail.sent.failure", length(metadata.emails), %{mailer: metadata.mailer})
-    end
-  end
+        def handle_event([:swoosh, :deliver_many, :exception], _measurements, metadata, _config) do
+          StatsD.increment("mail.sent.failure", length(metadata.emails), %{mailer: metadata.mailer})
+        end
+      end
 
-  :telemetry.attach_many("my-handler", [
-     [:swoosh, :deliver, :stop],
-     [:swoosh, :deliver, :exception],
-     [:swoosh, :deliver_many, :stop],
-     [:swoosh, :deliver_many, :exception],
-   ], &MyHandler.handle_event/4, nil)
-  ```
+  in `c:Application.start/2` callback:
+
+      :telemetry.attach_many("my-handler", [
+         [:swoosh, :deliver, :stop],
+         [:swoosh, :deliver, :exception],
+         [:swoosh, :deliver_many, :stop],
+         [:swoosh, :deliver_many, :exception],
+       ], &MyHandler.handle_event/4, nil)
   """
 
   alias Swoosh.DeliveryError

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -60,6 +60,49 @@ defmodule Swoosh.Mailer do
       %Swoosh.Email{from: {"", "tony.stark@example.com"}, ...}
       iex> Mailer.deliver(email, domain: "jarvis.com")
       :ok
+
+  ## Telemetry
+
+  Each mailer outputs the following telemetry events:
+
+  - `[:swoosh, :deliver, :start]`: occurs when `Mailer.deliver/2` begins.
+  - `[:swoosh, :deliver, :stop]`: occurs when `Mailer.deliver/2` completes.
+  - `[:swoosh, :deliver, :exception]`: occurs when `Mailer.deliver/2` throws an exception.
+  - `[:swoosh, :deliver_many, :start]`: occurs when `Mailer.deliver_many/2` begins.
+  - `[:swoosh, :deliver_many, :stop]`: occurs when `Mailer.deliver_many/2` completes.
+  - `[:swoosh, :deliver_many, :exception]`: occurs when `Mailer.deliver_many/2` throws an exception.
+
+  ### Capturing events
+
+  You can capture events by calling `:telemetry.attach/4` or `:telemetry.attach_many/4`. Here's an example:
+
+  ```
+  # tracks the number of emails sent successfully/errored
+  defmodule MyHandler do
+    def handle_event([:swoosh, :deliver, :stop], _measurements, metadata, _config) do
+      StatsD.increment("mail.sent.success", 1, %{mailer: metadata.mailer})
+    end
+
+    def handle_event([:swoosh, :deliver, :exception], _measurements, metadata, _config) do
+      StatsD.increment("mail.sent.failure", 1, %{mailer: metadata.mailer})
+    end
+
+    def handle_event([:swoosh, :deliver_many, :stop], _measurements, metadata, _config) do
+      StatsD.increment("mail.sent.success", length(metadata.emails), %{mailer: metadata.mailer})
+    end
+
+    def handle_event([:swoosh, :deliver_many, :exception], _measurements, metadata, _config) do
+      StatsD.increment("mail.sent.failure", length(metadata.emails), %{mailer: metadata.mailer})
+    end
+  end
+
+  :telemetry.attach_many("my-handler", [
+     [:swoosh, :deliver, :stop],
+     [:swoosh, :deliver, :exception],
+     [:swoosh, :deliver_many, :stop],
+     [:swoosh, :deliver_many, :exception],
+   ], &MyHandler.handle_event/4, nil)
+  ```
   """
 
   alias Swoosh.DeliveryError

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Swoosh.Mixfile do
     [
       {:mime, "~> 1.1 or ~> 2.0"},
       {:jason, "~> 1.0"},
-      {:telemetry, "~> 0.4 or ~> 1.0"},
+      {:telemetry, "~> 0.4.2 or ~> 1.0"},
       {:hackney, "~> 1.9", optional: true},
       {:finch, "~> 0.6", optional: true},
       {:mail, "~> 0.2", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule Swoosh.Mixfile do
     [
       {:mime, "~> 1.1 or ~> 2.0"},
       {:jason, "~> 1.0"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:hackney, "~> 1.9", optional: true},
       {:finch, "~> 0.6", optional: true},
       {:mail, "~> 0.2", optional: true},

--- a/test/swoosh/mailer_test.exs
+++ b/test/swoosh/mailer_test.exs
@@ -185,14 +185,20 @@ defmodule Swoosh.MailerTest do
 
     test "deliver/2 outputs telemetry event on success", %{valid_email: email} do
       assert {:ok, _} = FakeMailer.deliver(email)
-      assert_receive {:telemetry, [:swoosh, :deliver, :start], %{mailer: FakeMailer}}
-      assert_receive {:telemetry, [:swoosh, :deliver, :stop], %{mailer: FakeMailer}}
+
+      assert_receive {:telemetry, [:swoosh, :deliver, :start],
+                      %{mailer: FakeMailer, email: ^email}}
+
+      assert_receive {:telemetry, [:swoosh, :deliver, :stop], %{mailer: FakeMailer, result: _}}
     end
 
     test "deliver/2 outputs telemetry event on error", %{valid_email: email} do
       assert {:error, _} = FakeMailer.deliver(email, force_error: true)
-      assert_receive {:telemetry, [:swoosh, :deliver, :start], %{mailer: FakeMailer}}
-      assert_receive {:telemetry, [:swoosh, :deliver, :stop], %{mailer: FakeMailer}}
+
+      assert_receive {:telemetry, [:swoosh, :deliver, :start],
+                      %{mailer: FakeMailer, email: ^email}}
+
+      assert_receive {:telemetry, [:swoosh, :deliver, :stop], %{mailer: FakeMailer, error: _}}
     end
 
     test "deliver/2 outputs telemetry event on exception", %{valid_email: email} do
@@ -200,8 +206,11 @@ defmodule Swoosh.MailerTest do
         FakeMailer.deliver(email, force_error: :exception)
       end
 
-      assert_receive {:telemetry, [:swoosh, :deliver, :start], %{mailer: FakeMailer}}
-      assert_receive {:telemetry, [:swoosh, :deliver, :exception], %{mailer: FakeMailer}}
+      assert_receive {:telemetry, [:swoosh, :deliver, :start],
+                      %{mailer: FakeMailer, email: ^email}}
+
+      assert_receive {:telemetry, [:swoosh, :deliver, :exception],
+                      %{mailer: FakeMailer, kind: :error, reason: _}}
     end
 
     test "deliver_many/2 outputs telemetry event on success", %{valid_email: email} do
@@ -212,7 +221,7 @@ defmodule Swoosh.MailerTest do
                       %{mailer: FakeMailer, emails: ^emails}}
 
       assert_receive {:telemetry, [:swoosh, :deliver_many, :stop],
-                      %{mailer: FakeMailer, emails: ^emails}}
+                      %{mailer: FakeMailer, result: _}}
     end
 
     test "deliver_many/2 outputs telemetry event on error", %{valid_email: email} do
@@ -223,7 +232,7 @@ defmodule Swoosh.MailerTest do
                       %{mailer: FakeMailer, emails: ^emails}}
 
       assert_receive {:telemetry, [:swoosh, :deliver_many, :stop],
-                      %{mailer: FakeMailer, emails: ^emails}}
+                      %{mailer: FakeMailer, error: _}}
     end
 
     test "deliver_many/2 outputs telemetry event on exception", %{valid_email: email} do
@@ -231,11 +240,10 @@ defmodule Swoosh.MailerTest do
         FakeMailer.deliver_many([email], force_error: :exception)
       end
 
-      assert_receive {:telemetry, [:swoosh, :deliver_many, :start],
-                      %{mailer: FakeMailer, emails: [^email]}}
+      assert_receive {:telemetry, [:swoosh, :deliver_many, :start], %{mailer: FakeMailer}}
 
       assert_receive {:telemetry, [:swoosh, :deliver_many, :exception],
-                      %{mailer: FakeMailer, emails: [^email]}}
+                      %{mailer: FakeMailer, kind: :error, reason: _}}
     end
   end
 end


### PR DESCRIPTION
This PR adds the following telemetry events:

- `[:swoosh, :deliver, :start]`: occurs when `Mailer.deliver/2` starts
- `[:swoosh, :deliver, :stop]`: occurs when `Mailer.deliver/2` succeeds
- `[:swoosh, :deliver, :exception]`: occurs when `Mailer.deliver/2` fails
- `[:swoosh, :deliver_many, :start]`: occurs when `Mailer.deliver_many/2` starts
- `[:swoosh, :deliver_many, :stop]`: occurs when `Mailer.deliver_many/2` succeeds
- `[:swoosh, :deliver_many, :exception]`: occurs when `Mailer.deliver_many/2` fails

## Usage

Example of capturing a count of emails that succeed and fail:

```elixir
defmodule MyHandler do
  def handle_event([:swoosh, :deliver, :stop], _measurements, metadata, _config) do
     StatsD.increment("mail.sent.success", 1, %{mailer: metadata.mailer})
  end

  def handle_event([:swoosh, :deliver, :exception], _measurements, metadata, _config) do
     StatsD.increment("mail.sent.failure", 1, %{mailer: metadata.mailer})
  end 

  def handle_event([:swoosh, :deliver_many, :stop], _measurements, metadata, _config) do
     StatsD.increment("mail.sent.success", length(metadata.emails), %{mailer: metadata.mailer})
  end

  def handle_event([:swoosh, :deliver_many, :exception], _measurements, metadata, _config) do
     StatsD.increment("mail.sent.failure", length(metadata.emails), %{mailer: metadata.mailer})
  end 
end

:telemetry.attach_many("my-handler", [
   [:swoosh, :deliver, :stop],
   [:swoosh, :deliver, :exception],
   [:swoosh, :deliver_many, :stop],
   [:swoosh, :deliver_many, :exception],
 ], &MyHandler.handle_event/4, nil)
``` 

## TODO

- [x] add info to readme

Closes #613