### PR TITLE
Allow usage of idna 7.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Swoosh.Mixfile do
       {:mime, "~> 1.1 or ~> 2.0"},
       {:jason, "~> 1.0"},
       {:telemetry, "~> 0.4.2 or ~> 1.0"},
-      {:idna, "~> 6.0"},
+      {:idna, ">= 6.0.0 and < 8.0.0"},
       {:hackney, ">= 1.9.0 and < 5.0.0", optional: true},
       {:finch, "~> 0.6", optional: true},
       {:req, "~> 0.5.10 or ~> 0.6 or ~> 1.0", optional: true},


### PR DESCRIPTION
According to the idna changelog, the only breaking changes were to drop support for versions of Erlang older than 21.

https://github.com/benoitc/erlang-idna/blob/master/CHANGELOG