### PR TITLE
Fix Req header handling

### DIFF
--- a/lib/swoosh/api_client/req.ex
+++ b/lib/swoosh/api_client/req.ex
@@ -57,7 +57,13 @@ defmodule Swoosh.ApiClient.Req do
 
     case Req.post(url, options) do
       {:ok, response} ->
-        {:ok, response.status, response.headers, response.body}
+        headers =
+          for {name, values} <- response.headers,
+              value <- values do
+            {name, value}
+          end
+
+        {:ok, response.status, headers, response.body}
 
       {:error, reason} ->
         {:error, reason}

--- a/test/swoosh/api_client/req_test.exs
+++ b/test/swoosh/api_client/req_test.exs
@@ -1,0 +1,44 @@
+defmodule Swoosh.ApiClient.ReqTest do
+  # async: false because we change application env
+  use ExUnit.Case, async: false
+
+  import Swoosh.Email
+  alias Swoosh.Adapters.Sendgrid
+
+  setup do
+    old_api_client = Application.fetch_env!(:swoosh, :api_client)
+    Application.put_env(:swoosh, :api_client, Swoosh.ApiClient.Req)
+
+    on_exit(fn ->
+      Application.put_env(:swoosh, :api_client, old_api_client)
+    end)
+
+    :ok
+  end
+
+  test "it works" do
+    config = [
+      base_url: "http://mailgun",
+      api_key: "fake",
+      domain: "avengers.com"
+    ]
+
+    plug = fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("x-message-id", "123-xyz")
+      |> Req.Test.json(%{message: "success"})
+    end
+
+    email =
+      new()
+      |> put_private(:client_options, plug: plug)
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+
+    assert Sendgrid.deliver(email, config) ==
+             {:ok, %{id: "123-xyz"}}
+  end
+end


### PR DESCRIPTION
Since Req v0.4.0 (*), request and response headers are _maps_ of name and lists of values, e.g.:

```elixir
%{"content-type" => ["text/html"]}
```

(*) there's a way to keep the old behaviour, setting `config :req, legacy_headers_as_lists: true` but at this point people should upgrade away from it so I wouldn't even worry about it.