### PR TITLE
Do not send subject to customer.io when empty

### DIFF
--- a/lib/swoosh/adapters/customer_io.ex
+++ b/lib/swoosh/adapters/customer_io.ex
@@ -179,6 +179,7 @@ defmodule Swoosh.Adapters.CustomerIO do
     do: Map.put(body, :reply_to, render_recipient(reply_to))
 
   defp prepare_subject(body, %Email{subject: nil}), do: body
+  defp prepare_subject(body, %Email{subject: ""}), do: body
   defp prepare_subject(body, %Email{subject: subject}), do: Map.put(body, :subject, subject)
 
   defp prepare_content(body, %Email{html_body: nil, text_body: nil}), do: body


### PR DESCRIPTION
Customer.io transactional emails can have subjects defined in the template, and if the subject is empty they won't deliver the email.

This PR changes the code so that, if the subject is an empty string, it won't set it in the request to customer.io. Previously it would only check if subject is `nil`, but that's not supported by swoosh's API (I still left the `nil` implementation in case someone managed to use it).

Also added a test checking that we're not sending empty `from` values, as those can also be populated by customer.io