### PR TITLE
Add Accept header to all requests made by Sendgrid adapter

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -123,6 +123,7 @@ defmodule Swoosh.Adapters.Sendgrid do
     headers =
       [
         {"Content-Type", "application/json"},
+        {"Accept", "application/json"},
         {"User-Agent", "swoosh/#{Swoosh.version()}"},
         {"Authorization", "Bearer #{config[:api_key]}"}
       ]


### PR DESCRIPTION
Hello team! Recently we started seeing intermittent 406 errors from Sendgrid API. After spending some time researching and talking to their support, we came to a conclusion that a valid Accept header has to be present in all requests. Here is a simple PR to accomplish that. (I'm sorry, had to not follow the general contribution guideline, cuz no request headers covered by the tests. Let me know if you think it makes sense to add such tests though). Here is what we got from their support just in case: 
<img width="878" alt="Screenshot 2025-06-05 at 19 26 11" src="https://github.com/user-attachments/assets/4dab78da-545f-4ddc-bff5-e08dab068715" />

We're already using this solution in our production and it seems to be working fine.