### PR TITLE
Add support for Mailgun Template Versions

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -134,6 +134,7 @@ defmodule Swoosh.Adapters.Mailgun do
     |> prepare_tags(email)
     |> prepare_custom_headers(email)
     |> prepare_template(email)
+    |> prepare_version(email)
     |> encode_body()
   end
 
@@ -216,6 +217,11 @@ defmodule Swoosh.Adapters.Mailgun do
     do: Map.put(body, "template", template_name)
 
   defp prepare_template(body, _), do: body
+
+  defp prepare_version(body, %{provider_options: %{template_version: template_version}}),
+    do: Map.put(body, "t:version", template_version)
+
+  defp prepare_version(body, _), do: body
 
   defp encode_body(%{attachments: attachments, inline: inline} = params) do
     {:multipart,

--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -52,6 +52,7 @@ defmodule Swoosh.Adapters.Mailgun do
       |> put_provider_option(:sending_options, %{dkim: "yes", tracking: "no"})
       |> put_provider_option(:tags, ["worldwide-peace", "unity"])
       |> put_provider_option(:template_name, "avengers-templates")
+      |> put_provider_option(:template_version, "initial")
 
   ## Provider options
 

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -68,6 +68,7 @@ defmodule Swoosh.Adapters.MailgunTest do
       |> html_body("<h1>Hello</h1>")
       |> text_body("Hello")
       |> put_provider_option(:template_name, "avengers-templates")
+      |> put_provider_option(:template_version, "initial")
       |> put_provider_option(:custom_vars, %{"key" => "value"})
 
     Bypass.expect(bypass, fn conn ->
@@ -84,7 +85,8 @@ defmodule Swoosh.Adapters.MailgunTest do
         "text" => "Hello",
         "html" => "<h1>Hello</h1>",
         "h:X-Mailgun-Variables" => "{\"key\":\"value\"}",
-        "template" => "avengers-templates"
+        "template" => "avengers-templates",
+        "t:version" => "initial"
       }
 
       assert body_params == conn.body_params


### PR DESCRIPTION
Add support for mail template versions as per https://documentation.mailgun.com/en/latest/api-sending.html#sending