### PR TITLE
Support assertions for headers

### DIFF
--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -151,6 +151,9 @@ defmodule Swoosh.TestAssertions do
   defp assert_equal(email, {:html_body, value}),
     do: assert(email.html_body == value)
 
+  defp assert_equal(email, {:headers, value}),
+    do: assert(email.headers == value)
+
   @doc ~S"""
   Asserts no emails were sent.
   """

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -300,12 +300,12 @@ defmodule Swoosh.TestAssertionsTest do
   end
 
   test "refute email sent with specific header" do
-    refute_email_sent(headers: unquote(%{"Revengers" => "Gather"}))
+    refute_email_sent(headers: %{"Revengers" => "Gather"})
   end
 
   test "refute email sent with expected header" do
     assert_raise ExUnit.AssertionError, fn ->
-      refute_email_sent(headers: unquote(%{"Avengers" => "Assemble"}))
+      refute_email_sent(headers: %{"Avengers" => "Assemble"})
     end
   end
 

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -17,6 +17,7 @@ defmodule Swoosh.TestAssertionsTest do
       |> to(["steve.rogers@example.com", "bruce.banner@example.com"])
       |> cc(["natasha.romanoff@example.com", "stephen.strange@example.com"])
       |> bcc("loki.odinson@example.com")
+      |> header("Avengers", "Assemble")
       |> subject("Hello, Avengers!")
       |> html_body("some html")
       |> text_body("some text")
@@ -97,6 +98,12 @@ defmodule Swoosh.TestAssertionsTest do
   test "assert email sent with wrong bcc" do
     assert_raise ExUnit.AssertionError, fn ->
       assert_email_sent(bcc: "bruce.banner@example.com")
+    end
+  end
+
+  test "assert email sent with wrong header" do
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_email_sent(headers: %{"Revengers" => "Gather"})
     end
   end
 
@@ -289,6 +296,16 @@ defmodule Swoosh.TestAssertionsTest do
   test "refute email sent with expected bcc (list)" do
     assert_raise ExUnit.AssertionError, fn ->
       refute_email_sent(bcc: ["loki.odinson@example.com"])
+    end
+  end
+
+  test "refute email sent with specific header" do
+    refute_email_sent(headers: unquote(%{"Revengers" => "Gather"}))
+  end
+
+  test "refute email sent with expected header" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(headers: unquote(%{"Avengers" => "Assemble"}))
     end
   end
 


### PR DESCRIPTION
Added headers clause for `assert_equal` and some tests to check this functionality.