### PR TITLE
allow custom CIDs for inline attachments

### DIFF
--- a/lib/swoosh/adapters/oh_my_smtp.ex
+++ b/lib/swoosh/adapters/oh_my_smtp.ex
@@ -102,7 +102,7 @@ defmodule Swoosh.Adapters.OhMySmtp do
         }
 
         if attachment.type == :inline do
-          Map.put(attachment_object, :cid, name)
+          Map.put(attachment_object, :cid, attachment.cid)
         else
           attachment_object
         end

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -211,7 +211,7 @@ defmodule Swoosh.Adapters.Postmark do
         attachment_data
 
       :inline ->
-        Map.put(attachment_data, "ContentID", "cid:#{attachment.filename}")
+        Map.put(attachment_data, "ContentID", "cid:#{attachment.cid}")
     end
   end
 

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -24,7 +24,7 @@ defmodule Swoosh.Attachment do
       |> VillainMailer.deliver()
   """
 
-  defstruct filename: nil, content_type: nil, path: nil, data: nil, type: :attachment, headers: []
+  defstruct filename: nil, content_type: nil, path: nil, data: nil, type: :attachment, cid: nil, headers: []
 
   @type t :: %__MODULE__{
           filename: String.t(),
@@ -32,6 +32,7 @@ defmodule Swoosh.Attachment do
           path: String.t() | nil,
           data: binary | nil,
           type: :inline | :attachment,
+          cid: String.t() | nil,
           headers: [{String.t(), String.t()}]
         }
 
@@ -63,6 +64,10 @@ defmodule Swoosh.Attachment do
   Gives you something like this:
 
       <img src="cid:file.png">
+
+  You can optionally override this default by passing in the cid option:
+
+      Attachment.new("/data/file.png", type: :inline, cid: "custom-cid")
   """
   @spec new(binary | struct | {:data, binary}, Keyword.t() | map) :: %__MODULE__{}
   def new(path, opts \\ [])
@@ -92,12 +97,15 @@ defmodule Swoosh.Attachment do
 
   def new(path, opts) do
     attachment = struct!(__MODULE__, opts)
+    filename = attachment.filename || Path.basename(path)
+    cid = if attachment.type == :inline, do: attachment.cid || filename, else: nil
 
     %{
       attachment
       | path: path,
-        filename: attachment.filename || Path.basename(path),
-        content_type: attachment.content_type || MIME.from_path(path)
+        filename: filename,
+        content_type: attachment.content_type || MIME.from_path(path),
+        cid: cid
     }
   end
 

--- a/lib/swoosh/attachment.ex
+++ b/lib/swoosh/attachment.ex
@@ -24,7 +24,13 @@ defmodule Swoosh.Attachment do
       |> VillainMailer.deliver()
   """
 
-  defstruct filename: nil, content_type: nil, path: nil, data: nil, type: :attachment, cid: nil, headers: []
+  defstruct filename: nil,
+            content_type: nil,
+            path: nil,
+            data: nil,
+            type: :attachment,
+            cid: nil,
+            headers: []
 
   @type t :: %__MODULE__{
           filename: String.t(),

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -472,28 +472,28 @@ defmodule Swoosh.Email do
        reply_to: nil, subject: "", text_body: nil, to: [],
        attachments: [%Swoosh.Attachment{path: "/data/att.zip",
         content_type: "application/zip", filename: "att.zip",
-        type: :attachment, data: nil, headers: []}]}
+        type: :attachment, data: nil, headers: [], cid: nil}]}
       iex> new() |> attachment(Swoosh.Attachment.new("/data/att.zip"))
       %Swoosh.Email{assigns: %{}, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: [],
        attachments: [%Swoosh.Attachment{path: "/data/att.zip",
         content_type: "application/zip", filename: "att.zip",
-        type: :attachment, data: nil, headers: []}]}
+        type: :attachment, data: nil, headers: [], cid: nil}]}
       iex> new() |> attachment(%Plug.Upload{path: "/data/abcdefg", content_type: "test/type", filename: "att.zip"})
       %Swoosh.Email{assigns: %{}, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: [],
        attachments: [%Swoosh.Attachment{path: "/data/abcdefg",
         content_type: "test/type", filename: "att.zip",
-        type: :attachment, data: nil, headers: []}]}
+        type: :attachment, data: nil, headers: [], cid: nil}]}
       iex> new() |> attachment(Swoosh.Attachment.new("/data/att.png", type: :inline))
       %Swoosh.Email{assigns: %{}, bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: nil, subject: "", text_body: nil, to: [],
        attachments: [%Swoosh.Attachment{path: "/data/att.png",
         content_type: "image/png", filename: "att.png",
-        type: :inline, data: nil, headers: []}]}
+        type: :inline, data: nil, headers: [], cid: "att.png"}]}
   """
   @spec attachment(t, binary | Swoosh.Attachment.t()) :: t
   def attachment(%__MODULE__{attachments: attachments} = email, path) when is_binary(path) do

--- a/test/swoosh/adapters/oh_my_smtp_test.exs
+++ b/test/swoosh/adapters/oh_my_smtp_test.exs
@@ -129,7 +129,9 @@ defmodule Swoosh.Adapters.OhMySmtpTest do
       |> from({"T Stark", "tony.stark@example.com"})
       |> to({"Steve Rogers", "steve.rogers@example.com"})
       |> subject("Hello, Avengers!")
-      |> attachment(Swoosh.Attachment.new("test/support/attachment.txt", type: :inline))
+      |> attachment(
+        Swoosh.Attachment.new("test/support/attachment.txt", type: :inline, cid: "attachment-cid")
+      )
 
     Bypass.expect(bypass, fn conn ->
       conn = parse(conn)
@@ -148,7 +150,7 @@ defmodule Swoosh.Adapters.OhMySmtpTest do
             "name" => "attachment.txt",
             "content" => attachment_content,
             "content_type" => "text/plain",
-            "cid" => "attachment.txt"
+            "cid" => "attachment-cid"
           }
         ]
       }

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -295,6 +295,44 @@ defmodule Swoosh.Adapters.PostmarkTest do
     assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
   end
 
+  test "deliver/1 with inline attachment uses correct CID", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"Steve Rogers", "steve.rogers@example.com"})
+      |> to("tony.stark@example.com")
+      |> attachment(
+        Swoosh.Attachment.new("test/support/attachment.txt", type: :inline, cid: "attachment-cid")
+      )
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      attachment_content =
+        "test/support/attachment.txt"
+        |> File.read!()
+        |> Base.encode64()
+
+      body_params = %{
+        "To" => "tony.stark@example.com",
+        "From" => "\"Steve Rogers\" <steve.rogers@example.com>",
+        "Attachments" => [%{
+          "Name" => "attachment.txt",
+          "ContentType" => "text/plain",
+          "Content" => attachment_content,
+          "ContentID" => "cid:attachment-cid"
+        }]
+      }
+
+      assert body_params == conn.body_params
+      assert "/email" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
+  end
+
   test "delivery/2 with defined message stream returns :ok", %{
     bypass: bypass,
     config: config

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -315,12 +315,14 @@ defmodule Swoosh.Adapters.PostmarkTest do
       body_params = %{
         "To" => "tony.stark@example.com",
         "From" => "\"Steve Rogers\" <steve.rogers@example.com>",
-        "Attachments" => [%{
-          "Name" => "attachment.txt",
-          "ContentType" => "text/plain",
-          "Content" => attachment_content,
-          "ContentID" => "cid:attachment-cid"
-        }]
+        "Attachments" => [
+          %{
+            "Name" => "attachment.txt",
+            "ContentType" => "text/plain",
+            "Content" => attachment_content,
+            "ContentID" => "cid:attachment-cid"
+          }
+        ]
       }
 
       assert body_params == conn.body_params

--- a/test/swoosh/attachment_test.exs
+++ b/test/swoosh/attachment_test.exs
@@ -51,6 +51,18 @@ defmodule Swoosh.AttachmentTest do
   test "create an attachment that should be sent as an inline-attachment" do
     attachment = Attachment.new("/data/file.png", type: :inline)
     assert attachment.type == :inline
+    assert attachment.cid == "file.png"
+  end
+
+  test "create an inline attachment with a custom CID" do
+    attachment = Attachment.new("/data/file.png", type: :inline, cid: "my-cid")
+    assert attachment.type == :inline
+    assert attachment.cid == "my-cid"
+  end
+
+  test "does not set cid for regular (non-inline) attachments" do
+    attachment = Attachment.new("/data/file.png")
+    assert is_nil(attachment.cid)
   end
 
   test "create an attachment with custom headers" do


### PR DESCRIPTION
Closes #658 

Added some tests for this (for OhMySMTP and Postmark, the only adapters that handle inline images). Also tested manually with OhMySMTP and it works.