### PR TITLE
Add support of subaccount and tags for Mandrill

### DIFF
--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -52,6 +52,8 @@ defmodule Swoosh.Adapters.Mandrill do
       |> put_provider_option(:metadata, %{"website" => "www.example.com"})
       |> put_provider_option(:template_name, "welcome-user")
       |> put_provider_option(:template_content, [%{"name" => "a", "content" => "b"}])
+      |> put_provider_option(:subaccount, "subaccount-x")
+      |> put_provider_option(:tags, ["tag-1", "tag-2"])
 
   ## Provider options
 
@@ -71,6 +73,10 @@ defmodule Swoosh.Adapters.Mandrill do
 
     * `:template_name` (string) - a name of slug of the template belongs to a
       user
+
+    * `:subaccount` (string) - the unique id of a subaccount for this message
+
+    * `:tags` (list[string]) - a list of strings to tag the message with
 
   """
 
@@ -141,6 +147,8 @@ defmodule Swoosh.Adapters.Mandrill do
     |> prepare_merge_vars(email)
     |> prepare_merge_language(email)
     |> prepare_custom_headers(email)
+    |> prepare_subaccount(email)
+    |> prepare_tags(email)
   end
 
   defp set_api_key(body, config), do: Map.put(body, :key, config[:api_key])
@@ -256,4 +264,16 @@ defmodule Swoosh.Adapters.Mandrill do
     custom_headers = Map.merge(body[:headers] || %{}, headers)
     Map.put(body, :headers, custom_headers)
   end
+
+  defp prepare_subaccount(body, %{provider_options: %{subaccount: subaccount}}) do
+    Map.put(body, :subaccount, to_string(subaccount))
+  end
+
+  defp prepare_subaccount(body, _email), do: body
+
+  defp prepare_tags(body, %{provider_options: %{tags: tags}}) when is_list(tags) do
+    Map.put(body, :tags, tags)
+  end
+
+  defp prepare_tags(body, _email), do: body
 end

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -520,4 +520,80 @@ defmodule Swoosh.Adapters.MandrillTest do
 
     assert Mandrill.deliver(email, config) == {:ok, %{id: "9"}}
   end
+
+  test "deliver/1 with subaccount returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> to("wasp.avengers@example.com")
+      |> reply_to("office.avengers@example.com")
+      |> subject("Hello, Avengers!")
+      |> put_provider_option(:subaccount, "team-cap")
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "key" => "jarvis",
+        "message" => %{
+          "subject" => "Hello, Avengers!",
+          "headers" => %{"Reply-To" => "office.avengers@example.com"},
+          "to" => [
+            %{"type" => "to", "email" => "wasp.avengers@example.com"},
+            %{"type" => "to", "email" => "steve.rogers@example.com", "name" => "Steve Rogers"}
+          ],
+          "subaccount" => "team-cap",
+          "from_name" => "T Stark",
+          "from_email" => "tony.stark@example.com"
+        }
+      }
+
+      assert body_params == conn.body_params
+      assert "/messages/send.json" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mandrill.deliver(email, config) == {:ok, %{id: "9"}}
+  end
+
+  test "deliver/1 with tags returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> to("wasp.avengers@example.com")
+      |> reply_to("office.avengers@example.com")
+      |> subject("Hello, Avengers!")
+      |> put_provider_option(:tags, ["Team Iron-Man", "Tony", "Spider-Man", "War Machine"])
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "key" => "jarvis",
+        "message" => %{
+          "subject" => "Hello, Avengers!",
+          "headers" => %{"Reply-To" => "office.avengers@example.com"},
+          "to" => [
+            %{"type" => "to", "email" => "wasp.avengers@example.com"},
+            %{"type" => "to", "email" => "steve.rogers@example.com", "name" => "Steve Rogers"}
+          ],
+          "tags" => ["Team Iron-Man", "Tony", "Spider-Man", "War Machine"],
+          "from_name" => "T Stark",
+          "from_email" => "tony.stark@example.com"
+        }
+      }
+
+      assert body_params == conn.body_params
+      assert "/messages/send.json" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mandrill.deliver(email, config) == {:ok, %{id: "9"}}
+  end
 end


### PR DESCRIPTION
Add support for subaccount and tags as per https://mailchimp.com/developer/transactional/api/messages/send-new-message/ -> message's properties.