### PR TITLE
Support specifying ip_pool_name data for Sendgrid #1081

### DIFF
--- a/lib/swoosh/adapters/sendgrid.ex
+++ b/lib/swoosh/adapters/sendgrid.ex
@@ -12,7 +12,8 @@ defmodule Swoosh.Adapters.Sendgrid do
     :mail_settings,
     :tracking_settings,
     :send_at,
-    :batch_id
+    :batch_id,
+    :ip_pool_name
   ]
 
   @moduledoc ~s"""
@@ -68,6 +69,7 @@ defmodule Swoosh.Adapters.Sendgrid do
         subscription_tracking: %{enable: false}
       })
       |> put_provider_option(:batch_id, "AsdFgHjklQweRTYuIopzXcVBNm0aSDfGHjklmZcVbNMqWert1znmOP2asDFjkl")
+      |> put_provider_option(:ip_pool_name, "my-pool-name")
       |> put_provider_option(:send_at, 1617260400)
 
   ## Provider Options
@@ -103,6 +105,8 @@ defmodule Swoosh.Adapters.Sendgrid do
 
     * `:batch_id` (string) - An ID representing a batch of emails to be sent at
       the same time. It also enables you to cancel or pause the delivery of that batch
+
+    * `:ip_pool_name` (string) - The name of the IP Pool you wish to send using
 
   ## Sandbox mode
 


### PR DESCRIPTION
`ip_pool_name` needs to be a root level option in `body` for Sendgrid to accept it