### PR TITLE
Adapters: Add documentation about setting the base_url for ZeptoMail …

### DIFF
--- a/lib/swoosh/adapters/zepto_mail.ex
+++ b/lib/swoosh/adapters/zepto_mail.ex
@@ -8,6 +8,7 @@ defmodule Swoosh.Adapters.ZeptoMail do
 
   * `:api_key` - the API key without the prefix `Zoho-enczapikey` used with ZeptoMail.
   * `:type` - the type of email to send `:single` or `:batch`. Defaults to `:single`
+  * `:base_url` - the url to use as the API endpoint. For EU, use https://api.zeptomail.eu/v1.1
 
   ## Example
 


### PR DESCRIPTION
Hi,

I had some problems with the ZeptoMail adapter which were caused by the `base_url` being different than the one set by default in the adapter (default: https://api.zeptomail.com/v1.1). For me the `base_url` should have been https://api.zeptomail.eu/v1.1 I would guess because I am using ZeptoMail from EU. Looking at the adapter implementation I noticed that it was already possible to change the `base_url` but this was not documented in the ZeptoMail page so I added it to the documentation.