### PR TITLE
Redirect to latest message in mailbox if one exists

### DIFF
--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -75,12 +75,11 @@ if Code.ensure_loaded?(Plug) do
         [%Swoosh.Email{headers: %{"Message-ID" => id}} | _] ->
           redir(conn, Path.join(conn.assigns.base_path, id))
 
-
         emails ->
           conn
           |> put_resp_content_type("text/html")
           |> send_resp(200, template(emails: emails, email: nil, conn: conn))
-        end
+      end
     end
 
     get "/:id/html" do
@@ -203,7 +202,10 @@ if Code.ensure_loaded?(Plug) do
       conn
       |> put_resp_header("location", location)
       |> put_resp_content_type("text/html")
-      |> send_resp(302, "<html><body>You are being <a href=\"#{location}\">redirected</a>.</body></html>")
+      |> send_resp(
+        302,
+        "<html><body>You are being <a href=\"#{location}\">redirected</a>.</body></html>"
+      )
     end
   end
 end

--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -71,21 +71,16 @@ if Code.ensure_loaded?(Plug) do
     end
 
     get "/" do
-      emails = conn.assigns.storage_driver.all()
-
-      conn
-      |> put_resp_content_type("text/html")
-      |> send_resp(200, template(emails: emails, email: nil, conn: conn))
-    end
-
-    get "/latest" do
       case conn.assigns.storage_driver.all() do
         [%Swoosh.Email{headers: %{"Message-ID" => id}} | _] ->
           redir(conn, Path.join(conn.assigns.base_path, id))
 
-        [] ->
-          redir(conn, conn.assigns.base_path)
-      end
+
+        emails ->
+          conn
+          |> put_resp_content_type("text/html")
+          |> send_resp(200, template(emails: emails, email: nil, conn: conn))
+        end
     end
 
     get "/:id/html" do

--- a/test/plug/mailbox_preview_test.exs
+++ b/test/plug/mailbox_preview_test.exs
@@ -1,6 +1,7 @@
 defmodule Plug.Swoosh.MailboxPreviewTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+
+  import Plug.{Conn, Test}
 
   alias Plug.Swoosh.MailboxPreview
 
@@ -130,7 +131,7 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
 
     test "with no messages redirects to base path" do
       opts = MailboxPreview.init(storage_driver: EmptyDriver)
-      conn = conn(:get, "/latest")
+      conn = conn(:get, "/")
       conn = MailboxPreview.call(conn, opts)
       assert get_resp_header(conn, "location") == []
     end

--- a/test/plug/mailbox_preview_test.exs
+++ b/test/plug/mailbox_preview_test.exs
@@ -47,6 +47,12 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
     end
   end
 
+  defmodule EmptyDriver do
+    def all, do: []
+    def get(_id), do: nil
+    def template_model, do: %{}
+  end
+
   describe "/json" do
     test "renders emails in json" do
       opts = MailboxPreview.init(storage_driver: StorageDriver)
@@ -107,6 +113,26 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
                  }
                ]
              }
+    end
+  end
+
+  describe "/latest" do
+    test "with existing messages redirects to most recent" do
+      opts = MailboxPreview.init(storage_driver: StorageDriver)
+
+      conn = conn(:get, "/latest")
+      conn = MailboxPreview.call(conn, opts)
+
+      assert conn.state == :sent
+      assert conn.status == 302
+      assert get_resp_header(conn, "location") == ["/1"]
+    end
+
+    test "with no messages redirects to base path" do
+      opts = MailboxPreview.init(storage_driver: EmptyDriver)
+      conn = conn(:get, "/latest")
+      conn = MailboxPreview.call(conn, opts)
+      assert get_resp_header(conn, "location") == ["/"]
     end
   end
 

--- a/test/plug/mailbox_preview_test.exs
+++ b/test/plug/mailbox_preview_test.exs
@@ -116,11 +116,11 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
     end
   end
 
-  describe "/latest" do
+  describe "/" do
     test "with existing messages redirects to most recent" do
       opts = MailboxPreview.init(storage_driver: StorageDriver)
 
-      conn = conn(:get, "/latest")
+      conn = conn(:get, "/")
       conn = MailboxPreview.call(conn, opts)
 
       assert conn.state == :sent
@@ -132,7 +132,7 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
       opts = MailboxPreview.init(storage_driver: EmptyDriver)
       conn = conn(:get, "/latest")
       conn = MailboxPreview.call(conn, opts)
-      assert get_resp_header(conn, "location") == ["/"]
+      assert get_resp_header(conn, "location") == []
     end
   end
 


### PR DESCRIPTION
This would be super useful for `phx.gen.auth` magic links where we direct folks to `/dev/mailbox` in dev and they can hop to the most recent email for a more convenient login flow in dev