### PR TITLE
Allow send email with empty 'To' header

### DIFF
--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -62,6 +62,7 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
 
   defp prepare_from(headers, %{from: from}), do: [{"From", render_recipient(from)} | headers]
 
+  defp prepare_to(headers, %{to: []}), do: headers
   defp prepare_to(headers, %{to: to}), do: [{"To", render_recipient(to)} | headers]
 
   defp prepare_cc(headers, %{cc: []}), do: headers


### PR DESCRIPTION
I need to send emails with only bcc addresses, but when I tried to send with an empty list in `to` attribute I got:

```sh
** (MatchError) no match of right hand side value: {:error, {999999, :smtp_rfc5322_parse, ['syntax error before: ', []]}}
    (gen_smtp 1.2.0) /__w/app/app/deps/gen_smtp/src/mimemail.erl:999: :mimemail.encode_header_value/2
    (gen_smtp 1.2.0) /__w/app/app/deps/gen_smtp/src/mimemail.erl:963: :mimemail.encode_headers/1
    (gen_smtp 1.2.0) /__w/app/app/deps/gen_smtp/src/mimemail.erl:964: :mimemail.encode_headers/1
    (gen_smtp 1.2.0) /__w/app/app/deps/gen_smtp/src/mimemail.erl:210: :mimemail.encode/2
    (swoosh 1.6.6) lib/swoosh/adapters/amazon_ses.ex:165: Swoosh.Adapters.AmazonSES.generate_raw_message_data/2
    (swoosh 1.6.6) lib/swoosh/adapters/amazon_ses.ex:134: Swoosh.Adapters.AmazonSES.prepare_body/2
    (swoosh 1.6.6) lib/swoosh/adapters/amazon_ses.ex:90: Swoosh.Adapters.AmazonSES.deliver/2
    (app 0.1.0) lib/app/notifications/emails/mailer.ex:2: anonymous fn/2 in App.Notifications.Emails.Mailer.instrument/3
```

We can just don't add the `to` header when we have an empty list, just like `cc`