### PR TITLE
Fix ex_aws region override

### DIFF
--- a/lib/swoosh/adapters/ex_aws_amazon_ses.ex
+++ b/lib/swoosh/adapters/ex_aws_amazon_ses.ex
@@ -59,14 +59,17 @@ defmodule Swoosh.Adapters.ExAwsAmazonSES do
   alias Swoosh.Adapters.AmazonSES
 
   def deliver(%Email{} = email, config \\ []) do
-    credentials = ExAws.Config.new(:ses)
-
+    region_override = Keyword.get(config, :region)
+    credentials = get_credentials(region_override)
     config = add_credentials(config, credentials)
 
     email
     |> add_security_token(credentials)
     |> AmazonSES.deliver(config)
   end
+
+  defp get_credentials(nil), do: ExAws.Config.new(:ses)
+  defp get_credentials(region), do: ExAws.Config.new(:ses, region: region)
 
   defp add_credentials(config, credentials) do
     Keyword.merge(

--- a/test/swoosh/adapters/ex_aws_amazonses_test.exs
+++ b/test/swoosh/adapters/ex_aws_amazonses_test.exs
@@ -63,6 +63,37 @@ defmodule Swoosh.Adapters.ExAwsAmazonSESTest do
              {:ok, %{id: "messageId", request_id: "requestId"}}
   end
 
+  test "unsupported region can be overridden with a supported region", %{
+    bypass: bypass,
+    config: config,
+    valid_email: email
+  } do
+    Application.put_env(:ex_aws, :access_key_id, "FAKE")
+    Application.put_env(:ex_aws, :secret_access_key, "FAKE")
+    Application.put_env(:ex_aws, :region, "ap-east-1")
+
+    on_exit(fn ->
+      Application.put_env(:ex_aws, :access_key_id, nil)
+      Application.put_env(:ex_aws, :secret_access_key, nil)
+      Application.put_env(:ex_aws, :region, nil)
+    end)
+
+    Bypass.expect(bypass, fn conn ->
+      import Plug.Conn
+
+      [authorization_header] = get_req_header(conn, "authorization")
+      assert "AWS4-HMAC-SHA256 Credential=FAKE/" <> _ = authorization_header
+      assert authorization_header =~ "us-east-1"
+
+      resp(conn, 200, @success_response)
+    end)
+
+    config = Keyword.put(config, :region, "us-east-1")
+
+    assert ExAwsAmazonSES.deliver(email, config) ==
+             {:ok, %{id: "messageId", request_id: "requestId"}}
+  end
+
   test "validate_config/1 with valid config", %{config: config} do
     assert ExAwsAmazonSES.validate_config(config) == :ok
   end


### PR DESCRIPTION
Fixes issue #913 allowing to override the region set in ex_aws config.