### PR TITLE
Fix markdown issues and typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Changelog
+# Changelog
 
 ## 1.7.3
 
@@ -70,8 +70,8 @@
 
 ## 1.6.2
 
-- SMTP can now utilize the new `:cid` addition in attachments, if `:cid` is `nil` it will fallback
-  to original behavior and use `:filename`
+- SMTP can now utilize the new `:cid` addition in attachments, if `:cid` is
+  `nil` it will fallback to original behavior and use `:filename`
 - Fixed filename for inline images sent via SMTP
 
 ## 1.6.1
@@ -163,13 +163,15 @@ You can configure what API Client to use by setting the config. Swoosh comes wit
 config :swoosh, :api_client, MyAPIClient
 ```
 
-It defaults to use `:hackney` with `Swoosh.ApiClient.Hackney`. To use `Finch`, add the below config
+It defaults to use `:hackney` with `Swoosh.ApiClient.Hackney`. To use `Finch`,
+add the below config
 
 ```elixir
 config :swoosh, :api_client, Swoosh.ApiClient.Finch
 ```
 
-To use `Swoosh.ApiClient.Finch` you also need to start `Finch`, either in your supervision tree
+To use `Swoosh.ApiClient.Finch` you also need to start `Finch`, either in your
+supervision tree
 
 ```elixir
 children = [
@@ -183,8 +185,8 @@ or somehow manually, and very rarely dynamically
 Finch.start_link(name: Swoosh.Finch)
 ```
 
-If a name different from `Swoosh.Finch` is used, or you want to use an existing Finch instance,
-you can provide the name via the config.
+If a name different from `Swoosh.Finch` is used, or you want to use an existing
+Finch instance, you can provide the name via the config.
 
 ```elixir
 config :swoosh,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,14 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:
 
@@ -10,13 +16,25 @@ Examples of unacceptable behavior by participants include:
 * Personal attacks
 * Trolling or insulting/derogatory comments
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
 * Other unethical or unprofessional conduct.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct. By adopting this Code of Conduct,
+project maintainers commit themselves to fairly and consistently applying these
+principles to every aspect of managing this project. Project maintainers who do
+not follow or enforce the Code of Conduct may be permanently removed from the
+project team.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue or contacting one or more of the project
+maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)
+This Code of Conduct is adapted from the
+[Contributor Covenant](http://contributor-covenant.org), version 1.2.0,
+available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,31 @@
 # Contributing to Swoosh
 
-Thanks for thinking about contributing to Swoosh. Please review this document first and also take a look at our
-[Code of Conduct](CODE_OF_CONDUCT.md), to help us keep this project inclusive to all those that may wish to contribute
+Thanks for thinking about contributing to Swoosh. Please review this document
+first and also take a look at our [Code of Conduct](CODE_OF_CONDUCT.md), to
+help us keep this project inclusive to all those that may wish to contribute
 also.
 
 ## Opening Issues
 
-We classify bugs as any unexpected behaviour that occurs based on the code in the project, and we really appreciate it
-when users take the time to [create an issue](https://github.com/soosh/swoosh/issues).
+We classify bugs as any unexpected behaviour that occurs based on the code in
+the project, and we really appreciate it when users take the time to
+[create an issue](https://github.com/soosh/swoosh/issues).
 
-Please take time to add as much detail as you can to any bug reports, consider including things like the version of
-Elixir you are using, which adapter you are having trouble with and any custom config you have passed for that adapter.
+Please take time to add as much detail as you can to any bug reports, consider
+including things like the version of Elixir you are using, which adapter you
+are having trouble with and any custom config you have passed for that adapter.
 
-If you are thinking about adding a feature, you should the check Issues first, someone else may have started already,
-or it might be a feature we've decided not to implement intentionally.
+If you are thinking about adding a feature, you should the check Issues first,
+someone else may have started already, or it might be a feature we've decided
+not to implement intentionally.
 
 ## Submitting Pull Requests
 
-Whether you're fixing a bug, or proposing a feature you'd like to see included, you can submit Pull Requests by
-following this guide:
+Whether you're fixing a bug, or proposing a feature you'd like to see included,
+you can submit Pull Requests by following this guide:
 
-1. [Fork this repository](https://github.com/swoosh/swoosh/fork) and then clone it locally:
+1. [Fork this repository](https://github.com/swoosh/swoosh/fork) and then clone
+   it locally:
 
   ```bash
   git clone https://github.com/swoosh/swoosh
@@ -58,16 +63,16 @@ following this guide:
 
 7. [Submit a pull request.](https://help.github.com/articles/creating-a-pull-request)
 
-
 ## Style guidelines
 
-We support the common conventions found in Elixir, if you're in doubt take a look at the code in the project, and we
-would like to keep the style consistent throughout.
+We support the common conventions found in Elixir, if you're in doubt take a
+look at the code in the project, and we would like to keep the style consistent
+throughout.
 
 ### General rules
 
 - Keep line length below 120 characters.
 - Complex anonymous functions should be extracted into named functions.
 - One line functions, should only take up one line!
-- Pipes are great, but don't use them, if they are less readable than brackets then drop the pipe!
-
+- Pipes are great, but don't use them, if they are less readable than brackets
+  then drop the pipe!

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ configuration options.
   Swoosh also accepts [`Finch`](https://hex.pm/packages/finch) out-of-the-box.
   See `Swoosh.ApiClient.Finch` for details.
 
-  If you need to integrate with another HTTP client, it's easy to define a new API client.
-  Follow the `Swoosh.ApiClient` behaviour and configure Swoosh to use it:
+  If you need to integrate with another HTTP client, it's easy to define a new
+  API client.  Follow the `Swoosh.ApiClient` behaviour and configure Swoosh to
+  use it:
 
   ```elixir
   config :swoosh, :api_client, MyApp.ApiClient
@@ -105,8 +106,9 @@ configuration options.
   config :swoosh, :api_client, false
   ```
 
-  This is the case when you are using `Swoosh.Adapters.Local`, `Swoosh.Adapters.Test` and
-  adapters that are SMTP based, that don't require an API client.
+  This is the case when you are using `Swoosh.Adapters.Local`,
+  `Swoosh.Adapters.Test` and adapters that are SMTP based, that don't require
+  an API client.
 
 - (Optional) If you are using `Swoosh.Adapters.SMTP`,
   `Swoosh.Adapters.Sendmail` or `Swoosh.Adapters.AmazonSES`, you also need to
@@ -223,7 +225,8 @@ Elixir's ecosystem has many
 
 - [Oban](https://hexdocs.pm/oban/Oban.html) is the current community favourite.
   It uses PostgreSQL for storage and coordination.
-- [Exq](https://hexdocs.pm/exq/readme.html) uses Redis and is compatible with Resque / Sidekiq.
+- [Exq](https://hexdocs.pm/exq/readme.html) uses Redis and is compatible with
+  Resque / Sidekiq.
 
 ## Phoenix integration
 
@@ -236,7 +239,8 @@ Taking the example from above the "Getting Started" section, your code would
 look something like this:
 
 > web/templates/layout/email.html.eex
-```
+
+```html
 <html>
   <head>
     <title><%= @email.subject %></title>
@@ -248,6 +252,7 @@ look something like this:
 ```
 
 > web/templates/email/welcome.html.eex
+
 ```html
 <div>
   <h1>Welcome to Sample, <%= @username %>!</h1>
@@ -255,6 +260,7 @@ look something like this:
 ```
 
 > web/emails/user_email.ex
+
 ```elixir
 defmodule Sample.UserEmail do
   use Phoenix.Swoosh, view: Sample.EmailView, layout: {Sample.LayoutView, :email}
@@ -305,7 +311,8 @@ defmodule Sample.UserTest do
   import Swoosh.TestAssertions
 
   test "send email on user signup" do
-    # Assuming `create_user` creates a new user then sends out a `Sample.UserEmail.welcome` email
+    # Assuming `create_user` creates a new user then sends out a
+    # `Sample.UserEmail.welcome` email
     user = create_user(%{username: "ironman", email: "tony.stark@example.com"})
     assert_email_sent Sample.UserEmail.welcome(user)
   end
@@ -368,7 +375,7 @@ And finally you can also use the following Mix task to start the mailbox
 preview server independently:
 
 ```console
-$ mix swoosh.mailbox.server
+mix swoosh.mailbox.server
 ```
 
 _Note_: the mailbox preview won't display emails
@@ -383,7 +390,7 @@ If you are curious, this is how it the mailbox preview looks like:
 The preview is also available as a JSON endpoint.
 
 ```sh
-$ curl http://localhost:4000/dev/mailbox/json
+curl http://localhost:4000/dev/mailbox/json
 ```
 
 ### Production
@@ -406,7 +413,8 @@ The following events are emitted:
 - `[:swoosh, :deliver, :exception]`: occurs when `Mailer.deliver/2` throws an exception.
 - `[:swoosh, :deliver_many, :start]`: occurs when `Mailer.deliver_many/2` begins.
 - `[:swoosh, :deliver_many, :stop]`: occurs when `Mailer.deliver_many/2` completes.
-- `[:swoosh, :deliver_many, :exception]`: occurs when `Mailer.deliver_many/2` throws an exception.
+- `[:swoosh, :deliver_many, :exception]`: occurs when `Mailer.deliver_many/2`
+  throws an exception.
 
 View [example in docs](https://hexdocs.pm/swoosh/Swoosh.Mailer.html#module-telemetry)
 
@@ -422,22 +430,28 @@ We are grateful for any contributions. Before you submit an issue or a pull
 request, remember to:
 
 - Look at our [Contributing guidelines](CONTRIBUTING.md)
-- Not use the issue tracker for help or support requests (try StackOverflow, IRC or Slack instead)
-- Do a quick search in the issue tracker to make sure the issues hasn't been reported yet.
+- Not use the issue tracker for help or support requests (try StackOverflow,
+  IRC or Slack instead)
+- Do a quick search in the issue tracker to make sure the issues hasn't been
+  reported yet.
 - Look and follow the [Code of Conduct](CODE_OF_CONDUCT.md). Be nice and have fun!
 
 ### Running tests
 
 Clone the repo and fetch its dependencies:
 
-    $ git clone https://github.com/swoosh/swoosh.git
-    $ cd swoosh
-    $ mix deps.get
-    $ mix test
+```sh
+git clone https://github.com/swoosh/swoosh.git
+cd swoosh
+mix deps.get
+mix test
+```
 
 ### Building docs
 
-    $ MIX_ENV=docs mix docs
+```sh
+MIX_ENV=docs mix docs
+```
 
 ## LICENSE
 

--- a/lib/swoosh/adapters/smtp.ex
+++ b/lib/swoosh/adapters/smtp.ex
@@ -82,7 +82,7 @@ defmodule Swoosh.Adapters.SMTP do
         else
           raise ArgumentError, """
           #{key} is not configured properly,
-          got: #{value}, expected one of the followings:
+          got: #{value}, expected one of the following:
           #{valid_values |> Enum.map_join(", ", &inspect/1)}
           """
         end

--- a/lib/swoosh/adapters/sparkpost.ex
+++ b/lib/swoosh/adapters/sparkpost.ex
@@ -56,7 +56,7 @@ defmodule Swoosh.Adapters.SparkPost do
     * `:template_id` (string) - id of the template to use
 
     * `:substitution_data` (map) - data passed to the template language in
-      the content, and take precendence over the other data like `:metadata`
+      the content, and take precedence over the other data like `:metadata`
 
   """
 

--- a/test/swoosh/adapters/smtp_test.exs
+++ b/test/swoosh/adapters/smtp_test.exs
@@ -54,7 +54,7 @@ defmodule Swoosh.Adapters.SMTPTest do
     assert_raise ArgumentError,
                  """
                  ssl is not configured properly,
-                 got: INVALID, expected one of the followings:
+                 got: INVALID, expected one of the following:
                  true, false
                  """,
                  fn ->
@@ -66,7 +66,7 @@ defmodule Swoosh.Adapters.SMTPTest do
     assert_raise ArgumentError,
                  """
                  auth is not configured properly,
-                 got: INVALID, expected one of the followings:
+                 got: INVALID, expected one of the following:
                  :always, :never, :if_available
                  """,
                  fn ->
@@ -78,7 +78,7 @@ defmodule Swoosh.Adapters.SMTPTest do
     assert_raise ArgumentError,
                  """
                  tls is not configured properly,
-                 got: INVALID, expected one of the followings:
+                 got: INVALID, expected one of the following:
                  :always, :never, :if_available
                  """,
                  fn ->


### PR DESCRIPTION
See a detailed description of the rules is available at
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md