### PR TITLE
Add toggle for text preview

### DIFF
--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -107,11 +107,11 @@
                   viewBox="0 0 24 24"
                   stroke-width="1.5"
                   stroke="currentColor"
-                  class="size-4 inline">
+                  class="size-4 inline <%= if @email.html_body, do: "rotate-180" %>">
                   <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
                 </svg>
               </p>
-              <div id="text-body-content" class="text-sm text-gray-700 leading-6 font-mono whitespace-pre-line ml-2 -mt-4 -mb-6">
+              <div id="text-body-content" class="text-sm text-gray-700 leading-6 font-mono whitespace-pre-line ml-2 -mt-4 -mb-6 <%= if @email.html_body, do: "hidden" %>">
                 <%= @email.text_body %>
               </div>
             </div>

--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -99,8 +99,19 @@
 
           <%= if @email.text_body do %>
             <div class="border-t border-gray-100 pl-4 py-2">
-              <p class="text-sm font-medium leading-6 text-gray-900">Text body</p>
-              <div class="text-sm text-gray-700 leading-6 font-mono whitespace-pre-line ml-2 -mt-4 -mb-6">
+              <p id="text-body-toggle" class="text-sm font-medium leading-6 text-gray-900 cursor-pointer" role="button">
+                Text body
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke-width="1.5"
+                  stroke="currentColor"
+                  class="size-4 inline">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                </svg>
+              </p>
+              <div id="text-body-content" class="text-sm text-gray-700 leading-6 font-mono whitespace-pre-line ml-2 -mt-4 -mb-6">
                 <%= @email.text_body %>
               </div>
             </div>
@@ -160,6 +171,18 @@
       const datetimes = Array.from(document.querySelectorAll('[data-datetime]'));
       for (let dt of datetimes) {
         dt.textContent = new Date(dt.dataset.datetime).toLocaleString();
+      }
+
+      const textToggle = document.querySelector("#text-body-toggle");
+
+      if (textToggle) {
+        textToggle.addEventListener("click", () => {
+          const textBody = document.querySelector("#text-body-content");
+          textBody.classList.toggle("hidden");
+
+          const icon = textToggle.querySelector("svg");
+          icon.classList.toggle("rotate-180");
+        });
       }
     </script>
   </body>


### PR DESCRIPTION
Text preview can be a bit too much if you're working on debugging or designing emails. This way we have a very easy way to just collapse it out of view.

It would be cool to be able to make it collapsed by default with a configuration flag, but I fist wanted to see what the community thinks of this.

## Demo

![CleanShot 2024-08-20 at 13 37 38](https://github.com/user-attachments/assets/7562f5c4-a629-451d-b603-7d5c273c2c36)
