### PR TITLE
Add support for Protonmail Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,23 +129,24 @@ Swoosh supports the most popular transactional email providers out of the box
 and also has a SMTP adapter. Below is the list of the adapters currently
 included:
 
-| Provider   | Swoosh adapter                                                                                  |
-| ---------- | ----------------------------------------------------------------------------------------------- |
-| SMTP       | [Swoosh.Adapters.SMTP](https://hexdocs.pm/swoosh/Swoosh.Adapters.SMTP.html#content)             |
-| SendGrid   | [Swoosh.Adapters.Sendgrid](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendgrid.html#content)     |
-| Sendinblue | [Swoosh.Adapters.Sendinblue](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendinblue.html#content) |
-| Sendmail   | [Swoosh.Adapters.Sendmail](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendmail.html#content)     |
-| Mandrill   | [Swoosh.Adapters.Mandrill](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mandrill.html#content)     |
-| Mailgun    | [Swoosh.Adapters.Mailgun](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mailgun.html#content)       |
-| Mailjet    | [Swoosh.Adapters.Mailjet](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mailjet.html#content)       |
-| Postmark   | [Swoosh.Adapters.Postmark](https://hexdocs.pm/swoosh/Swoosh.Adapters.Postmark.html#content)     |
-| SparkPost  | [Swoosh.Adapters.SparkPost](https://hexdocs.pm/swoosh/Swoosh.Adapters.SparkPost.html#content)   |
-| Amazon SES | [Swoosh.Adapters.AmazonSES](https://hexdocs.pm/swoosh/Swoosh.Adapters.AmazonSES.html#content)   |
-| Dyn        | [Swoosh.Adapters.Dyn](https://hexdocs.pm/swoosh/Swoosh.Adapters.Dyn.html#content)               |
-| SocketLabs | [Swoosh.Adapters.SocketLabs](https://hexdocs.pm/swoosh/Swoosh.Adapters.SocketLabs.html#content) |
-| Gmail      | [Swoosh.Adapters.Gmail](https://hexdocs.pm/swoosh/Swoosh.Adapters.Gmail.html#content)           |
-| MailPace   | [Swoosh.Adapters.MailPace](https://hexdocs.pm/swoosh/Swoosh.Adapters.MailPace.html#content)     |
-| SMTP2GO    | [Swoosh.Adapters.SMTP2GO](https://hexdocs.pm/swoosh/Swoosh.Adapters.SMTP2GO.html#content)     |
+| Provider     | Swoosh adapter                                                                                      |
+|--------------|-----------------------------------------------------------------------------------------------------|
+| SMTP         | [Swoosh.Adapters.SMTP](https://hexdocs.pm/swoosh/Swoosh.Adapters.SMTP.html#content)                 |
+| SendGrid     | [Swoosh.Adapters.Sendgrid](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendgrid.html#content)         |
+| Sendinblue   | [Swoosh.Adapters.Sendinblue](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendinblue.html#content)     |
+| Sendmail     | [Swoosh.Adapters.Sendmail](https://hexdocs.pm/swoosh/Swoosh.Adapters.Sendmail.html#content)         |
+| Mandrill     | [Swoosh.Adapters.Mandrill](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mandrill.html#content)         |
+| Mailgun      | [Swoosh.Adapters.Mailgun](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mailgun.html#content)           |
+| Mailjet      | [Swoosh.Adapters.Mailjet](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mailjet.html#content)           |
+| Postmark     | [Swoosh.Adapters.Postmark](https://hexdocs.pm/swoosh/Swoosh.Adapters.Postmark.html#content)         |
+| SparkPost    | [Swoosh.Adapters.SparkPost](https://hexdocs.pm/swoosh/Swoosh.Adapters.SparkPost.html#content)       |
+| Amazon SES   | [Swoosh.Adapters.AmazonSES](https://hexdocs.pm/swoosh/Swoosh.Adapters.AmazonSES.html#content)       |
+| Dyn          | [Swoosh.Adapters.Dyn](https://hexdocs.pm/swoosh/Swoosh.Adapters.Dyn.html#content)                   |
+| SocketLabs   | [Swoosh.Adapters.SocketLabs](https://hexdocs.pm/swoosh/Swoosh.Adapters.SocketLabs.html#content)     |
+| Gmail        | [Swoosh.Adapters.Gmail](https://hexdocs.pm/swoosh/Swoosh.Adapters.Gmail.html#content)               |
+| MailPace     | [Swoosh.Adapters.MailPace](https://hexdocs.pm/swoosh/Swoosh.Adapters.MailPace.html#content)         |
+| SMTP2GO      | [Swoosh.Adapters.SMTP2GO](https://hexdocs.pm/swoosh/Swoosh.Adapters.SMTP2GO.html#content)           |
+| ProtonBridge | [Swoosh.Adapters.ProtonBridge](https://hexdocs.pm/swoosh/Swoosh.Adapters.ProtonBridge.html#content) |
 
 Configure which adapter you want to use by updating your `config/config.exs`
 file:

--- a/lib/swoosh/adapters/proton_bridge.ex
+++ b/lib/swoosh/adapters/proton_bridge.ex
@@ -1,0 +1,53 @@
+defmodule Swoosh.Adapters.ProtonBridge do
+  @moduledoc ~S"""
+  An adapter that sends email using the local Protonmail Bridge.
+
+  This is a very thin wrapper around the SMTP adapter.
+
+  Underneath this adapter uses the
+  [gen_smtp](https://github.com/Vagabond/gen_smtp) library, add it to your mix.exs file.
+
+  ## Example
+      # mix.exs
+      def deps do
+        [
+         {:swoosh, "~> 1.3"},
+         {:gen_smtp, "~> 1.1"}
+        ]
+      end
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.ProtonBridge,
+        username: "tonystark",
+        password: "ilovepepperpotts",
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample
+      end
+  """
+
+  use Swoosh.Adapter, required_config: [], required_deps: [gen_smtp: :gen_smtp_client]
+
+  alias Swoosh.Email
+  alias Swoosh.Adapters.SMTP
+
+  @impl true
+  def deliver(%Email{} = email, user_config) do
+    config = Keyword.merge(bridge_config(), user_config)
+    SMTP.deliver(email, config)
+  end
+
+  defp bridge_config do
+    [
+      relay: "127.0.0.1",
+      ssl: false,
+      tls: :never,
+      auth: :always,
+      port: 1025,
+      retries: 2,
+      no_mx_lookups: true
+    ]
+  end
+end

--- a/lib/swoosh/adapters/proton_bridge.ex
+++ b/lib/swoosh/adapters/proton_bridge.ex
@@ -8,6 +8,7 @@ defmodule Swoosh.Adapters.ProtonBridge do
   [gen_smtp](https://github.com/Vagabond/gen_smtp) library, add it to your mix.exs file.
 
   ## Example
+
       # mix.exs
       def deps do
         [

--- a/lib/swoosh/adapters/proton_bridge.ex
+++ b/lib/swoosh/adapters/proton_bridge.ex
@@ -11,8 +11,8 @@ defmodule Swoosh.Adapters.ProtonBridge do
       # mix.exs
       def deps do
         [
-         {:swoosh, "~> 1.3"},
-         {:gen_smtp, "~> 1.1"}
+          {:swoosh, "~> 1.3"},
+          {:gen_smtp, "~> 1.1"}
         ]
       end
 


### PR DESCRIPTION
The Protonmail bridge is a local SMTP server that bridges to Protonmail.
This adapter is a thin layer on-top the existing SMTP adapter.
Even if this adapter is trivial, I hope people will find it useful.

Ref: https://proton.me/mail/bridge