### PR TITLE
mua: fix mail.from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /cover
 /deps
 /doc
+/tmp
 erl_crash.dump
 *.ez
 .elixir_ls/

--- a/lib/swoosh/adapters/mua.ex
+++ b/lib/swoosh/adapters/mua.ex
@@ -187,7 +187,7 @@ defmodule Swoosh.Adapters.Mua do
 
   defp render(email) do
     Mail.build_multipart()
-    |> put_headers(email.headers)
+    |> put_headers(email)
     |> maybe(&Mail.put_from/2, email.from)
     |> maybe(&Mail.put_to/2, email.to)
     |> maybe(&Mail.put_cc/2, email.cc)
@@ -210,7 +210,9 @@ defmodule Swoosh.Adapters.Mua do
     end)
   end
 
-  defp put_headers(mail, headers) do
+  defp put_headers(mail, swoosh_email) do
+    %{from: from, headers: headers} = swoosh_email
+
     utc_now = DateTime.utc_now()
     keys = headers |> Map.keys() |> Enum.map(&String.downcase/1)
 
@@ -223,7 +225,7 @@ defmodule Swoosh.Adapters.Mua do
       if has_message_id? do
         headers
       else
-        address = address(mail.from)
+        address = address(from)
         host = host(address)
         Map.put(headers, "Message-ID", message_id(host, utc_now))
       end

--- a/test/swoosh/adapters/mua_test.exs
+++ b/test/swoosh/adapters/mua_test.exs
@@ -18,7 +18,7 @@ defmodule Swoosh.Adapters.MuaTest do
     end
 
     test "base email", %{email: email} do
-      {:ok, _email} = mailpit_deliver(email)
+      assert {:ok, _email} = mailpit_deliver(email)
 
       assert %{
                "From" => %{"Address" => "swoosh+mua@github.com", "Name" => "Mua"},
@@ -33,10 +33,112 @@ defmodule Swoosh.Adapters.MuaTest do
                "Message-Id" => [_has_message_id]
              } = mailpit_headers("latest")
     end
+
+    test "with address sender/recipient", %{email: email} do
+      assert {:ok, _email} =
+               email
+               |> Swoosh.Email.from("mua@github.com")
+               |> Swoosh.Email.to("to@mailpit.local")
+               |> Swoosh.Email.cc(["cc1@mailpit.examile", "cc2@mailpit.local"])
+               |> Swoosh.Email.bcc(["bcc1@mailpit.examile", "bcc2@mailpit.local"])
+               |> mailpit_deliver()
+
+      assert %{
+               "From" => %{"Address" => "mua@github.com", "Name" => ""},
+               "To" => [
+                 %{"Address" => "to@mailpit.local", "Name" => ""},
+                 %{"Address" => "recipient@mailpit.local", "Name" => "Recipient"}
+               ],
+               "Bcc" => [
+                 %{"Address" => "bcc1@mailpit.examile", "Name" => ""},
+                 %{"Address" => "bcc2@mailpit.local", "Name" => ""}
+               ],
+               "Cc" => [
+                 %{"Address" => "cc1@mailpit.examile", "Name" => ""},
+                 %{"Address" => "cc2@mailpit.local", "Name" => ""}
+               ]
+             } = mailpit_summary("latest")
+    end
+
+    test "with tuple recipient (empty name)", %{email: email} do
+      assert {:ok, _email} =
+               email
+               |> Swoosh.Email.from({nil, "mua@github.com"})
+               |> Swoosh.Email.to({nil, "to@mailpit.local"})
+               |> Swoosh.Email.cc([{nil, "cc1@mailpit.examile"}, {nil, "cc2@mailpit.local"}])
+               |> Swoosh.Email.bcc([{nil, "bcc1@mailpit.examile"}, {nil, "bcc2@mailpit.local"}])
+               |> mailpit_deliver()
+
+      assert %{
+               "From" => %{"Address" => "mua@github.com", "Name" => ""},
+               "To" => [
+                 %{"Address" => "to@mailpit.local", "Name" => ""},
+                 %{"Address" => "recipient@mailpit.local", "Name" => "Recipient"}
+               ],
+               "Bcc" => [
+                 %{"Address" => "bcc1@mailpit.examile", "Name" => ""},
+                 %{"Address" => "bcc2@mailpit.local", "Name" => ""}
+               ],
+               "Cc" => [
+                 %{"Address" => "cc1@mailpit.examile", "Name" => ""},
+                 %{"Address" => "cc2@mailpit.local", "Name" => ""}
+               ]
+             } = mailpit_summary("latest")
+    end
+
+    test "with cc and bcc", %{email: email} do
+      assert {:ok, _email} =
+               email
+               |> Swoosh.Email.cc([
+                 {"CC1", "cc1@mailpit.local"},
+                 {"CC2", "cc2@mailpit.local"}
+               ])
+               |> Swoosh.Email.bcc([
+                 {"BCC1", "bcc1@mailpit.local"},
+                 {"BCC2", "bcc2@mailpit.local"}
+               ])
+               |> mailpit_deliver()
+
+      assert %{
+               "Cc" => [
+                 %{"Address" => "cc1@mailpit.local", "Name" => "CC1"},
+                 %{"Address" => "cc2@mailpit.local", "Name" => "CC2"}
+               ],
+               "Bcc" => [
+                 %{"Address" => "bcc1@mailpit.local", "Name" => ""},
+                 %{"Address" => "bcc2@mailpit.local", "Name" => ""}
+               ]
+             } = mailpit_summary("latest")
+    end
+
+    @tag :tmp_dir
+    test "with attachments", %{email: email, tmp_dir: tmp_dir} do
+      attachment = Path.join(tmp_dir, "attachment.txt")
+      File.write!(attachment, "hello :)\n")
+
+      assert {:ok, _email} =
+               email
+               |> Swoosh.Email.attachment(attachment)
+               |> mailpit_deliver()
+
+      assert %{
+               "ID" => message_id,
+               "Attachments" => [
+                 %{
+                   "ContentType" => "text/plain",
+                   "FileName" => "attachment.txt",
+                   "PartID" => part_id,
+                   "Size" => 9
+                 }
+               ]
+             } = mailpit_summary("latest")
+
+      assert mailpit_attachment(message_id, part_id) == "hello :)\n"
+    end
   end
 
-  defp mailpit_deliver(email) do
-    config = [relay: "localhost", port: 1025]
+  defp mailpit_deliver(email, config \\ []) do
+    config = Keyword.merge([relay: "localhost", port: 1025], config)
     Swoosh.Adapters.Mua.deliver(email, config)
   end
 
@@ -46,6 +148,10 @@ defmodule Swoosh.Adapters.MuaTest do
 
   defp mailpit_headers(message_id) do
     mailpit_api_request("http://localhost:8025/api/v1/message/#{message_id}/headers")
+  end
+
+  defp mailpit_attachment(message_id, part_id) do
+    mailpit_api_request("http://localhost:8025/api/v1/message/#{message_id}/part/#{part_id}")
   end
 
   defp mailpit_api_request(url) do

--- a/test/swoosh/adapters/mua_test.exs
+++ b/test/swoosh/adapters/mua_test.exs
@@ -3,6 +3,11 @@ defmodule Swoosh.Adapters.MuaTest do
 
   @moduletag :mailpit
 
+  defp mailpit_deliver(email, config \\ []) do
+    config = Keyword.merge([relay: "localhost", port: 1025], config)
+    Swoosh.Adapters.Mua.deliver(email, config)
+  end
+
   describe "deliver/2" do
     setup do
       base_email =
@@ -39,8 +44,8 @@ defmodule Swoosh.Adapters.MuaTest do
                email
                |> Swoosh.Email.from("mua@github.com")
                |> Swoosh.Email.to("to@mailpit.local")
-               |> Swoosh.Email.cc(["cc1@mailpit.examile", "cc2@mailpit.local"])
-               |> Swoosh.Email.bcc(["bcc1@mailpit.examile", "bcc2@mailpit.local"])
+               |> Swoosh.Email.cc(["cc1@mailpit.local", "cc2@mailpit.local"])
+               |> Swoosh.Email.bcc(["bcc1@mailpit.local", "bcc2@mailpit.local"])
                |> mailpit_deliver()
 
       assert %{
@@ -50,11 +55,11 @@ defmodule Swoosh.Adapters.MuaTest do
                  %{"Address" => "recipient@mailpit.local", "Name" => "Recipient"}
                ],
                "Bcc" => [
-                 %{"Address" => "bcc1@mailpit.examile", "Name" => ""},
+                 %{"Address" => "bcc1@mailpit.local", "Name" => ""},
                  %{"Address" => "bcc2@mailpit.local", "Name" => ""}
                ],
                "Cc" => [
-                 %{"Address" => "cc1@mailpit.examile", "Name" => ""},
+                 %{"Address" => "cc1@mailpit.local", "Name" => ""},
                  %{"Address" => "cc2@mailpit.local", "Name" => ""}
                ]
              } = mailpit_summary("latest")
@@ -65,8 +70,8 @@ defmodule Swoosh.Adapters.MuaTest do
                email
                |> Swoosh.Email.from({nil, "mua@github.com"})
                |> Swoosh.Email.to({nil, "to@mailpit.local"})
-               |> Swoosh.Email.cc([{nil, "cc1@mailpit.examile"}, {nil, "cc2@mailpit.local"}])
-               |> Swoosh.Email.bcc([{nil, "bcc1@mailpit.examile"}, {nil, "bcc2@mailpit.local"}])
+               |> Swoosh.Email.cc([{nil, "cc1@mailpit.local"}, {nil, "cc2@mailpit.local"}])
+               |> Swoosh.Email.bcc([{nil, "bcc1@mailpit.local"}, {nil, "bcc2@mailpit.local"}])
                |> mailpit_deliver()
 
       assert %{
@@ -76,11 +81,11 @@ defmodule Swoosh.Adapters.MuaTest do
                  %{"Address" => "recipient@mailpit.local", "Name" => "Recipient"}
                ],
                "Bcc" => [
-                 %{"Address" => "bcc1@mailpit.examile", "Name" => ""},
+                 %{"Address" => "bcc1@mailpit.local", "Name" => ""},
                  %{"Address" => "bcc2@mailpit.local", "Name" => ""}
                ],
                "Cc" => [
-                 %{"Address" => "cc1@mailpit.examile", "Name" => ""},
+                 %{"Address" => "cc1@mailpit.local", "Name" => ""},
                  %{"Address" => "cc2@mailpit.local", "Name" => ""}
                ]
              } = mailpit_summary("latest")
@@ -137,24 +142,19 @@ defmodule Swoosh.Adapters.MuaTest do
     end
   end
 
-  defp mailpit_deliver(email, config \\ []) do
-    config = Keyword.merge([relay: "localhost", port: 1025], config)
-    Swoosh.Adapters.Mua.deliver(email, config)
-  end
-
   defp mailpit_summary(message_id) do
-    mailpit_api_request("http://localhost:8025/api/v1/message/#{message_id}")
+    mailpit_get("http://localhost:8025/api/v1/message/#{message_id}")
   end
 
   defp mailpit_headers(message_id) do
-    mailpit_api_request("http://localhost:8025/api/v1/message/#{message_id}/headers")
+    mailpit_get("http://localhost:8025/api/v1/message/#{message_id}/headers")
   end
 
   defp mailpit_attachment(message_id, part_id) do
-    mailpit_api_request("http://localhost:8025/api/v1/message/#{message_id}/part/#{part_id}")
+    mailpit_get("http://localhost:8025/api/v1/message/#{message_id}/part/#{part_id}")
   end
 
-  defp mailpit_api_request(url) do
+  defp mailpit_get(url) do
     Req.get!(url, retry: false).body
   end
 end

--- a/test/swoosh/adapters/mua_test.exs
+++ b/test/swoosh/adapters/mua_test.exs
@@ -1,0 +1,54 @@
+defmodule Swoosh.Adapters.MuaTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :mailpit
+
+  describe "deliver/2" do
+    setup do
+      base_email =
+        Swoosh.Email.new(
+          from: {"Mua", "swoosh+mua@github.com"},
+          to: {"Recipient", "recipient@mailpit.local"},
+          subject: "how are you? 😋",
+          text_body: "I'm fine 😌",
+          html_body: "I'm <i>fine</i> 😌"
+        )
+
+      {:ok, email: base_email}
+    end
+
+    test "base email", %{email: email} do
+      {:ok, _email} = mailpit_deliver(email)
+
+      assert %{
+               "From" => %{"Address" => "swoosh+mua@github.com", "Name" => "Mua"},
+               "To" => [%{"Address" => "recipient@mailpit.local", "Name" => "Recipient"}],
+               "Subject" => "how are you? 😋",
+               "Text" => "I'm fine 😌\r\n",
+               "HTML" => "I'm <i>fine</i> 😌"
+             } = mailpit_summary("latest")
+
+      assert %{
+               "Date" => [_has_date],
+               "Message-Id" => [_has_message_id]
+             } = mailpit_headers("latest")
+    end
+  end
+
+  defp mailpit_deliver(email) do
+    config = [relay: "localhost", port: 1025]
+    Swoosh.Adapters.Mua.deliver(email, config)
+  end
+
+  defp mailpit_summary(message_id) do
+    mailpit_api_request("http://localhost:8025/api/v1/message/#{message_id}")
+  end
+
+  defp mailpit_headers(message_id) do
+    mailpit_api_request("http://localhost:8025/api/v1/message/#{message_id}/headers")
+  end
+
+  defp mailpit_api_request(url) do
+    Req.get!(url, retry: false).body
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,7 +3,27 @@ if Application.fetch_env!(:swoosh, :api_client) == Swoosh.ApiClient.Finch do
   Finch.start_link(name: Swoosh.Test.Finch)
 end
 
+if :mailpit in ExUnit.configuration()[:include] do
+  mailpit_available? =
+    case Req.get("http://localhost:8025/api/v1/info", retry: false) do
+      {:ok, %{status: 200}} -> true
+      {:error, %{reason: :econnrefused}} -> false
+    end
+
+  unless mailpit_available? do
+    Mix.shell().error("""
+    To enable Mailpit tests, start the local container with the following command:
+
+        docker run -d --rm -p 1025:1025 -p 8025:8025 --name mailpit axllent/mailpit
+
+    And stop it once done:
+
+        docker stop mailpit
+    """)
+  end
+end
+
 ExUnit.start()
-ExUnit.configure(exclude: :integration)
+ExUnit.configure(exclude: [:integration, :mailpit])
 
 Application.ensure_all_started(:bypass)


### PR DESCRIPTION
Fixes the error reported in https://github.com/swoosh/swoosh/pull/978#issuecomment-2543317353 and adds some basic tests using Mailpit.

And I think it might make sense to retire the Swoosh version with the broken Swoosh.Adapters.Mua:

```console
$ mix hex.retire swoosh 1.17.4 deprecated --message "broken Swoosh.Adapters.Mua"
```

🙏 Sorry for the trouble! 🙏