### PR TITLE
Escape email content in mailbox preview UI

### DIFF
--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -169,6 +169,7 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp content_disposition(filename) do
+      filename = if is_binary(filename), do: filename, else: "attachment"
       "attachment; filename*=UTF-8''" <> URI.encode(filename, &URI.char_unreserved?/1)
     end
 

--- a/lib/plug/mailbox_preview.ex
+++ b/lib/plug/mailbox_preview.ex
@@ -25,6 +25,8 @@ if Code.ensure_loaded?(Plug) do
     alias Swoosh.Email.Render
     alias Swoosh.Adapters.Local.Storage.Memory
 
+    import Plug.HTML, only: [html_escape: 1]
+
     require EEx
 
     EEx.function_from_file(
@@ -103,13 +105,13 @@ if Code.ensure_loaded?(Plug) do
             %{data: data, content_type: content_type, filename: filename} when not is_nil(data) ->
               conn
               |> put_resp_content_type(content_type)
-              |> put_resp_header("content-disposition", "attachment; filename=\"#{filename}\"")
+              |> put_resp_header("content-disposition", content_disposition(filename))
               |> send_resp(200, data)
 
             %{path: path, content_type: content_type, filename: filename} when not is_nil(path) ->
               conn
               |> put_resp_content_type(content_type)
-              |> put_resp_header("content-disposition", "attachment; filename=\"#{filename}\"")
+              |> put_resp_header("content-disposition", content_disposition(filename))
               |> send_resp(200, File.read!(path))
 
             _ ->
@@ -164,6 +166,10 @@ if Code.ensure_loaded?(Plug) do
 
     defp to_absolute_url(conn, path) do
       Path.join(conn.assigns.base_path, path)
+    end
+
+    defp content_disposition(filename) do
+      "attachment; filename*=UTF-8''" <> URI.encode(filename, &URI.char_unreserved?/1)
     end
 
     defp csp_nonce(conn, type) when type in [:script, :style] do

--- a/lib/plug/templates/mailbox_viewer/index.html.eex
+++ b/lib/plug/templates/mailbox_viewer/index.html.eex
@@ -20,9 +20,9 @@
             <div class="flex flex-col h-full">
               <%= for email <- @emails do %>
                 <% id = email.headers["Message-ID"] %>
-                <a href="<%= to_absolute_url(@conn, id) %>" class="flex flex-col border-b border-gray-200 dark:border-gray-700 p-4<%= if @email && @email.headers["Message-ID"] == id, do: " bg-gray-100 dark:bg-gray-800" %>">
+                <a href="<%= to_absolute_url(@conn, id) |> html_escape() %>" class="flex flex-col border-b border-gray-200 dark:border-gray-700 p-4<%= if @email && @email.headers["Message-ID"] == id, do: " bg-gray-100 dark:bg-gray-800" %>">
                   <div class="font-bold"><%= render_email_name(email) %></div>
-                  <p class="text-sm leading-6 text-gray-700 dark:text-gray-300"><%= email.subject %></p>
+                  <p class="text-sm leading-6 text-gray-700 dark:text-gray-300"><%= html_escape(email.subject) %></p>
                 </a>
               <% end %>
               <div class="flex-grow">&nbsp;</div>
@@ -55,7 +55,7 @@
                   <%= if @email.subject == "" do %>
                     <i>No subject</i>
                   <% else %>
-                    <%= @email.subject %>
+                    <%= html_escape(@email.subject) %>
                   <% end %>
                 </dd>
               </div>
@@ -74,21 +74,21 @@
 
               <%= for {name, value} <- @email.headers do %>
                 <div class="pl-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4">
-                  <dt class="details__label text-sm font-medium leading-6 text-gray-900 dark:text-gray-100"><%= name %></dt>
-                  <dd class="details__value text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2"><%= value %></dd>
+                  <dt class="details__label text-sm font-medium leading-6 text-gray-900 dark:text-gray-100"><%= to_string(name) |> html_escape() %></dt>
+                  <dd class="details__value text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2"><%= to_string(value) |> html_escape() %></dd>
                 </div>
               <% end %>
 
               <%= for {name, value} <- @email.provider_options do %>
                 <div class="pl-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4">
-                  <dt class="details__label text-sm font-medium leading-6 text-gray-900 dark:text-gray-100"><%= name %></dt>
-                  <dd class="details__value text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2"><%= inspect(value) %></dd>
+                  <dt class="details__label text-sm font-medium leading-6 text-gray-900 dark:text-gray-100"><%= to_string(name) |> html_escape() %></dt>
+                  <dd class="details__value text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2"><%= inspect(value) |> html_escape() %></dd>
                 </div>
               <% end %>
 
               <div class="pl-4 py-2 sm:grid sm:grid-cols-3 sm:gap-4">
                 <dt class="details__label text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">Sent at</dt>
-                <dd class="details__value text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2" data-datetime="<%= @email.private.sent_at %>"></dd>
+                <dd class="details__value text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2" data-datetime="<%= to_string(@email.private.sent_at) |> html_escape() %>"></dd>
               </div>
             </dl>
           </div>
@@ -103,7 +103,7 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
                 </svg>
               </p>
-              <div id="text-body-content" class="text-gray-700 dark:text-gray-300 leading-6 font-mono whitespace-pre-line ml-2 my-2 <%= if @email.html_body, do: "hidden" %>"><%= @email.text_body %></div>
+              <div id="text-body-content" class="text-gray-700 dark:text-gray-300 leading-6 font-mono whitespace-pre-line ml-2 my-2 <%= if @email.html_body, do: "hidden" %>"><%= html_escape(@email.text_body) %></div>
             </div>
           <% end %>
 
@@ -111,12 +111,12 @@
             <div class="grow flex flex-col border-t border-gray-100 dark:border-gray-700 pl-4 py-2">
               <div class="flex items-center">
                 <p class="text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">HTML body</p>
-                <a href="<%= to_absolute_url(@conn, @email.headers["Message-ID"]) %>/html" class="ml-2" target="_blank">
+                <a href="<%= to_absolute_url(@conn, @email.headers["Message-ID"]) |> html_escape() %>/html" class="ml-2" target="_blank">
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 14a1 1 0 0 0-1 1v3.077c0 .459-.022.57-.082.684a.363.363 0 0 1-.157.157c-.113.06-.225.082-.684.082H5.923c-.459 0-.571-.022-.684-.082a.363.363 0 0 1-.157-.157c-.06-.113-.082-.225-.082-.684L4.999 5.5a.5.5 0 0 1 .5-.5l3.5.005a1 1 0 1 0 .002-2L5.501 3a2.5 2.5 0 0 0-2.502 2.5v12.577c0 .76.083 1.185.32 1.627.223.419.558.753.977.977.442.237.866.319 1.627.319h12.154c.76 0 1.185-.082 1.627-.319.419-.224.753-.558.977-.977.237-.442.319-.866.319-1.627V15a1 1 0 0 0-1-1zm-2-9.055v-.291l-.39.09A10 10 0 0 1 15.36 5H14a1 1 0 1 1 0-2l5.5.003a1.5 1.5 0 0 1 1.5 1.5V10a1 1 0 1 1-2 0V8.639c0-.757.086-1.511.256-2.249l.09-.39h-.295a10 10 0 0 1-1.411 1.775l-5.933 5.932a1 1 0 0 1-1.414-1.414l5.944-5.944A10 10 0 0 1 18 4.945z" fill="currentColor"/></svg>
                 </a>
               </div>
               <div class="grow">
-                <iframe id="html-mail" src="<%= to_absolute_url(@conn, @email.headers["Message-ID"]) %>/html" class="w-full mt-1 -mb-4 h-full" frameborder="0"></iframe>
+                <iframe id="html-mail" src="<%= to_absolute_url(@conn, @email.headers["Message-ID"]) |> html_escape() %>/html" class="w-full mt-1 -mb-4 h-full" frameborder="0"></iframe>
               </div>
             </div>
           <% end %>
@@ -126,11 +126,11 @@
               <p class="text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">Attachment(s)</p>
               <div class="flex mt-2">
                 <%= for {attachment, index} <- Enum.with_index(@email.attachments) do %>
-                  <a href="<%= to_absolute_url(@conn, @email.headers["Message-ID"]) %>/attachments/<%= index %>"
+                  <a href="<%= to_absolute_url(@conn, @email.headers["Message-ID"]) |> html_escape() %>/attachments/<%= index %>"
                     target="_blank"
                     class="flex items-center p-4 border border-gray-200 dark:border-gray-700 rounded mr-4">
                     <!-- unchanged attachment icon -->
-                    <p class="ml-2 text-sm"><%= attachment.filename %></p>
+                    <p class="ml-2 text-sm"><%= html_escape(attachment.filename) %></p>
                   </a>
                 <% end %>
               </div>
@@ -184,17 +184,27 @@
       // make links in text only view clickable
       const textMail = document.querySelector("#text-body-content");
       if (textMail) {
-        const textContent = textMail.textContent;
+        const text = textMail.textContent;
         // match common URL formats starting with http://, https://, or www.
         const urlRegex = /(https?:\/\/[^\s]+)|(www\.[^\s]+)/g;
-        const htmlWithLinks = textContent.replace(urlRegex, function(url) {
-          // Add https:// prefix to URLs starting with www.
-          const href = url.startsWith('www.') ? 'https://' + url : url;
-          return `<a href="${href}" style="text-decoration: underline;">${url}</a>`;
-        });
-
-        // Set the HTML content with clickable links
-        textMail.innerHTML = htmlWithLinks;
+        textMail.textContent = "";
+        let lastIndex = 0;
+        let match;
+        while ((match = urlRegex.exec(text)) !== null) {
+          const url = match[0];
+          if (match.index > lastIndex) {
+            textMail.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+          }
+          const link = document.createElement("a");
+          link.href = url.startsWith("www.") ? "https://" + url : url;
+          link.style.textDecoration = "underline";
+          link.textContent = url;
+          textMail.appendChild(link);
+          lastIndex = match.index + url.length;
+        }
+        if (lastIndex < text.length) {
+          textMail.appendChild(document.createTextNode(text.slice(lastIndex)));
+        }
       }
     </script>
   </body>

--- a/test/plug/mailbox_preview_test.exs
+++ b/test/plug/mailbox_preview_test.exs
@@ -87,6 +87,21 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
     def get(_id), do: email()
   end
 
+  defmodule NilFilenameDriver do
+    import Swoosh.Email
+
+    def email do
+      new()
+      |> from("admin@example.com")
+      |> to("victim@example.com")
+      |> header("Message-ID", "nil-fn")
+      |> attachment(Swoosh.Attachment.new({:data, "data"}, content_type: "image/png"))
+    end
+
+    def all, do: [email()]
+    def get(_id), do: email()
+  end
+
   describe "/json" do
     test "renders emails in json" do
       opts = MailboxPreview.init(storage_driver: StorageDriver)
@@ -253,6 +268,19 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
       refute header =~ "<"
       refute header =~ ~s|"|
       assert header == "attachment; filename*=UTF-8''FNAME%3Cscript%3Ealert%281%29%3C%2Fscript%3E.png"
+    end
+
+    test "falls back to a default content-disposition filename when nil" do
+      opts = MailboxPreview.init(storage_driver: NilFilenameDriver)
+
+      conn = conn(:get, "/nil-fn/attachments/0")
+      conn = MailboxPreview.call(conn, opts)
+
+      assert conn.status == 200
+
+      assert get_resp_header(conn, "content-disposition") == [
+               "attachment; filename*=UTF-8''attachment"
+             ]
     end
   end
 end

--- a/test/plug/mailbox_preview_test.exs
+++ b/test/plug/mailbox_preview_test.exs
@@ -60,6 +60,33 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
     def template_model, do: %{}
   end
 
+  defmodule XssDriver do
+    import Swoosh.Email
+
+    def email do
+      new()
+      |> subject("SUBJ<script>alert(1)</script>")
+      |> from({"Admin", "admin@example.com"})
+      |> to("victim@example.com")
+      |> text_body("TXT<img src=x onerror=alert(1)>")
+      |> html_body("<p>ok</p>")
+      |> header("Message-ID", ~s|MID" onfocus="alert(1)|)
+      |> header("X-Custom-Header", "HDRVAL<b>tag</b>")
+      |> header("X-<raw-name>", "hv")
+      |> put_provider_option(:template_model, "POV<script>alert(1)</script>")
+      |> attachment(
+        Swoosh.Attachment.new({:data, "data"},
+          filename: "FNAME<script>alert(1)</script>.png",
+          content_type: "image/png"
+        )
+      )
+      |> Swoosh.Email.put_private(:sent_at, "2026-04-19T00:00:00Z")
+    end
+
+    def all, do: [email()]
+    def get(_id), do: email()
+  end
+
   describe "/json" do
     test "renders emails in json" do
       opts = MailboxPreview.init(storage_driver: StorageDriver)
@@ -159,6 +186,48 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
     end
   end
 
+  describe "HTML escaping in mailbox viewer" do
+    setup do
+      opts = MailboxPreview.init(storage_driver: XssDriver)
+      conn = conn(:get, "/any-id") |> MailboxPreview.call(opts)
+      {:ok, body: conn.resp_body}
+    end
+
+    test "escapes subject in the sidebar and detail view", %{body: body} do
+      refute body =~ "SUBJ<script>alert(1)</script>"
+      assert body =~ "SUBJ&lt;script&gt;alert(1)&lt;/script&gt;"
+    end
+
+    test "escapes text body", %{body: body} do
+      refute body =~ "TXT<img src=x onerror=alert(1)>"
+      assert body =~ "TXT&lt;img src=x onerror=alert(1)&gt;"
+    end
+
+    test "escapes arbitrary header values", %{body: body} do
+      refute body =~ "HDRVAL<b>tag</b>"
+      assert body =~ "HDRVAL&lt;b&gt;tag&lt;/b&gt;"
+    end
+
+    test "escapes arbitrary header names", %{body: body} do
+      refute body =~ "X-<raw-name>"
+      assert body =~ "X-&lt;raw-name&gt;"
+    end
+
+    test "escapes Message-ID when interpolated into href/src attributes", %{body: body} do
+      refute body =~ ~s|onfocus="alert(1)"|
+    end
+
+    test "escapes provider_options values rendered via inspect/1", %{body: body} do
+      refute body =~ "POV<script>alert(1)</script>"
+      assert body =~ "POV&lt;script&gt;alert(1)&lt;/script&gt;"
+    end
+
+    test "escapes attachment filenames", %{body: body} do
+      refute body =~ "FNAME<script>alert(1)</script>.png"
+      assert body =~ "FNAME&lt;script&gt;alert(1)&lt;/script&gt;.png"
+    end
+  end
+
   describe "/:id/attachments/:index" do
     test "download attachment" do
       opts = MailboxPreview.init(storage_driver: StorageDriver)
@@ -170,8 +239,20 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
       assert conn.status == 200
 
       assert get_resp_header(conn, "content-disposition") == [
-               "attachment; filename=\"file.png\""
+               "attachment; filename*=UTF-8''file.png"
              ]
+    end
+
+    test "percent-encodes content-disposition for filenames with unsafe characters" do
+      opts = MailboxPreview.init(storage_driver: XssDriver)
+
+      conn = conn(:get, "/any/attachments/0")
+      conn = MailboxPreview.call(conn, opts)
+
+      [header] = get_resp_header(conn, "content-disposition")
+      refute header =~ "<"
+      refute header =~ ~s|"|
+      assert header == "attachment; filename*=UTF-8''FNAME%3Cscript%3Ealert%281%29%3C%2Fscript%3E.png"
     end
   end
 end

--- a/test/plug/mailbox_preview_test.exs
+++ b/test/plug/mailbox_preview_test.exs
@@ -267,7 +267,9 @@ defmodule Plug.Swoosh.MailboxPreviewTest do
       [header] = get_resp_header(conn, "content-disposition")
       refute header =~ "<"
       refute header =~ ~s|"|
-      assert header == "attachment; filename*=UTF-8''FNAME%3Cscript%3Ealert%281%29%3C%2Fscript%3E.png"
+
+      assert header ==
+               "attachment; filename*=UTF-8''FNAME%3Cscript%3Ealert%281%29%3C%2Fscript%3E.png"
     end
 
     test "falls back to a default content-disposition filename when nil" do


### PR DESCRIPTION
Escapes every interpolation in the `/dev/mailbox` preview template (subject, header name/value, provider_options, text body, attachment filename, Message-ID used in `href`/`src`, `sent_at`). Rewrites the text-body link-ification JS to build anchor elements via `createElement`/`textContent` so it no longer uses `innerHTML`. Encodes attachment filenames in `Content-Disposition` using RFC 5987 `filename*=UTF-8''…`.

The preview compiles its template with `EEx.function_from_file` using the default `EEx.SmartEngine`, which does not HTML-escape. I noticed this when a header value containing an email address in angle brackets didn't appear in the UI. The same unescaped interpolation applies to subject, text body, filenames, and Message-ID in attribute context, and the text-body link-ifier reintroduced HTML interpretation via `innerHTML` even when the server escaped. Since the preview is dev-only and emails are locally generated the exposure is limited, but the output should still be correct and safe.

I haven't got a test for the new link-ifier JS but have manually tested it with a variety of inputs.