### PR TITLE
Write docs for functions in Mailer __using__ macro 

### DIFF
--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -150,6 +150,11 @@ defmodule Swoosh.Mailer do
         end
       end
 
+      @doc ~S"""
+      Delivers a list of emails with the given config.
+
+      It accepts a list of `%Swoosh.Email{}` as its first parameter.
+      """
       @spec deliver_many(list(%Swoosh.Email{}), Keyword.t()) :: {:ok, term} | {:error, term}
       def deliver_many(emails, config \\ [])
 

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -117,6 +117,12 @@ defmodule Swoosh.Mailer do
 
       Swoosh.Mailer.deprecated_system_env(@otp_app, __MODULE__)
 
+      @doc ~S"""
+      Delivers an email.
+
+      If the email is delivered it returns an `{:ok, result}` tuple. If it fails,
+      returns an `{:error, error}` tuple.
+      """
       @spec deliver(Swoosh.Email.t(), Keyword.t()) :: {:ok, term} | {:error, term}
       def deliver(email, config \\ [])
 

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -134,6 +134,12 @@ defmodule Swoosh.Mailer do
         end)
       end
 
+      @doc ~S"""
+      Delivers an email with the given config.
+
+      If the email is delivered, it returns the result. If it fails, it raises
+      a `DeliveryError`.
+      """
       @spec deliver!(Swoosh.Email.t(), Keyword.t()) :: term | no_return
       def deliver!(email, config \\ [])
 

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -135,7 +135,7 @@ defmodule Swoosh.Mailer do
       end
 
       @doc ~S"""
-      Delivers an email with the given config.
+      Delivers an email, raises on error.
 
       If the email is delivered, it returns the result. If it fails, it raises
       a `DeliveryError`.
@@ -151,7 +151,7 @@ defmodule Swoosh.Mailer do
       end
 
       @doc ~S"""
-      Delivers a list of emails with the given config.
+      Delivers a list of emails.
 
       It accepts a list of `%Swoosh.Email{}` as its first parameter.
       """


### PR DESCRIPTION
Hi!
I found #939 and decide to check if I could make my first contribution, at least writing docs, so here here it is!

With this PR I write basic documentation for the functions inside the `__using__` `defmacro`:

- `deliver/2`
- `deliver!/2`
- `deliver_many/2`

I know that sometimes functions inside macro are not documented, however, I think it may be useful when the user generates the documentation for its project or even if the user has an editor that shows this docs (at least in my VSCode with ElixirLS in an test project doesn't shows the docs, but I imagine there is some way).

I can't say it fix #939, because I think the issue it is a bit in the wrong direction because `deliver!/2` won't be never in Swoosh documentation because it is implemented outside the `__using__`.

Well, hope this little contribution may be useful!