### PR TITLE
fix: assert_no_email_sent and refute_email_sent now catch deliver_many

### DIFF
--- a/lib/swoosh/test_assertions.ex
+++ b/lib/swoosh/test_assertions.ex
@@ -215,6 +215,15 @@ defmodule Swoosh.TestAssertions do
   end
 
   @doc ~S"""
+  Refutes any email was sent via `deliver_many`.
+  """
+  defmacro refute_emails_sent() do
+    quote do
+      refute_received {:emails, _}
+    end
+  end
+
+  @doc ~S"""
   Asserts email with `attributes` was not sent.
 
   Performs pattern matching using the given pattern, equivalent to `pattern = email`.
@@ -257,6 +266,7 @@ defmodule Swoosh.TestAssertions do
   @spec assert_no_email_sent() :: false | no_return
   def assert_no_email_sent() do
     refute_email_sent()
+    refute_emails_sent()
   end
 
   @doc ~S"""

--- a/test/swoosh/test_assertions_test.exs
+++ b/test/swoosh/test_assertions_test.exs
@@ -401,5 +401,17 @@ defmodule Swoosh.TestAssertionsTest do
         }
       ])
     end
+
+    test "assert_no_email_sent catches emails from deliver_many" do
+      assert_raise ExUnit.AssertionError, fn ->
+        assert_no_email_sent()
+      end
+    end
+
+    test "refute_emails_sent catches emails from deliver_many" do
+      assert_raise ExUnit.AssertionError, fn ->
+        refute_emails_sent()
+      end
+    end
   end
 end


### PR DESCRIPTION
When emails are sent via `deliver_many/2`, calling `assert_no_email_sent()` passes silently because the assertions only check for `{:email, _}` messages while `deliver_many` sends `{:emails, emails}`.

## The fix

- Added `refute_emails_sent/0` macro that checks for `{:emails, _}` messages
- Updated `assert_no_email_sent/0` to call both `refute_email_sent()` and `refute_emails_sent()`

```elixir
# Before: this passes even after deliver_many
deliver_many(emails)
assert_no_email_sent()  # no assertion error

# After: correctly catches it
deliver_many(emails)
assert_no_email_sent()  # raises ExUnit.AssertionError
```

Added two test cases in the "when multiple emails are sent" describe block.

Closes #854