### PR TITLE
Add fields to Postmark `deliver_many` response

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -112,7 +112,9 @@ defmodule Swoosh.Adapters.Postmark do
             %{
               id: email_result["MessageID"],
               error_code: email_result["ErrorCode"],
-              message: email_result["Message"]
+              message: email_result["Message"],
+              to: email_result["To"],
+              submitted_at: email_result["SubmittedAt"]
             }
           end)
 

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -451,12 +451,16 @@ defmodule Swoosh.Adapters.PostmarkTest do
                 %{
                   id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817",
                   error_code: 0,
-                  message: "OK"
+                  message: "OK",
+                  to: "steve.rogers@example.com",
+                  submitted_at: "2010-11-26T12:01:05.1794748-05:00"
                 },
                 %{
                   id: "e2ecbbfc-fe12-463d-b933-9fe22915106d",
                   error_code: 0,
-                  message: "OK"
+                  message: "OK",
+                  to: "natasha.romanova@example.com",
+                  submitted_at: "2010-11-26T12:01:05.1794748-05:00"
                 }
               ]}
   end
@@ -550,12 +554,16 @@ defmodule Swoosh.Adapters.PostmarkTest do
                 %{
                   id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817",
                   error_code: 0,
-                  message: "OK"
+                  message: "OK",
+                  to: "steve.rogers@example.com",
+                  submitted_at: "2010-11-26T12:01:05.1794748-05:00"
                 },
                 %{
                   id: "e2ecbbfc-fe12-463d-b933-9fe22915106d",
                   error_code: 0,
-                  message: "OK"
+                  message: "OK",
+                  to: "natasha.romanova@example.com",
+                  submitted_at: "2010-11-26T12:01:05.1794748-05:00"
                 }
               ]}
   end


### PR DESCRIPTION
While working on a feature to send a number of emails using `deliver_many`, I was referencing [Postmark's docs on sending batch emails](https://postmarkapp.com/developer/api/email-api#send-batch-emails). I had assumed that the value returned by the Postmark adapter's `deliver_many` implementation (and also `deliver`) would return the API response using something like `Jason.decode!`, so my original implementation was expecting the String keys matching the casing found in the Postmark API response. I was surprised to find the response was a map with atomized keys and only a subset of the API response. Digging into the Postmark adapter's source, I found the bit of code that was performing the JSON decoding and mapping a subset of values. I need to extend that return value with the "To" field from the API response so I can perform some internal mapping of the recipient and store a receipt of the email.

This PR extends the Postmark adapter's `deliver_many` response to include the "To" and "SubmittedAt" fields from the API. I need the "To" field for my project, but I threw in the "SubmittedAt" field because I figured some additional data couldn't hurt. I'm looking forward to your feedback. Thanks! 💜 