### PR TITLE
Add message_stream documentation to Postmark adapter

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -48,6 +48,9 @@ defmodule Swoosh.Adapters.Postmark do
       |> put_provider_option(:tag, "some tag")
 
   ## Provider Options
+  
+    * `:message_stream` (string) – `MessageStream`, configure the message stream
+      for the email
 
     * `:metadata` (map) - `Metadata`, add metadata to an email
 


### PR DESCRIPTION
`put_provider_option/3` accepts `:message_stream` as an option, but this was not documented.