### PR TITLE
Add support for allow_nil_from

### DIFF
--- a/lib/swoosh/adapters/mandrill.ex
+++ b/lib/swoosh/adapters/mandrill.ex
@@ -78,6 +78,14 @@ defmodule Swoosh.Adapters.Mandrill do
 
     * `:tags` (list[string]) - a list of strings to tag the message with
 
+  ## Template-configured 'from' address
+
+  Mandrill templates allow you to configure the 'from' address in the template itself.
+  To use the 'from' fields configured in the template, rather than specifying the value
+  explicitly, you can set
+
+    |> from("TEMPLATE")
+
   """
 
   use Swoosh.Adapter, required_config: [:api_key]
@@ -155,6 +163,8 @@ defmodule Swoosh.Adapters.Mandrill do
 
   defp set_async(body, %{provider_options: %{async: true}}), do: Map.put(body, :async, true)
   defp set_async(body, _email), do: body
+
+  defp prepare_from(body, %{from: {_, "TEMPLATE"}}), do: body
 
   defp prepare_from(body, %{from: {nil, address}}), do: Map.put(body, :from_email, address)
 

--- a/test/swoosh/adapters/mandrill_test.exs
+++ b/test/swoosh/adapters/mandrill_test.exs
@@ -596,4 +596,34 @@ defmodule Swoosh.Adapters.MandrillTest do
 
     assert Mandrill.deliver(email, config) == {:ok, %{id: "9"}}
   end
+
+  test "deliver/1 with TEMPLATE from value returns :ok and has no from values",
+       %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("TEMPLATE")
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "key" => "jarvis",
+        "message" => %{
+          "subject" => "",
+          "to" => [
+            %{"type" => "to", "email" => "steve.rogers@example.com", "name" => "Steve Rogers"}
+          ]
+        }
+      }
+
+      assert body_params == conn.body_params
+      assert "/messages/send.json" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mandrill.deliver(email, config) == {:ok, %{id: "9"}}
+  end
 end


### PR DESCRIPTION
Mandrill email templates allow specification of the `from` email address and name on the template itself. Swoosh, however, requires `from` to be explicitly set which will cause the template values to always be overridden. This change adds the `allow_nil_from` config option which skips that check and allows use of the template-sourced values.