### PR TITLE
Update the MSGraph Adapter Dependency

### DIFF
--- a/lib/swoosh/adapters/ms_graph.ex
+++ b/lib/swoosh/adapters/ms_graph.ex
@@ -34,7 +34,7 @@ defmodule Swoosh.Adapters.MsGraph do
 
   use Swoosh.Adapter,
     required_config: [:auth],
-    required_deps: [:gen_smtp]
+    required_deps: [gen_smtp: :gen_smtp_client]
 
   require Logger
   alias Swoosh.Email


### PR DESCRIPTION
Attempting to resolve #954 

This dependency is more generic than it needs to be _and_ seems to consistently fail in more recent builds as I can't seem to get gen_smtp to return true for Code.ensure_loaded at all, with any variations on how it's specified as a dependency.