### PR TITLE
Fix: Prevent zeptomail error when receiving non json response body on 500

### DIFF
--- a/lib/swoosh/adapters/zepto_mail.ex
+++ b/lib/swoosh/adapters/zepto_mail.ex
@@ -123,7 +123,15 @@ defmodule Swoosh.Adapters.ZeptoMail do
         {:ok, %{id: Swoosh.json_library().decode!(body)["request_id"]}}
 
       {:ok, code, _headers, body} when code > 399 ->
-        {:error, {code, Swoosh.json_library().decode!(body)}}
+        reason =
+          body
+          |> Swoosh.json_library().decode()
+          |> case do
+            {:ok, decoded} -> decoded
+            {:error, _reason} -> body
+          end
+
+        {:error, {code, reason}}
 
       {:error, reason} ->
         {:error, reason}


### PR DESCRIPTION
Currently Zeptomail returns "\n" as body on 500 error, this breaks `Swoosh.json_library().decode!(body)}` since it is not valid json.

The proposed fix tries to decode if possible, or returns the raw body otherwise.