### PR TITLE
Update Mailgun docs for sandbox mode

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -15,7 +15,7 @@ defmodule Swoosh.Adapters.Mailgun do
   ## Configuration options
 
   * `:api_key` - the API key used with Mailgun
-  * `:domain` - the domain you will be sending emails from
+  * `:domain` - the domain you will be sending emails from. For sandbox domains, make sure to use the sandbox adddress, for example: `https://api.mailgun.net/v3/sandbox123456.mailgun.org/messages` then you should set `domain: "sandbox123456.mailgun.org"`.
   * `:base_url` - the url to use as the API endpoint. For EU domains, use https://api.eu.mailgun.net/v3
 
   ## Example


### PR DESCRIPTION
The work is based on this topic: https://elixirforum.com/t/sending-email-404-not-found-nothing-is-happening-no-debug-messages/55230

When using Mailgun sandbox mode you have to set the domain based on the sandbox address used on the API url. Let me know if I should rephrase or move it to somewhere else.

Thanks.