### PR TITLE
sendgrid add support for scheduling emails

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -62,6 +62,8 @@ defmodule Swoosh.Adapters.Sendgrid do
       |> put_provider_option(:tracking_settings, %{
         subscription_tracking: %{enable: false}
       })
+      |> put_provider_option(:batch_id, "AsdFgHjklQweRTYuIopzXcVBNm0aSDfGHjklmZcVbNMqWert1znmOP2asDFjkl")
+      |> put_provider_option(:send_at, 1617260400)
 
   ## Provider Options
 
@@ -90,6 +92,12 @@ defmodule Swoosh.Adapters.Sendgrid do
 
     * `:tracking_settings` (map) - collection of settings to track the metrics
       of responses of email recipients
+
+    * `:send_at` (integer) - A unix timestamp allowing you to specify when
+      you want your email to be delivered.
+
+    * `:batch_id` (string) - An ID representing a batch of emails to be sent at
+      the same time. It also enables you to cancel or pause the delivery of that batch
 
   ## Sandbox mode
 

--- a/test/swoosh/adapters/sendgrid_test.exs
+++ b/test/swoosh/adapters/sendgrid_test.exs
@@ -644,8 +644,11 @@ defmodule Swoosh.Adapters.SendgridTest do
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
-      |> put_provider_option(:batch_id, "AsdFgHjklQweRTYuIopzXcVBNm0aSDfGHjklmZcVbNMqWert1znmOP2asDFjkl")
-      |> put_provider_option(:send_at, 1617260400)
+      |> put_provider_option(
+        :batch_id,
+        "AsdFgHjklQweRTYuIopzXcVBNm0aSDfGHjklmZcVbNMqWert1znmOP2asDFjkl"
+      )
+      |> put_provider_option(:send_at, 1_617_260_400)
 
     Bypass.expect(bypass, fn conn ->
       conn = parse(conn)
@@ -663,7 +666,7 @@ defmodule Swoosh.Adapters.SendgridTest do
         ],
         "subject" => "Hello, Avengers!",
         "batch_id" => "AsdFgHjklQweRTYuIopzXcVBNm0aSDfGHjklmZcVbNMqWert1znmOP2asDFjkl",
-        "send_at"  => 1617260400
+        "send_at" => 1_617_260_400
       }
 
       assert body_params == conn.body_params


### PR DESCRIPTION
For sending scheduled emails through sendgrid, two body fields were missing. This PR adds `send_at` and `batch_id` to sendgrid adapter `provider_options_body_fields`