### PR TITLE
Explain how to recompile after installing gen_smtp

### DIFF
--- a/lib/swoosh/adapters/amazon_ses.ex
+++ b/lib/swoosh/adapters/amazon_ses.ex
@@ -19,6 +19,9 @@ defmodule Swoosh.Adapters.AmazonSES do
         ]
       end
 
+  **Note**: If Swoosh was compiled prior to `:gen_smtp` being installed, it may be necessary to
+  force a recompilation of the library. This can be accomplished using `mix deps.compile swoosh --force`.
+
   **This adapter requires an API Client.** Swoosh comes with Hackney, Finch and Req out of the box.
   See the [installation section](https://hexdocs.pm/swoosh/Swoosh.html#module-installation)
   for details.


### PR DESCRIPTION
Hi there 👋🏼 

I recently ran into the same issue as described in #552 and #578. The solution was to force a recompilation of Swoosh after installing `gen_smtp`. This PR adds a related note to the moduledoc for the adapter.