### PR TITLE
Encode international domain names (IDNA)

### DIFF
--- a/lib/swoosh/email/render.ex
+++ b/lib/swoosh/email/render.ex
@@ -2,8 +2,8 @@ defmodule Swoosh.Email.Render do
   @moduledoc false
 
   def render_recipient(nil), do: ""
-  def render_recipient({nil, address}), do: address
-  def render_recipient({"", address}), do: address
+  def render_recipient({nil, address}), do: puny_encode(address)
+  def render_recipient({"", address}), do: puny_encode(address)
   def render_recipient([]), do: ""
   def render_recipient("TEMPLATE"), do: "TEMPLATE"
 
@@ -13,11 +13,22 @@ defmodule Swoosh.Email.Render do
       |> String.replace("\\", "\\\\")
       |> String.replace("\"", "\\\"")
 
-    ~s("#{name}" <#{address}>)
+    ~s("#{name}" <#{puny_encode(address)}>)
   end
 
   def render_recipient(list) when is_list(list) do
     list
     |> Enum.map_join(", ", &render_recipient/1)
+  end
+
+  defp puny_encode(email) do
+    case String.split(email, "@") do
+      [local, domain] ->
+        encoded_domain = :idna.utf8_to_ascii(domain)
+        Enum.join([local, encoded_domain], "@")
+
+      _ ->
+        email
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -70,6 +70,7 @@ defmodule Swoosh.Mixfile do
       {:mime, "~> 1.1 or ~> 2.0"},
       {:jason, "~> 1.0"},
       {:telemetry, "~> 0.4.2 or ~> 1.0"},
+      {:idna, "~> 6.0"},
       {:hackney, "~> 1.9", optional: true},
       {:finch, "~> 0.6", optional: true},
       {:req, "~> 0.5.10 or ~> 0.6 or ~> 1.0", optional: true},

--- a/test/swoosh/email/smtp_test.exs
+++ b/test/swoosh/email/smtp_test.exs
@@ -129,6 +129,30 @@ defmodule Swoosh.Email.SMTPTest do
              }
   end
 
+  test "simple email to recipients with non-ASCII characters domains", %{valid_email: email} do
+    email =
+      email
+      |> html_body(nil)
+      |> from({nil, "tony@stärk.com"})
+      |> cc({"", "loki@jötunheim.god"})
+      |> to({"Steve Rogers", "steve@rœgers.com"})
+
+    assert Helpers.prepare_message(email, []) ==
+             {
+               "text",
+               "plain",
+               [
+                 {"Content-Type", "text/plain; charset=\"utf-8\""},
+                 {"From", "tony@xn--strk-moa.com"},
+                 {"To", "\"Steve Rogers\" <steve@xn--rgers-hbb.com>, steve@rogers.com"},
+                 {"Cc", "loki@xn--jtunheim-n4a.god"},
+                 {"Subject", "Hello, Avengers!"},
+                 {"MIME-Version", "1.0"}
+               ],
+               "Hello"
+             }
+  end
+
   test "simple html email", %{valid_email: email} do
     email = email |> text_body(nil)
 


### PR DESCRIPTION
Hello! Sorry once again for an unsolicited PR.

Thank you for working on Swoosh, we just started using it at work, and we ran into a corner case: we have a number of German users who have emails with non-ASCII domain names, such as `_redacted_@hörexperte.de`.

This use case is usually covered by [IDNA](https://en.wikipedia.org/wiki/Internationalized_domain_name) and [RFC 3492](https://datatracker.ietf.org/doc/html/rfc3492), so I thought Swoosh could also handle it. Our previous email setup used the Erlang [`:idna`](https://hexdocs.pm/idna/) package to handle the encoding into Punycode, and since it was already a transitive dependency of hackney, I thought it was a good choice.

The encoding leaves ASCII domains untouched.

Let me know if I can make any changes to improve the PR.