### PR TITLE
Fix broken attachments on Scaleway adapter

### DIFF
--- a/lib/swoosh/adapters/scaleway.ex
+++ b/lib/swoosh/adapters/scaleway.ex
@@ -164,7 +164,8 @@ defmodule Swoosh.Adapters.Scaleway do
         attachments,
         &%{
           name: &1.filename,
-          content: Swoosh.Attachment.get_content(&1, :base64)
+          content: Swoosh.Attachment.get_content(&1, :base64),
+          type: &1.content_type
         }
       )
     )


### PR DESCRIPTION
This PR adds the required `type` prop (Scaleways name for "content type") to Scaleway provider.

Any request without "type" fails with 400 error after Scaleway updated their API lately.

Scaleway api docs here: https://www.scaleway.com/en/developers/api/transactional-email/#path-emails-send-an-email