### PR TITLE
fix broken anchor link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Compose, deliver and test your emails easily in Elixir.
 
 Swoosh comes with many adapters, including SendGrid, Mandrill, Mailgun, Postmark and SMTP.
-See the full list of [adapters below](#adapters).
+See the full list of [adapters below](#module-adapters).
 
 The complete documentation for Swoosh is [available online at HexDocs](https://hexdocs.pm/swoosh).
 


### PR DESCRIPTION
I noticed one broken link when reading the docs. I didn't find the same bug anywhere else.