### PR TITLE
Set attachment's ContentId in Mailjet

### DIFF
--- a/lib/swoosh/adapters/mailjet.ex
+++ b/lib/swoosh/adapters/mailjet.ex
@@ -208,7 +208,8 @@ defmodule Swoosh.Adapters.Mailjet do
     %{
       "ContentType" => attachment.content_type,
       "Filename" => attachment.filename,
-      "Base64Content" => Attachment.get_content(attachment, :base64)
+      "Base64Content" => Attachment.get_content(attachment, :base64),
+      "ContentId" => attachment.cid || attachment.filename
     }
   end
 


### PR DESCRIPTION
I can see that cid is not honoured in other adapters as well, but I just checked the Mailjet docs for how to pass that param in there.