### PR TITLE
fix(config): prioritize runtime config for Mailer

### DIFF
--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -223,8 +223,9 @@ defmodule Swoosh.Mailer do
 
   @doc false
   def parse_config(otp_app, mailer, mailer_config, dynamic_config) do
-    Application.get_env(otp_app, mailer, [])
-    |> Keyword.merge(mailer_config)
+    application_config = Application.get_env(otp_app, mailer, [])
+
+    Keyword.merge(mailer_config, application_config)
     |> Keyword.merge(dynamic_config)
     |> interpolate_env_vars()
   end

--- a/lib/swoosh/mailer.ex
+++ b/lib/swoosh/mailer.ex
@@ -225,7 +225,8 @@ defmodule Swoosh.Mailer do
   def parse_config(otp_app, mailer, mailer_config, dynamic_config) do
     application_config = Application.get_env(otp_app, mailer, [])
 
-    Keyword.merge(mailer_config, application_config)
+    mailer_config
+    |> Keyword.merge(application_config)
     |> Keyword.merge(dynamic_config)
     |> interpolate_env_vars()
   end


### PR DESCRIPTION
Fixes the issue https://github.com/swoosh/swoosh/issues/1133#issue-4408748459

Prioritize runtime application config over compile-time mailer_config in parse_config/4.

Application.get_env now takes precedence over @mailer_config, allowing runtime to override compile-time values passed into use Swoosh.Mailer.