### PR TITLE
Add configuration options to Mailgun documentation

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -7,7 +7,13 @@ defmodule Swoosh.Adapters.Mailgun do
   ## Dependency
 
   Mailgun adapter requires `Plug` to work properly.
-
+  
+  ## Configuration options
+  
+  * `:api_key` - the API key used with Mailgun
+  * `:domain` - the domain you will be sending emails from
+  * `:base_url` - the url to use as the API endpoint. For EU domains, use https://api.eu.mailgun.net/v3
+  
   ## Example
 
       # config/config.exs


### PR DESCRIPTION
It took me some time to figure out I had to change the `base_url` to get my configuration to work.