### PR TITLE
Config bypass only on test

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,6 @@
 import Config
 
-config :bypass, adapter: Plug.Adapters.Cowboy2
-
 if Mix.env() == :test do
   config :logger, level: :info
+  config :bypass, adapter: Plug.Adapters.Cowboy2
 end


### PR DESCRIPTION
`bypass` is only used on test env, but is configured on all envs.