### PR TITLE
Rename Mime-Version header to MIME-Version

### DIFF
--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -75,7 +75,7 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
   defp prepare_reply_to(headers, %{reply_to: reply_to}),
     do: [{"Reply-To", render_recipient(reply_to)} | headers]
 
-  defp prepare_mime_version(headers), do: [{"Mime-Version", "1.0"} | headers]
+  defp prepare_mime_version(headers), do: [{"MIME-Version", "1.0"} | headers]
 
   defp prepare_additional_headers(headers, %{headers: additional_headers}) do
     Map.to_list(additional_headers) ++ headers

--- a/test/swoosh/adapters/gmail_test.exs
+++ b/test/swoosh/adapters/gmail_test.exs
@@ -35,7 +35,7 @@ defmodule Swoosh.Adapters.GmailTest do
         ~s"""
         To: "" <tony.stark@example.com>\r
         Subject: Hello, Avengers!\r
-        Mime-Version: 1.0\r
+        MIME-Version: 1.0\r
         From: "" <steve.rogers@example.com>\r
         Content-Type: multipart/alternative; boundary="#{boundary}"\r
         \r
@@ -89,7 +89,7 @@ defmodule Swoosh.Adapters.GmailTest do
         To: "Steve Rogers" <steve.rogers@example.com>, "" <wasp.avengers@example.com>\r
         Subject: Hello, Avengers!\r
         Reply-To: "" <iron.stark@example.com>\r
-        Mime-Version: 1.0\r
+        MIME-Version: 1.0\r
         From: "T Stark" <tony.stark@example.com>\r
         Content-Type: multipart/alternative; boundary="#{boundary}"\r
         Cc: "" <thor.odinson@example.com>\r

--- a/test/swoosh/email/smtp_test.exs
+++ b/test/swoosh/email/smtp_test.exs
@@ -27,7 +27,7 @@ defmodule Swoosh.Email.SMTPTest do
                 {"From", "tony@stark.com"},
                 {"To", "steve@rogers.com"},
                 {"Subject", "Hello, Avengers!"},
-                {"Mime-Version", "1.0"}
+                {"MIME-Version", "1.0"}
               ], "Hello"}
   end
 
@@ -54,7 +54,7 @@ defmodule Swoosh.Email.SMTPTest do
                 {"Bcc", "beast@avengers.com, \"Clinton Francis Barton\" <hawk@eye.com>"},
                 {"Subject", "Hello, Avengers!"},
                 {"Reply-To", "black@widow.com"},
-                {"Mime-Version", "1.0"},
+                {"MIME-Version", "1.0"},
                 {"X-Custom-ID", "4f034001"},
                 {"X-Feedback-ID", "403f4983b02a"}
               ], "Hello"}
@@ -70,7 +70,7 @@ defmodule Swoosh.Email.SMTPTest do
                 {"From", "tony@stark.com"},
                 {"To", "\"Bruce Banner\" <bruce@banner.com>, steve@rogers.com"},
                 {"Subject", "Hello, Avengers!"},
-                {"Mime-Version", "1.0"}
+                {"MIME-Version", "1.0"}
               ], "Hello"}
   end
 
@@ -89,7 +89,7 @@ defmodule Swoosh.Email.SMTPTest do
                 {"To", "\"Bruce Banner\" <bruce@banner.com>, steve@rogers.com"},
                 {"Cc", "thor@odinson.com"},
                 {"Subject", "Hello, Avengers!"},
-                {"Mime-Version", "1.0"}
+                {"MIME-Version", "1.0"}
               ], "Hello"}
   end
 
@@ -103,7 +103,7 @@ defmodule Swoosh.Email.SMTPTest do
                 {"From", "tony@stark.com"},
                 {"To", "steve@rogers.com"},
                 {"Subject", "Hello, Avengers!"},
-                {"Mime-Version", "1.0"}
+                {"MIME-Version", "1.0"}
               ], "<h1>Hello</h1>"}
   end
 
@@ -114,7 +114,7 @@ defmodule Swoosh.Email.SMTPTest do
                 {"From", "tony@stark.com"},
                 {"To", "steve@rogers.com"},
                 {"Subject", "Hello, Avengers!"},
-                {"Mime-Version", "1.0"}
+                {"MIME-Version", "1.0"}
               ],
               [
                 {"text", "plain",


### PR DESCRIPTION
Even though [RFC5234](https://www.rfc-editor.org/rfc/rfc5234#section-2.3) says email headers are case-insensitive, prefer to use the value given by [RFC1341](https://datatracker.ietf.org/doc/html/rfc1341#page-5).

For instance, [rspamd doesn't like `Mime-Version`](https://github.com/rspamd/rspamd/blob/f24d59a607066d339597a1a537f3171c9350a1d6/rules/headers_checks.lua#L589-L596).