### PR TITLE
Allow overriding delivery functions

### DIFF
--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -176,6 +176,8 @@ defmodule Swoosh.Mailer do
           end
         end)
       end
+
+      defoverridable deliver: 2, deliver!: 2, deliver_many: 2
     end
   end
 

--- a/test/swoosh/mailer_test.exs
+++ b/test/swoosh/mailer_test.exs
@@ -131,6 +131,20 @@ defmodule Swoosh.MailerTest do
     end
   end
 
+  test "allows overriding default delivery functions", %{valid_email: email} do
+    defmodule OveriddenMailer do
+      use Swoosh.Mailer, otp_app: :swoosh, adapter: FakeAdapter
+
+      def deliver(%Swoosh.Email{to: []}, _config), do: {:error, :no_recipient}
+      def deliver(email, config), do: super(email, config)
+    end
+
+    email_without_recipient = %{email | to: []}
+
+    assert {:ok, _} = OveriddenMailer.deliver(email)
+    assert {:error, :no_recipient} = OveriddenMailer.deliver(email_without_recipient)
+  end
+
   test "raise when sending without an adapter configured", %{valid_email: email} do
     defmodule NoAdapterMailer do
       use Swoosh.Mailer, otp_app: :swoosh


### PR DESCRIPTION
Sometimes, it's really convenient to do some preprocessing of an email (returning an error when recipient list is empty, inlining CSS, etc) that is adapter independent.

I'm open to suggestions how to improve telemetry as only base implementation is covered by it.