### PR TITLE
Clarify that you need to add :gen_smtp as a dependency

### DIFF
--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -7,10 +7,6 @@ defmodule Swoosh.Adapters.SMTP do
 
   ## Example
       # mix.exs
-      def application do
-        [applications: [:swoosh, :gen_smtp]]
-      end
-
       def deps do
         [
          {:swoosh, "~> 1.3"},

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -3,12 +3,19 @@ defmodule Swoosh.Adapters.SMTP do
   An adapter that sends email using the SMTP protocol.
 
   Underneath this adapter uses the
-  [gen_smtp](https://github.com/Vagabond/gen_smtp) library.
+  [gen_smtp](https://github.com/Vagabond/gen_smtp) library, add it to your mix.exs file.
 
   ## Example
       # mix.exs
       def application do
         [applications: [:swoosh, :gen_smtp]]
+      end
+
+      def deps do
+        [
+         {:swoosh, "~> 1.3"},
+         {:gen_smtp, "~> 1.1}
+        ]
       end
 
       # config/config.exs


### PR DESCRIPTION
I ran afoul of this after deploying my app to production.

The fact that the beam crashed on this with no clear error message took me some time to investigate.
