### PR TITLE
Fix unused variable warnings in CI - Gmail Test

### DIFF
--- a/test/swoosh/adapters/gmail_test.exs
+++ b/test/swoosh/adapters/gmail_test.exs
@@ -29,7 +29,7 @@ defmodule Swoosh.Adapters.GmailTest do
   test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect(bypass, fn conn ->
       conn = parse(conn)
-      boundary = Mail.Message.get_boundary(conn.body_params)
+      _boundary = Mail.Message.get_boundary(conn.body_params)
 
       body_params =
         ~s"""


### PR DESCRIPTION
I noticed there was an unused variable in the gmail test that was raising warnings in CI. 

![image](https://github.com/user-attachments/assets/4bc445b8-c22b-4d9c-8712-99ccf5339f72)

This should make them go away. 