### PR TITLE
Fix typos in gmail and socket labs adapters

### DIFF
--- a/lib/swoosh/adapters/gmail.ex
+++ b/lib/swoosh/adapters/gmail.ex
@@ -15,7 +15,7 @@ defmodule Swoosh.Adapters.Gmail do
 
   ## Example
 
-      # config/congig.exs
+      # config/config.exs
       config :sample, Sample.Mailer,
         adapter: Swoosh.Adapters.Gmail,
         access_token: {:system, "GMAIL_API_ACCESS_TOKEN"}

--- a/lib/swoosh/adapters/socket_labs.ex
+++ b/lib/swoosh/adapters/socket_labs.ex
@@ -6,7 +6,7 @@ defmodule Swoosh.Adapters.SocketLabs do
 
   ## Example
 
-      # config/congig.exs
+      # config/config.exs
       config :sample, Sample.Mailer
         adapter: Swoosh.Adapters.SocketLabs,
         server_id: "",


### PR DESCRIPTION
Fixes a small typo in gmail and socket labs adapter documentation.