### PR TITLE
Postmark: Support per email tracking options

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -65,6 +65,10 @@ defmodule Swoosh.Adapters.Postmark do
     * `:template_model` (map), `TemplateModel`, a map of key/value field to be
       used in the `HtmlBody`, `TextBody`, and `Subject` field in the template
 
+    * `:track_opens` (boolean) - `TrackOpens`, specify if open tracking needs to be enabled for this email.
+
+    * `:track_links` (string) - `TrackOpens`, specify if link tracking needs to be enabled for this email.
+       Valid values are: `None`, `HtmlAndText`, `HtmlOnly`, `TextOnly`
   """
 
   use Swoosh.Adapter, required_config: [:api_key]
@@ -186,6 +190,8 @@ defmodule Swoosh.Adapters.Postmark do
     |> prepare_tag(email)
     |> prepare_metadata(email)
     |> prepare_message_stream(email)
+    |> prepare_track_opens(email)
+    |> prepare_track_links(email)
   end
 
   defp prepare_from(body, %{from: from}), do: Map.put(body, "From", render_recipient(from))
@@ -280,4 +286,14 @@ defmodule Swoosh.Adapters.Postmark do
     do: Map.put(body, "MessageStream", value)
 
   defp prepare_message_stream(body, _), do: body
+
+  defp prepare_track_opens(body, %{provider_options: %{track_opens: value}}),
+    do: Map.put(body, "TrackOpens", value)
+
+  defp prepare_track_opens(body, _), do: body
+
+  defp prepare_track_links(body, %{provider_options: %{track_links: value}}),
+    do: Map.put(body, "TrackLinks", value)
+
+  defp prepare_track_links(body, _), do: body
 end

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -295,6 +295,58 @@ defmodule Swoosh.Adapters.PostmarkTest do
     assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
   end
 
+  test "deliver/1 with track_opens option returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"Steve Rogers", "steve.rogers@example.com"})
+      |> to("tony.stark@example.com")
+      |> put_provider_option(:track_opens, false)
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "To" => "tony.stark@example.com",
+        "From" => "\"Steve Rogers\" <steve.rogers@example.com>",
+        "TrackOpens" => false
+      }
+
+      assert body_params == conn.body_params
+      assert "/email" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
+  end
+
+  test "deliver/1 with track_links option returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"Steve Rogers", "steve.rogers@example.com"})
+      |> to("tony.stark@example.com")
+      |> put_provider_option(:track_links, "HtmlAndText")
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "To" => "tony.stark@example.com",
+        "From" => "\"Steve Rogers\" <steve.rogers@example.com>",
+        "TrackLinks" => "HtmlAndText"
+      }
+
+      assert body_params == conn.body_params
+      assert "/email" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
+  end
+
   test "deliver/1 with inline attachment uses correct CID", %{bypass: bypass, config: config} do
     email =
       new()


### PR DESCRIPTION
Postmark allows overriding the "Open" and "Click" tracking on a per email basis. This commit allows (optionally) setting the required fields in the API calls via the provider options.