### PR TITLE
Feat mailgun multiple reply to

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -205,12 +205,7 @@ defmodule Swoosh.Adapters.Mailgun do
   defp prepare_reply_to(body, %{reply_to: reply_tos}) when is_list(reply_tos) do
     addresses =
       reply_tos
-      |> Enum.map(fn reply_to ->
-        case reply_to do
-          {_name, address} -> address
-          address -> address
-        end
-      end)
+      |> Enum.map(fn {_name, address} -> address end)
       |> Enum.join(", ")
 
     Map.put(body, "h:Reply-To", addresses)

--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -202,6 +202,20 @@ defmodule Swoosh.Adapters.Mailgun do
   defp prepare_reply_to(body, %{reply_to: {_name, address}}),
     do: Map.put(body, "h:Reply-To", address)
 
+  defp prepare_reply_to(body, %{reply_to: reply_tos}) when is_list(reply_tos) do
+    addresses =
+      reply_tos
+      |> Enum.map(fn reply_to ->
+        case reply_to do
+          {_name, address} -> address
+          address -> address
+        end
+      end)
+      |> Enum.join(", ")
+
+    Map.put(body, "h:Reply-To", addresses)
+  end
+
   defp prepare_cc(body, %{cc: []}), do: body
   defp prepare_cc(body, %{cc: cc}), do: Map.put(body, :cc, render_recipient(cc))
 

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -211,7 +211,8 @@ defmodule Swoosh.Email do
   end
 
   @doc """
-  Sets a recipient in the `reply_to` field.
+  Sets a recipient in the `reply_to` field. May also set a list of recipients as `reply_to`, but the
+  support for it on adapters is on case-by-case basis.
 
   ## Examples
 
@@ -232,7 +233,7 @@ defmodule Swoosh.Email do
        subject: "", text_body: nil, to: []}
   """
   @spec reply_to(t, Recipient.t() | [Recipient.t()]) :: t
-  def reply_to(%__MODULE__{reply_to: nil} = email, reply_to) when is_list(reply_to) do
+  def reply_to(%__MODULE__{} = email, reply_to) when is_list(reply_to) do
     %{email | reply_to: Enum.map(reply_to, &Recipient.format(&1))}
   end
 

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -224,6 +224,16 @@ defmodule Swoosh.Email do
       %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: {"", "steve.rogers@example.com"}, subject: "", text_body: nil, to: []}
+
+      iex> new() |> reply_to(["steve.rogers@example.com", "bucky.barnes@example.com"])
+      %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: nil,
+       headers: %{}, html_body: nil, private: %{}, provider_options: %{},
+       reply_to: [{"", "steve.rogers@example.com"}, {"", "bucky.barnes@example.com"}], subject: "", text_body: nil, to: []}
+
+      iex> new() |> reply_to([{"Steve Rogers", "steve.rogers@example.com"}, {"Bucky Barnes", "bucky.barnes@example.com"}])
+      %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: nil,
+       headers: %{}, html_body: nil, private: %{}, provider_options: %{},
+       reply_to: [{"Steve Rogers", "steve.rogers@example.com"}, {"Bucky Barnes", "bucky.barnes@example.com"}], subject: "", text_body: nil, to: []}
   """
   @spec reply_to(t, Recipient.t() | [Recipient.t()]) :: t
   def reply_to(%__MODULE__{reply_to: nil} = email, reply_to) when is_list(reply_to) do

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -85,7 +85,7 @@ defmodule Swoosh.Email do
           bcc: [mailbox] | [],
           text_body: text_body | nil,
           html_body: html_body | nil,
-          reply_to: mailbox | nil,
+          reply_to: [mailbox] | mailbox | nil,
           headers: map,
           private: map,
           assigns: map,
@@ -225,7 +225,26 @@ defmodule Swoosh.Email do
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: {"", "steve.rogers@example.com"}, subject: "", text_body: nil, to: []}
   """
-  @spec reply_to(t, Recipient.t()) :: t
+  @spec reply_to(t, Recipient.t() | [Recipient.t()]) :: t
+  def reply_to(%__MODULE__{reply_to: nil} = email, reply_to) when is_list(reply_to) do
+    reply_to =
+      reply_to
+      |> List.wrap()
+      |> Enum.map(&Recipient.format(&1))
+
+    %{email | reply_to: reply_to}
+  end
+
+  def reply_to(%__MODULE__{reply_to: reply_to} = email, recipients) when is_list(reply_to) do
+    recipients =
+      recipients
+      |> List.wrap()
+      |> Enum.map(&Recipient.format(&1))
+      |> Enum.concat(reply_to)
+
+    %{email | reply_to: recipients}
+  end
+
   def reply_to(%__MODULE__{} = email, reply_to) do
     %{email | reply_to: Recipient.format(reply_to)}
   end

--- a/lib/swoosh/email.ex
+++ b/lib/swoosh/email.ex
@@ -225,34 +225,15 @@ defmodule Swoosh.Email do
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
        reply_to: {"", "steve.rogers@example.com"}, subject: "", text_body: nil, to: []}
 
-      iex> new() |> reply_to(["steve.rogers@example.com", "bucky.barnes@example.com"])
+      iex> new() |> reply_to([{"Steve Rogers", "steve.rogers@example.com"}, "bucky.barnes@example.com"])
       %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: nil,
        headers: %{}, html_body: nil, private: %{}, provider_options: %{},
-       reply_to: [{"", "steve.rogers@example.com"}, {"", "bucky.barnes@example.com"}], subject: "", text_body: nil, to: []}
-
-      iex> new() |> reply_to([{"Steve Rogers", "steve.rogers@example.com"}, {"Bucky Barnes", "bucky.barnes@example.com"}])
-      %Swoosh.Email{assigns: %{}, attachments: [], bcc: [], cc: [], from: nil,
-       headers: %{}, html_body: nil, private: %{}, provider_options: %{},
-       reply_to: [{"Steve Rogers", "steve.rogers@example.com"}, {"Bucky Barnes", "bucky.barnes@example.com"}], subject: "", text_body: nil, to: []}
+       reply_to: [{"Steve Rogers", "steve.rogers@example.com"}, {"", "bucky.barnes@example.com"}],
+       subject: "", text_body: nil, to: []}
   """
   @spec reply_to(t, Recipient.t() | [Recipient.t()]) :: t
   def reply_to(%__MODULE__{reply_to: nil} = email, reply_to) when is_list(reply_to) do
-    reply_to =
-      reply_to
-      |> List.wrap()
-      |> Enum.map(&Recipient.format(&1))
-
-    %{email | reply_to: reply_to}
-  end
-
-  def reply_to(%__MODULE__{reply_to: reply_to} = email, recipients) when is_list(reply_to) do
-    recipients =
-      recipients
-      |> List.wrap()
-      |> Enum.map(&Recipient.format(&1))
-      |> Enum.concat(reply_to)
-
-    %{email | reply_to: recipients}
+    %{email | reply_to: Enum.map(reply_to, &Recipient.format(&1))}
   end
 
   def reply_to(%__MODULE__{} = email, reply_to) do

--- a/test/integration/adapters/mailtrap_test.exs
+++ b/test/integration/adapters/mailtrap_test.exs
@@ -44,7 +44,6 @@ defmodule Swoosh.Integration.Adapters.MailtrapTest do
 
     sandbox_config = [sandbox_inbox_id: System.get_env("MAILTRAP_INBOX")]
 
-    assert {:ok, _response} =
-             Swoosh.Adapters.Mailtrap.deliver(email, config ++ sandbox_config)
+    assert {:ok, _response} = Swoosh.Adapters.Mailtrap.deliver(email, config ++ sandbox_config)
   end
 end

--- a/test/swoosh/adapters/mailtrap_test.exs
+++ b/test/swoosh/adapters/mailtrap_test.exs
@@ -398,8 +398,7 @@ defmodule Swoosh.Adapters.MailtrapTest do
 
     Bypass.expect(bypass, &Plug.Conn.resp(&1, 400, errors))
 
-    response =
-      {:error, {400, %{"errors" => ["bla bla"], "success" => false}}}
+    response = {:error, {400, %{"errors" => ["bla bla"], "success" => false}}}
 
     assert Mailtrap.deliver(email, config) == response
   end
@@ -409,8 +408,7 @@ defmodule Swoosh.Adapters.MailtrapTest do
 
     Bypass.expect(bypass, &Plug.Conn.resp(&1, 400, errors))
 
-    response =
-      {:error, {400, %{"errors" => ["bla bla"], "success" => false}}}
+    response = {:error, {400, %{"errors" => ["bla bla"], "success" => false}}}
 
     assert Mailtrap.deliver(email, config) == response
   end


### PR DESCRIPTION
feature addition for https://github.com/swoosh/swoosh/issues/849

Added `[mailbox]` to `reply_to` types and handle `is_list` recipients in `emails.ex` and mailgun adapter

![swoosh-feat](https://github.com/swoosh/swoosh/assets/20119474/c43010e3-0928-4b90-b0f3-ceba25fced15)

now we are getting consistent reply-to