### PR TITLE
Change assert_email_sent to pass if assigns differ

### DIFF
--- a/lib/swoosh/adapters/test.ex
+++ b/lib/swoosh/adapters/test.ex
@@ -21,6 +21,8 @@ defmodule Swoosh.Adapters.Test do
 
   @impl true
   def deliver(email, _config) do
+    email = clean_assigns(email)
+
     for pid <- pids() do
       send(pid, {:email, email})
     end
@@ -30,11 +32,17 @@ defmodule Swoosh.Adapters.Test do
 
   @impl true
   def deliver_many(emails, _config) do
+    emails = Enum.map(emails, fn email -> clean_assigns(email) end)
+
     for pid <- pids() do
       send(pid, {:emails, emails})
     end
 
     {:ok, %{}}
+  end
+
+  def clean_assigns(email) do
+    %{email | assigns: :assigns_removed_for_testing}
   end
 
   # Essentially finds all of the processes that tried to send an email (in the test)

--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -97,6 +97,7 @@ defmodule Swoosh.TestAssertions do
       iex> assert_email_sent fn email -> length(email.to) == 2 end
   """
   def assert_email_sent(%Email{} = email) do
+    email = Swoosh.Adapters.Test.clean_assigns(email)
     assert_received {:email, ^email}
   end
 

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -64,6 +64,20 @@ defmodule Swoosh.TestAssertionsTest do
     end)
   end
 
+  test "assert email sent with differing assigns" do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to(["steve.rogers@example.com", "bruce.banner@example.com"])
+      |> html_body("some html")
+      |> text_body("some text")
+      |> assign(:user, %{assoc: :not_loaded})
+
+    deliver(email)
+
+    assert_email_sent(assign(email, :user, %{assoc: %{}}))
+  end
+
   test "assert email sent with wrong subject" do
     assert_raise ExUnit.AssertionError, fn ->
       assert_email_sent(subject: "Hello, X-Men!")


### PR DESCRIPTION
`assert_email_sent(email)` currently fails if the `email.assigns` structs differ.

I'm coming from Bamboo, where this is not the case:
https://github.com/thoughtbot/bamboo/issues/154

As an example, I might have

users.exs
```elixir
def grant_admin_permission(user) do
  user = Repo.preload(:permissions)

  # ...grant some permissions based on existing user.permissions

  MyApp.Mailer.admin_permission_granted(user)
  |> MyApp.Mailer.deliver()
end
```

test.exs
```elixir
test "can grant admin permissions and an email gets sent" do
  user = Users.create(%{name: "Sue", email: "sue@example.com"})
  # Note that we don't have the association loaded here in the test
  refute Ecto.assoc_loaded?(user.permissions)

  Users.grant_admin_permission(user)
  assert_email_sent(MyApp.Mailer.admin_permission_granted(user))
end
```

This test will fail, as the email that got delivered had a different `assigns.user.permissions value` than the one in the test.

This PR ignores any assigns when asserting an email was sent, as they're not part of the actual email.