### PR TITLE
Add experimental new test assertion module

### DIFF
--- a/lib/swoosh/x_test_assertions.ex
+++ b/lib/swoosh/x_test_assertions.ex
@@ -265,24 +265,6 @@ defmodule Swoosh.X.TestAssertions do
     """
   end
 
-  @doc ~S"""
-  Asserts no emails were sent.
-  """
-  @spec assert_no_email_sent() :: boolean | no_return
-  def assert_no_email_sent() do
-    refute_email_sent()
-  end
-
-  @doc ~S"""
-  Asserts `email` was not sent.
-
-  Performs exact matching of the email struct.
-  """
-  @spec assert_email_not_sent(Email.t()) :: boolean | no_return
-  def assert_email_not_sent(%Email{} = email) do
-    refute_email_sent(email)
-  end
-
   @doc """
   Removes and returns from mailbox all sent emails.
   """

--- a/lib/swoosh/x_test_assertions.ex
+++ b/lib/swoosh/x_test_assertions.ex
@@ -1,0 +1,309 @@
+defmodule Swoosh.X.TestAssertions do
+  @moduledoc ~S"""
+  This module contains a set of assertions functions that you can import in your
+  test cases.
+
+  It is meant to be used with the
+  [Swoosh.Adapters.Test](Swoosh.Adapters.Test.html) module.
+
+  **Note**: `Swoosh.TestAssertion` works for unit tests and basic integration tests.
+  Unfortunately it's not going to work for feature/E2E tests.
+  The mechanism of `assert_email_sent` is based on messaging sending between processes,
+  and is expecting the calling process (the one that calls `assert_email_sent`) to be
+  the calling process of `Mailer.deliver`, or be the parent process of the whatever
+  does the `Mailer.deliver` call.
+
+  For feature/E2E tests, you should use `Swoosh.Adapters.Local` adapter.
+  In your test, instead of calling `assert_email_sent`, you should navigate to the
+  preview url with your E2E tool (e.g. `wallaby`) and test that the email is in the inbox.
+  """
+
+  import ExUnit.Assertions
+
+  alias Swoosh.Email
+  alias Swoosh.Email.Recipient
+
+  @doc """
+  Sets Swoosh test adapter to global mode.
+
+  In global mode, emails are consumed by the current test process,
+  doesn't matter which process sent it.
+
+  An ExUnit case where tests use Swoosh in global mode cannot be `async: true`.
+
+  ## Examples
+
+      defmodule MyTest do
+        use ExUnit.Case, async: false
+
+        import Swoosh.Email
+        import Swoosh.TestAssertions
+
+        setup :set_swoosh_global
+
+        test "it sends email" do
+          # ...
+          assert_email_sent(subject: "Hi Avengers!")
+        end
+      end
+  """
+  def set_swoosh_global(context \\ %{}) do
+    if Map.get(context, :async) do
+      raise "Swoosh cannot be set to global mode when the ExUnit case is async. " <>
+              "If you want to use Swoosh in global mode, remove \"async: true\" when using ExUnit.Case"
+    else
+      Application.put_env(:swoosh, :shared_test_process, self())
+
+      ExUnit.Callbacks.on_exit(fn ->
+        Application.delete_env(:swoosh, :shared_test_process)
+      end)
+
+      :ok
+    end
+  end
+
+  @doc ~S"""
+  Asserts any email was sent.
+  """
+  @spec assert_email_sent() :: boolean | no_return
+  def assert_email_sent do
+    refute Enum.empty?(emails()), "Expected any emails to be sent but none were present"
+  end
+
+  @spec assert_email_sent(Email.t() | Keyword.t() | (Email.t() -> boolean())) ::
+          boolean | no_return
+
+  @doc ~S"""
+  Asserts `email` was sent.
+
+  You can pass a keyword list to match on specific params
+  or an anonymous function that returns a boolean.
+
+  ## Examples
+
+      iex> alias Swoosh.Email
+      iex> import Swoosh.TestAssertions
+
+      iex> email = Email.new(subject: "Hello, Avengers!")
+      iex> Swoosh.Adapters.Test.deliver(email, [])
+
+      # assert a specific email was sent
+      iex> assert_email_sent(email)
+
+      # assert an email with specific field(s) was sent
+      iex> assert_email_sent(subject: "Hello, Avengers!")
+
+      # assert an email that satisfies a condition
+      iex> assert_email_sent(fn email ->
+      ...>   assert length(email.to) == 2
+      ...> end)
+  """
+  def assert_email_sent(%Email{} = email) do
+    matches? = &match?(^email, &1)
+    emails = emails()
+
+    assert Enum.any?(emails, matches?), """
+    Expected
+
+    #{inspect(emails, pretty: true)}
+
+    to contain email
+
+    #{inspect(email, pretty: true)}
+
+    but no email matched
+    """
+  end
+
+  def assert_email_sent(attributes) when is_list(attributes) do
+    has_attributes? = fn email -> Enum.all?(attributes, &has?(email, &1)) end
+    emails = emails()
+
+    assert Enum.any?(emails, has_attributes?), """
+    Expected
+
+    #{inspect(emails, pretty: true)}
+
+    to contain email with attributes
+
+    #{inspect(attributes, pretty: true)}
+
+    but none matched
+    """
+  end
+
+  def assert_email_sent(predicate) when is_function(predicate, 1) do
+    emails = emails()
+
+    assert Enum.any?(emails, predicate), """
+    Expected 
+
+    #{inspect(emails, pretty: true)}
+
+    to contain matching email but none matched
+    """
+  end
+
+  defp has?(email, {:subject, value}),
+    do: email.subject == value
+
+  defp has?(email, {:from, value}),
+    do: email.from == Recipient.format(value)
+
+  defp has?(email, {:reply_to, value}),
+    do: email.reply_to == Recipient.format(value)
+
+  defp has?(email, {:to, value}) when is_list(value),
+    do: email.to == Enum.map(value, &Recipient.format/1)
+
+  defp has?(email, {:to, value}),
+    do: Recipient.format(value) in email.to
+
+  defp has?(email, {:cc, value}) when is_list(value),
+    do: email.cc == Enum.map(value, &Recipient.format/1)
+
+  defp has?(email, {:cc, value}),
+    do: Recipient.format(value) in email.cc
+
+  defp has?(email, {:bcc, value}) when is_list(value),
+    do: email.bcc == Enum.map(value, &Recipient.format/1)
+
+  defp has?(email, {:bcc, value}),
+    do: Recipient.format(value) in email.bcc
+
+  defp has?(email, {:text_body, %Regex{} = value}),
+    do: email.text_body =~ value
+
+  defp has?(email, {:text_body, value}),
+    do: email.text_body == value
+
+  defp has?(email, {:html_body, %Regex{} = value}),
+    do: email.html_body =~ value
+
+  defp has?(email, {:html_body, value}),
+    do: email.html_body == value
+
+  defp has?(email, {:headers, value}),
+    do: email.headers == value
+
+  @doc ~S"""
+  Asserts no emails were sent.
+  """
+  @spec refute_email_sent() :: boolean | no_return
+  def refute_email_sent() do
+    emails = emails()
+
+    assert Enum.empty?(emails), """
+    Expected no emails to be sent but those emails were present
+
+    #{inspect(emails, pretty: true)}
+    """
+  end
+
+  @spec refute_email_sent(Email.t() | list | (Email.t() -> boolean)) :: boolean | no_return
+  @doc ~S"""
+  Asserts email with `attributes` was not sent.
+
+  You can pass a keyword list to match on specific params
+  or an anonymous function that returns a boolean.
+  """
+  def refute_email_sent(%Email{} = email) do
+    matches? = &match?(^email, &1)
+    emails = emails()
+
+    matched_email = Enum.find(emails, matches?)
+
+    refute matched_email, """
+    Expected
+
+    #{inspect(emails, pretty: true)}
+
+    to not contain
+
+    #{inspect(email, pretty: true)}
+
+    but this email matched
+
+    #{inspect(matched_email, pretty: true)}
+    """
+  end
+
+  def refute_email_sent(attributes) when is_list(attributes) do
+    has_attributes? = fn email -> Enum.all?(attributes, &has?(email, &1)) end
+    emails = emails()
+
+    matched_email = Enum.find(emails, has_attributes?)
+
+    refute matched_email, """
+    Expected
+
+    #{inspect(emails, pretty: true)}
+
+    to not contain email with attributes
+
+    #{inspect(attributes, pretty: true)}
+
+    but this email matched
+
+    #{inspect(matched_email, pretty: true)}
+    """
+  end
+
+  def refute_email_sent(predicate) when is_function(predicate, 1) do
+    emails = emails()
+
+    matched_email = Enum.find(emails, predicate)
+
+    refute matched_email, """
+    Expected
+
+    #{inspect(emails, pretty: true)}
+
+    to not contain matching email but this email matched
+
+    #{inspect(matched_email, pretty: true)}
+    """
+  end
+
+  @doc ~S"""
+  Asserts no emails were sent.
+  """
+  @spec assert_no_email_sent() :: boolean | no_return
+  def assert_no_email_sent() do
+    refute_email_sent()
+  end
+
+  @doc ~S"""
+  Asserts `email` was not sent.
+
+  Performs exact matching of the email struct.
+  """
+  @spec assert_email_not_sent(Email.t()) :: boolean | no_return
+  def assert_email_not_sent(%Email{} = email) do
+    refute_email_sent(email)
+  end
+
+  @doc """
+  Removes and returns from mailbox all sent emails.
+  """
+  @spec flush_emails() :: list(Email.t())
+  def flush_emails do
+    do_flush_emails([])
+  end
+
+  defp do_flush_emails(emails) do
+    receive do
+      {:email, email} -> do_flush_emails([email | emails])
+    after
+      0 -> emails
+    end
+  end
+
+  defp emails() do
+    emails = flush_emails()
+
+    Enum.each(emails, &send(self(), {:email, &1}))
+
+    emails
+  end
+end

--- a/test/swoosh/x_test_assertions_test.exs
+++ b/test/swoosh/x_test_assertions_test.exs
@@ -90,44 +90,6 @@ defmodule Swoosh.X.TestAssertionsTest do
     end
   end
 
-  test "assert email not sent with unexpected email" do
-    unexpected_email = new() |> subject("Testing Avenger")
-
-    assert_email_not_sent(unexpected_email)
-  end
-
-  test "assert email not sent with expected email", %{email: email} do
-    message = ~r/Expected[\s\S]+to not contain[\s\S]+but this email matched/
-
-    try do
-      assert_email_not_sent(email)
-    rescue
-      error in [ExUnit.AssertionError] -> assert error.message =~ message
-    end
-  end
-
-  test "assert no email sent" do
-    flush_emails()
-
-    assert_no_email_sent()
-  end
-
-  test "assert no email sent with email sent" do
-    assert_raise ExUnit.AssertionError, fn ->
-      assert_no_email_sent()
-    end
-  end
-
-  test "assert no email sent when sending an email" do
-    message = "Expected no emails to be sent but those emails were present"
-
-    try do
-      assert_no_email_sent()
-    rescue
-      error in [ExUnit.AssertionError] -> assert error.message =~ message
-    end
-  end
-
   test "refute email sent" do
     flush_emails()
 

--- a/test/swoosh/x_test_assertions_test.exs
+++ b/test/swoosh/x_test_assertions_test.exs
@@ -1,0 +1,241 @@
+defmodule Swoosh.X.TestAssertionsTest do
+  use ExUnit.Case, async: true
+
+  import Swoosh.Email
+  import Swoosh.X.TestAssertions
+
+  defp deliver(%Swoosh.Email{} = email) do
+    {:ok, _} = Swoosh.Adapters.Test.deliver(email, nil)
+  end
+
+  setup do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> reply_to("bruce.banner@example.com")
+      |> to(["steve.rogers@example.com", "bruce.banner@example.com"])
+      |> cc(["natasha.romanoff@example.com", "stephen.strange@example.com"])
+      |> bcc("loki.odinson@example.com")
+      |> header("Avengers", "Assemble")
+      |> subject("Hello, Avengers!")
+      |> html_body("some html")
+      |> text_body("some text")
+
+    deliver(email)
+
+    %{email: email}
+  end
+
+  test "assert any email sent" do
+    assert_email_sent()
+  end
+
+  test "assert any email sent with no emails sent" do
+    flush_emails()
+
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_email_sent()
+    end
+  end
+
+  test "assert email sent with correct email", %{email: email} do
+    assert_email_sent(email)
+  end
+
+  test "assert email sent with some content matched by a regex" do
+    assert_email_sent(text_body: ~r/some text/, html_body: ~r/html$/)
+  end
+
+  test "assert email sent with specific params" do
+    assert_email_sent(subject: "Hello, Avengers!", to: "steve.rogers@example.com")
+  end
+
+  test "assert email sent with specific to (list)" do
+    assert_email_sent(to: ["steve.rogers@example.com", "bruce.banner@example.com"])
+  end
+
+  test "assert email sent with condition" do
+    assert_email_sent(fn email -> length(email.cc) == 2 end)
+  end
+
+  for {param_name, params} <- [
+        {"subject", subject: "Hello, X-Men!"},
+        {"from", from: "thor.odinson@example.com"},
+        {"to", to: "loki.odinson@example.com"},
+        {"to (list)", to: ["steve.rogers@example.com"]},
+        {"cc", cc: "bruce.banner@example.com"},
+        {"bcc", bcc: "bruce.banner@example.com"},
+        {"header", headers: %{"Revengers" => "Gather"}}
+      ] do
+    quote do
+      test "assert email sent with wrong #{unquote(param_name)}" do
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_email_sent(unquote(params))
+        end
+      end
+    end
+  end
+
+  test "assert email sent with wrong email", %{email: email} do
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_email_sent(email |> subject("Wrong"))
+    end
+  end
+
+  test "assert email sent with wrong condition" do
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_email_sent(fn email ->
+        email.to == "loki.odinson@example.com"
+      end)
+    end
+  end
+
+  test "assert email not sent with unexpected email" do
+    unexpected_email = new() |> subject("Testing Avenger")
+
+    assert_email_not_sent(unexpected_email)
+  end
+
+  test "assert email not sent with expected email", %{email: email} do
+    message = ~r/Expected[\s\S]+to not contain[\s\S]+but this email matched/
+
+    try do
+      assert_email_not_sent(email)
+    rescue
+      error in [ExUnit.AssertionError] -> assert error.message =~ message
+    end
+  end
+
+  test "assert no email sent" do
+    flush_emails()
+
+    assert_no_email_sent()
+  end
+
+  test "assert no email sent with email sent" do
+    assert_raise ExUnit.AssertionError, fn ->
+      assert_no_email_sent()
+    end
+  end
+
+  test "assert no email sent when sending an email" do
+    message = "Expected no emails to be sent but those emails were present"
+
+    try do
+      assert_no_email_sent()
+    rescue
+      error in [ExUnit.AssertionError] -> assert error.message =~ message
+    end
+  end
+
+  test "refute email sent" do
+    flush_emails()
+
+    refute_email_sent()
+  end
+
+  test "refute email sent with email sent" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent()
+    end
+  end
+
+  test "refute email sent with unexpected email" do
+    unexpected_email = new() |> subject("Testing Avenger")
+    refute_email_sent(unexpected_email)
+  end
+
+  test "refute email sent with expected email", %{email: email} do
+    message = ~r/Expected[\s\S]+to not contain[\s\S]+but this email matched/
+
+    try do
+      refute_email_sent(email)
+    rescue
+      error in [ExUnit.AssertionError] -> assert error.message =~ message
+    end
+  end
+
+  test "refute email sent with specific params" do
+    refute_email_sent(subject: "Good bye, Avengers!", to: "steve.rogers@example.com")
+  end
+
+  test "refute email sent with expected params" do
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(
+        subject: "Hello, Avengers!",
+        to: ["steve.rogers@example.com", "bruce.banner@example.com"]
+      )
+    end
+  end
+
+  for {param_name, params} <- [
+        {"from", from: "steve.rogers@example.com"},
+        {"reply to", reply_to: "steve.rogers@example.com"},
+        {"to", to: "steve.rogers@example.com"},
+        {"to (list)", to: ["steve.rogers@example.com"]},
+        {"cc", cc: "natasha.romanoff@example.com"},
+        {"cc (list)", cc: ["natasha.romanoff@example.com"]},
+        {"bcc", bcc: "steve.rogers@example.com"},
+        {"bcc (list)", bcc: ["steve.rogers@example.com"]},
+        {"header", headers: %{"Revengers" => "Gather"}},
+        {"subject", subject: "Hello, League!"},
+        {"text body", text_body: "some html"},
+        {"html body", html_body: "some text"}
+      ] do
+    quote do
+      test "refute email sent with specific #{unquote(param_name)}" do
+        refute_email_sent(unquote(params))
+      end
+    end
+  end
+
+  for {param_name, params} <- [
+        {"from", from: "tony.stark@example.com"},
+        {"reply to", reply_to: "bruce.banner@example.com"},
+        {"to (list)", to: ["steve.rogers@example.com", "bruce.banner@example.com"]},
+        {"cc (list)", cc: ["natasha.romanoff@example.com", "stephen.strange@example.com"]},
+        {"header", headers: %{"Avengers" => "Assemble"}},
+        {"bcc", bcc: "loki.odinson@example.com"},
+        {"bcc (list)", bcc: ["loki.odinson@example.com"]},
+        {"subject", subject: "Hello, Avengers!"},
+        {"text body", text_body: "some text"},
+        {"html body", html_body: "some html"}
+      ] do
+    quote do
+      test "refute email sent with expected #{unquote(param_name)}" do
+        assert_raise ExUnit.AssertionError, fn ->
+          refute_email_sent(unquote(params))
+        end
+      end
+    end
+  end
+
+  test "refute email sent with expected to" do
+    assert_email_sent(to: ["steve.rogers@example.com", "bruce.banner@example.com"])
+
+    deliver(new(to: "steve.rogers@example.com"))
+
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(to: "steve.rogers@example.com")
+    end
+  end
+
+  test "refute email sent with expected cc" do
+    assert_email_sent(cc: ["natasha.romanoff@example.com", "stephen.strange@example.com"])
+
+    deliver(new(cc: "natasha.romanoff@example.com"))
+
+    assert_raise ExUnit.AssertionError, fn ->
+      refute_email_sent(cc: "natasha.romanoff@example.com")
+    end
+  end
+
+  test "asserting on same email twice works" do
+    assert_email_sent(from: "tony.stark@example.com", subject: "Hello, Avengers!")
+
+    assert_email_sent(
+      cc: ["natasha.romanoff@example.com", "stephen.strange@example.com"],
+      subject: "Hello, Avengers!"
+    )
+  end
+end


### PR DESCRIPTION
❗ This isn't backwards compatible.

I had a few complaints about current implementation of test helpers - `refute` working only on literal params, assertions consuming emails from queue, kinda bad error reporting so I decided to take a spin on it.

It's a bit worse memory-wise because we keep entire email list but it shouldn't affect anything, I don't expect people to create MB worth of emails in tests.

I also thought about removing delegating assertions (`assert_email_not_sent` and family) since this is breaking change anyway.

Similar tests were grouped, I think it improves readability a bit.

I would love to hear your thoughts about this one.