### PR TITLE
Add postmark inline css option

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -69,6 +69,9 @@ defmodule Swoosh.Adapters.Postmark do
 
     * `:track_links` (string) - `TrackOpens`, specify if link tracking needs to be enabled for this email.
        Valid values are: `None`, `HtmlAndText`, `HtmlOnly`, `TextOnly`
+
+    * `:inline_css` (boolean) - `InlineCss`, specify if Postmark should apply the style blocks as inline
+      attributes to the rendered HTML content. Default is true.
   """
 
   use Swoosh.Adapter, required_config: [:api_key]
@@ -192,6 +195,7 @@ defmodule Swoosh.Adapters.Postmark do
     |> prepare_message_stream(email)
     |> prepare_track_opens(email)
     |> prepare_track_links(email)
+    |> prepare_inline_css(email)
   end
 
   defp prepare_from(body, %{from: from}), do: Map.put(body, "From", render_recipient(from))
@@ -296,4 +300,9 @@ defmodule Swoosh.Adapters.Postmark do
     do: Map.put(body, "TrackLinks", value)
 
   defp prepare_track_links(body, _), do: body
+
+  defp prepare_inline_css(body, %{provider_options: %{inline_css: value}}),
+    do: Map.put(body, "InlineCss", value)
+
+  defp prepare_inline_css(body, _), do: body
 end

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -347,6 +347,32 @@ defmodule Swoosh.Adapters.PostmarkTest do
     assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
   end
 
+  test "deliver/1 with inline_css option returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"Steve Rogers", "steve.rogers@example.com"})
+      |> to("tony.stark@example.com")
+      |> put_provider_option(:inline_css, false)
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "To" => "tony.stark@example.com",
+        "From" => "\"Steve Rogers\" <steve.rogers@example.com>",
+        "InlineCss" => false
+      }
+
+      assert body_params == conn.body_params
+      assert "/email" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
+  end
+
   test "deliver/1 with inline attachment uses correct CID", %{bypass: bypass, config: config} do
     email =
       new()


### PR DESCRIPTION
This is useful in some situation where Postmark's default CSS inlining does not yield great results.