### PR TITLE
Allow Regexp assertions for subjects

### DIFF
--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -159,6 +159,9 @@ defmodule Swoosh.TestAssertions do
     end)
   end
 
+  defp assert_equal(email, {:subject, %Regex{} = value}),
+    do: assert(email.subject =~ value)
+
   defp assert_equal(email, {:subject, value}),
     do: assert(email.subject == value)
 

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -51,7 +51,11 @@ defmodule Swoosh.TestAssertionsTest do
     end
 
     test "assert email sent with some content matched by a regex" do
-      assert_email_sent(text_body: ~r/some text/, html_body: ~r/html$/)
+      assert_email_sent(
+        subject: ~r/Avengers/,
+        text_body: ~r/some text/,
+        html_body: ~r/html$/
+      )
     end
 
     test "assert email sent with specific params" do


### PR DESCRIPTION
Hi!

I am still a beginner in Elixir/Phoenix/Swoosh, so it took me a while to understand why a regexp-based assertion didn't work with e-mail subject.

I found out, as you can tell, and I think it should be supported, hence this PR!

Thank you for a very beginner-friendly library!

/Stavros