### PR TITLE
Fix special "TEMPLATE" from option in CustomerIO adapter

### DIFF
--- a/lib/swoosh/adapters/customer_io.ex
+++ b/lib/swoosh/adapters/customer_io.ex
@@ -187,7 +187,8 @@ defmodule Swoosh.Adapters.CustomerIO do
   end
 
   defp prepare_from(body, %Email{from: nil}), do: body
-  defp prepare_from(body, %{from: "TEMPLATE"}), do: body
+  defp prepare_from(body, %Email{from: "TEMPLATE"}), do: body
+  defp prepare_from(body, %Email{from: {_, "TEMPLATE"}}), do: body
   defp prepare_from(body, %Email{from: from}), do: Map.put(body, :from, render_recipient(from))
 
   defp prepare_to(body, %Email{to: to}),

--- a/test/swoosh/adapters/customer_io_test.exs
+++ b/test/swoosh/adapters/customer_io_test.exs
@@ -97,12 +97,11 @@ defmodule Swoosh.Adapters.CustomerIOTest do
     assert CustomerIO.deliver(email, config) == {:ok, %{id: "123-xyz"}}
   end
 
-  test "delivery with from=TEMPLATE returns :ok", %{bypass: bypass, config: config} do
+  test "delivery with from 'TEMPLATE' omits the from parameter", %{bypass: bypass, config: config} do
     Bypass.expect(bypass, fn conn ->
       conn = parse(conn)
 
       body_params = %{
-        "from" => "TEMPLATE",
         "to" => "steve.rogers@example.com",
         "subject" => "Hello, Avengers!",
         "body" => "<h1>Hello</h1>",


### PR DESCRIPTION
This patch fixes #1068 by correctly handling the special `"TEMPLATE"` value in the mailbox tuple in `from`.

I've kept the `from: "TEMPLATE"` match to ensure backwards compatibility, in case users where manually doing `Map.put(email, :from, "TEMPLATE")`.