### PR TITLE
Specify the correct content_disposition and content_id

### DIFF
--- a/lib/swoosh/adapters/mua.ex
+++ b/lib/swoosh/adapters/mua.ex
@@ -185,7 +185,7 @@ defmodule Swoosh.Adapters.Mua do
     |> Enum.uniq()
   end
 
-  defp render(email) do
+  def render(email) do
     Mail.build_multipart()
     |> put_headers(email)
     |> maybe(&Mail.put_from/2, email.from)
@@ -206,7 +206,24 @@ defmodule Swoosh.Adapters.Mua do
     Enum.reduce(attachments, mail, fn attachment, mail ->
       %Swoosh.Attachment{filename: filename, content_type: content_type} = attachment
       data = Swoosh.Attachment.get_content(attachment)
-      Mail.put_attachment(mail, {filename, data}, headers: [content_type: content_type])
+
+      disposition =
+        if attachment.type == :inline do
+          ["inline", filename: filename]
+        else
+          ["attachment", filename: filename]
+        end
+
+      cid =
+        if attachment.cid do
+          [content_id: attachment.cid]
+        else
+          []
+        end
+
+      Mail.put_attachment(mail, {filename, data},
+        headers: [content_type: content_type, content_disposition: disposition] ++ cid
+      )
     end)
   end
 

--- a/lib/swoosh/adapters/mua.ex
+++ b/lib/swoosh/adapters/mua.ex
@@ -209,20 +209,16 @@ defmodule Swoosh.Adapters.Mua do
 
       disposition =
         if attachment.type == :inline do
-          ["inline", filename: filename]
+          [
+            content_disposition: ["inline", filename: filename],
+            content_id: "<#{attachment.cid || filename}>"
+          ]
         else
-          ["attachment", filename: filename]
-        end
-
-      cid =
-        if attachment.cid do
-          [content_id: attachment.cid]
-        else
-          []
+          [content_disposition: ["attachment", filename: filename]]
         end
 
       Mail.put_attachment(mail, {filename, data},
-        headers: [content_type: content_type, content_disposition: disposition] ++ cid
+        headers: [content_type: content_type] ++ disposition
       )
     end)
   end

--- a/test/plug/mailbox_preview_test.exs
+++ b/test/plug/mailbox_preview_test.exs
@@ -1,6 +1,7 @@
 defmodule Plug.Swoosh.MailboxPreviewTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Plug.Swoosh.MailboxPreview
 

--- a/test/swoosh/adapters/mua_test.exs
+++ b/test/swoosh/adapters/mua_test.exs
@@ -130,6 +130,33 @@ defmodule Swoosh.Adapters.MuaTest do
                "ID" => message_id,
                "Attachments" => [
                  %{
+                   "ContentID" => "",
+                   "ContentType" => "text/plain",
+                   "FileName" => "attachment.txt",
+                   "PartID" => part_id,
+                   "Size" => 9
+                 }
+               ]
+             } = mailpit_summary("latest")
+
+      assert mailpit_attachment(message_id, part_id) == "hello :)\n"
+    end
+
+    @tag :tmp_dir
+    test "with inline attachments", %{email: email, tmp_dir: tmp_dir} do
+      attachment = Path.join(tmp_dir, "attachment.txt")
+      File.write!(attachment, "hello :)\n")
+
+      assert {:ok, _email} =
+               email
+               |> Swoosh.Email.attachment(Swoosh.Attachment.new(attachment, type: :inline))
+               |> mailpit_deliver()
+
+      assert %{
+               "ID" => message_id,
+               "Inline" => [
+                 %{
+                   "ContentID" => "attachment.txt",
                    "ContentType" => "text/plain",
                    "FileName" => "attachment.txt",
                    "PartID" => part_id,


### PR DESCRIPTION
I recently migrated a project from using `Swoosh.Adapters.SMTP` to `Swoosh.Adapters.Mua`
and noticed that my inline attachments were no longer working.

Checking the code I saw that the `:type` and `:cid` fields were completely ignored when
creating the `Mail.Attachment`, hence this PR.
