### PR TITLE
Remove unnecessary sentence from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@
 
 Compose, deliver and test your emails easily in Elixir.
 
-We have applied the lessons learned from projects like Plug, Ecto and Phoenix
-in designing clean and composable APIs, with clear separation of concerns
-between modules. Swoosh comes with many adapters, including SendGrid, Mandrill,
-Mailgun, Postmark and SMTP. See the full list of [adapters below](#adapters).
+Swoosh comes with many adapters, including SendGrid, Mandrill, Mailgun, Postmark and SMTP.
+See the full list of [adapters below](#adapters).
 
 The complete documentation for Swoosh is [available online at HexDocs](https://hexdocs.pm/swoosh).
 


### PR DESCRIPTION
In my project, I want to customise the behaviour of `Swoosh.Mailer`. For example, doing things like:

* Adding custom error handling/reporting
* Chunking delivery of a mail with many recipients into separate mails
* etc...

However, the library makes this difficult, because multiple `deliver` functions are [automatically injected via `use`](https://github.com/swoosh/swoosh/blob/4a59f125c014edaaf9f23de43f76db1e8cb3b691/lib/swoosh/mailer.ex#L125-L155) and are not [overridable](https://hexdocs.pm/elixir/Kernel.html#defoverridable/1). Without being able to override these, the best that can be done is to wrap these functions, however they cannot be replaced so it may be that the default versions can be called accidentally, which I want to avoid (I'd rather replace them with my own versions).

This PR makes the functions overridable, so they can be extended.

There is probably a better architectural solution to this. For example, making `Swoosh.Mailer` a behaviour. However, this was the simplest approach I could think of.

I also removed a self-congratulatory sentence from the README 🙄 