### PR TITLE
Do not include Bcc header in delivered email

### DIFF
--- a/lib/swoosh/adapters/smtp/helpers.ex
+++ b/lib/swoosh/adapters/smtp/helpers.ex
@@ -51,8 +51,8 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
     |> prepare_mime_version()
     |> prepare_reply_to(email)
     |> prepare_subject(email)
-    |> prepare_bcc(email)
     |> prepare_cc(email)
+    # bcc is deliberately omitted: https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
     |> prepare_to(email)
     |> prepare_from(email)
   end
@@ -67,9 +67,6 @@ defmodule Swoosh.Adapters.SMTP.Helpers do
 
   defp prepare_cc(headers, %{cc: []}), do: headers
   defp prepare_cc(headers, %{cc: cc}), do: [{"Cc", render_recipient(cc)} | headers]
-
-  defp prepare_bcc(headers, %{bcc: []}), do: headers
-  defp prepare_bcc(headers, %{bcc: bcc}), do: [{"Bcc", render_recipient(bcc)} | headers]
 
   defp prepare_reply_to(headers, %{reply_to: nil}), do: headers
 

--- a/test/swoosh/email/smtp_test.exs
+++ b/test/swoosh/email/smtp_test.exs
@@ -64,7 +64,6 @@ defmodule Swoosh.Email.SMTPTest do
                 {"From", "tony@stark.com"},
                 {"To", "\"Janet Pym\" <wasp@avengers.com>, steve@rogers.com"},
                 {"Cc", "thor@odinson.com, \"Bruce Banner\" <hulk@smash.com>"},
-                {"Bcc", "beast@avengers.com, \"Clinton Francis Barton\" <hawk@eye.com>"},
                 {"Subject", "Hello, Avengers!"},
                 {"Reply-To", "black@widow.com"},
                 {"MIME-Version", "1.0"},
@@ -256,5 +255,20 @@ defmodule Swoosh.Email.SMTPTest do
                     ]}
                  ]}
               ]}
+  end
+
+  test "message includes to and cc, but omits the bcc header according to RFC 5322" do
+    email =
+      new()
+      |> from("from@test.com")
+      |> to("to@test.com")
+      |> cc("cc@test.com")
+      |> bcc("bcc@test.com")
+
+    {_type, _subtype, headers, _parts} = Helpers.prepare_message(email, %{})
+
+    assert {"To", "to@test.com"} in headers
+    assert {"Cc", "cc@test.com"} in headers
+    refute {"Bcc", "bcc@test.com"} in headers
   end
 end


### PR DESCRIPTION
Proposal following [this discussion](https://github.com/swoosh/swoosh/discussions/772).

According to [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3) method 1:

> when a message containing a "Bcc:" field is prepared to be sent, the "Bcc:" line is removed even though all of the recipients (including those specified in the "Bcc:" field) are sent a copy of the message

This PR removes the BCC header from the message that is delivered.

Note that the BCC addresses are still included in the `recipients`, so they will still receive the email. It is only the `body` that does not contain the bcc addresses:

https://github.com/swoosh/swoosh/blob/3cab4d812dfef1c842c127e4bb36b475716febe4/lib/swoosh/adapters/smtp.ex#L55-L59