### PR TITLE
Fix crashes caused by the memory GenServer restarts

### DIFF
--- a/lib/swoosh/adapters/local/storage/manager.ex
+++ b/lib/swoosh/adapters/local/storage/manager.ex
@@ -1,0 +1,39 @@
+defmodule Swoosh.Adapters.Local.Storage.Manager do
+  @moduledoc ~S"""
+  Manages the creation/monitoring of the global in-memory storage driver,
+  `Swoosh.Adapters.Local.Storage.Memory`
+  """
+
+  use GenServer
+
+  def start_link(args \\ []) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @doc false
+  def init(_args) do
+    {:ok, restart_or_monitor()}
+  end
+
+  @doc false
+  def handle_info({:DOWN, _, :process, _, :normal}, _) do
+    # In case the process is stopped normally with `stop/0`
+    {:stop, :normal, %{}}
+  end
+
+  def handle_info({:DOWN, _, :process, _, _reason}, _) do
+    # Try to either restart the global GenServer or monitor the newly
+    # created one.
+    {:noreply, restart_or_monitor()}
+  end
+
+  defp restart_or_monitor() do
+    case Swoosh.Adapters.Local.Storage.Memory.start() do
+      {:ok, pid} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
+    |> Process.monitor()
+
+    %{}
+  end
+end

--- a/lib/swoosh/adapters/local/storage/manager.ex
+++ b/lib/swoosh/adapters/local/storage/manager.ex
@@ -24,6 +24,7 @@ defmodule Swoosh.Adapters.Local.Storage.Manager do
   def handle_info({:DOWN, _, :process, _, _reason}, _) do
     # Try to either restart the global GenServer or monitor the newly
     # created one.
+    Process.sleep(:rand.uniform(1800) + 200)
     {:noreply, restart_or_monitor()}
   end
 

--- a/lib/swoosh/adapters/local/storage/memory.ex
+++ b/lib/swoosh/adapters/local/storage/memory.ex
@@ -12,15 +12,8 @@ defmodule Swoosh.Adapters.Local.Storage.Memory do
   @doc """
   Starts the server
   """
-  def start_link(args \\ []) do
-    case GenServer.start_link(__MODULE__, args, name: {:global, __MODULE__}) do
-      {:ok, pid} ->
-        {:ok, pid}
-
-      {:error, {:already_started, pid}} ->
-        Process.link(pid)
-        {:ok, pid}
-    end
+  def start(args \\ []) do
+    GenServer.start(__MODULE__, args, name: {:global, __MODULE__})
   end
 
   @doc """

--- a/lib/swoosh/application.ex
+++ b/lib/swoosh/application.ex
@@ -17,7 +17,7 @@ defmodule Swoosh.Application do
 
   defp runtime_children(children, :local) do
     if Application.get_env(:swoosh, :local, true) do
-      [Swoosh.Adapters.Local.Storage.Memory | children]
+      [Swoosh.Adapters.Local.Storage.Manager | children]
     else
       children
     end


### PR DESCRIPTION
Connecting/disconnecting nodes to a cluster will cause multiple restarts of the `Memory` adapter GenServer making [exceeding the `max_restarts` of the top-level supervisor](https://hexdocs.pm/elixir/1.13/Supervisor.html#init/2) easy thus crashing the application.

This adds a manager GenServer that will monitor the global adapter instead of linking to it to avoid crashing it when a node disconnects and trigger the above condition.

The bug is triggered by having two nodes in a cluster and running this code:
```elixir
def trigger do
    Node.connect(:"node1@127.0.0.1")
    Process.sleep(400)
    Node.disconnect(:"node1@127.0.0.1")
    Process.sleep(400)
    Node.connect(:"node1@127.0.0.1")
    Process.sleep(400)
    Node.disconnect(:"node1@127.0.0.1")
end
```

Not sure how I can add a test case for this so I'll look into it further first.