### PR TITLE
Add provider options doc for Mailjet

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -46,7 +46,7 @@ defmodule Swoosh.Adapters.Mailgun do
   ## Provider options
 
     * `:custom_vars` (map) - used to translate to `v:my-var`, now
-      `h:X-Mailgun-Variables`, add custome data to email
+      `h:X-Mailgun-Variables`, add custom data to email
 
     * `:recipient_vars` (map) - `recipient-variables`, assign
       custom variable for each email recipient

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -50,7 +50,7 @@ defmodule Swoosh.Adapters.Mailjet do
       send even if error in template if `true`, otherwise stop email delivery
       immediately upon error
 
-    * `:template_error_reporting` (string | tuple) - `TemplateErrorReporting`,
+    * `:template_error_reporting` (string | tuple | map) - `TemplateErrorReporting`,
       email address or a tuple of name and email address of a recipient to send a
       carbon copy upon error
 

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -44,7 +44,7 @@ defmodule Swoosh.Adapters.Mailjet do
   ## Provider options
 
     * `:template_id` (integer) - `TemplateID`, unique template id of the
-      template to be use as emai content
+      template to be used as email content
 
     * `:template_error_deliver` (boolean) - `TemplateErrorDeliver`,
       send even if error in template if `true`, otherwise stop email delivery

--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -20,6 +20,43 @@ defmodule Swoosh.Adapters.Mailjet do
       defmodule Sample.Mailer do
         use Swoosh.Mailer, otp_app: :sample
       end
+
+  ## Using with provider options
+
+      import Swoosh.Email
+
+      new()
+      |> from({"Billi Wang", "billi_wang@example.com"})
+      |> to({"Nai Nai", "nainai@example.com"})
+      |> reply_to("a24@example.com")
+      |> cc({"Haiyan Wang", "haiyan_wang@example.com"})
+      |> cc("lujian@example.com")
+      |> bcc({"Hao Hao", "haohao@example.com"})
+      |> bcc("aiko@example.com")
+      |> subject("Hello, Nai Nai!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> put_provider_option(:template_id, 123)
+      |> put_provider_option(:template_error_deliver, true)
+      |> put_provider_option(:template_error_reporting, "developer@example.com")
+      |> put_provider_option(:variables, %{firstname: "lulu", lastname: "wang"})
+
+  ## Provider options
+
+    * `:template_id` (integer) - `TemplateID`, unique template id of the
+      template to be use as emai content
+
+    * `:template_error_deliver` (boolean) - `TemplateErrorDeliver`,
+      send even if error in template if `true`, otherwise stop email delivery
+      immediately upon error
+
+    * `:template_error_reporting` (string | tuple) - `TemplateErrorReporting`,
+      email address or a tuple of name and email address of a recipient to send a
+      carbon copy upon error
+
+    * `:variables` (map) - `Variables`, custom key-value variable for the email
+      content
+
   """
 
   use Swoosh.Adapter,


### PR DESCRIPTION
Beside the provider options, we also fix typo and add code example.

![image](https://user-images.githubusercontent.com/134518/144512016-72af4ef6-b0a3-4d6b-962a-1f260c07e038.png)
