### PR TITLE
docs: document Postmark runtime API key option

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -16,6 +16,24 @@ defmodule Swoosh.Adapters.Postmark do
         use Swoosh.Mailer, otp_app: :sample
       end
 
+  ## Sending with multiple Postmark servers
+
+  Postmark server API keys are passed through the `:api_key` adapter config.
+  You can configure a default server API key and override it per delivery with
+  `Swoosh.Mailer.deliver/2`:
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.Postmark,
+        api_key: "default-server-api-key"
+
+      # use another Postmark server for this delivery
+      Sample.Mailer.deliver(email, api_key: "client-server-api-key")
+
+  Runtime config passed to `deliver/2` takes precedence over the configured
+  default, so the request uses the given key as the
+  `X-Postmark-Server-Token` header.
+
   ## Example of sending emails using templates
 
   This will use Postmark's `withTemplate` endpoint.

--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -20,7 +20,7 @@ defmodule Swoosh.Adapters.Postmark do
 
   Postmark server API keys are passed through the `:api_key` adapter config.
   You can configure a default server API key and override it per delivery with
-  `Swoosh.Mailer.deliver/2`:
+  your mailer module's `deliver/2`:
 
       # config/config.exs
       config :sample, Sample.Mailer,


### PR DESCRIPTION
Adds documentation explaining how to override the Postmark API key at delivery time using the  option.

This allows using different Postmark servers (e.g., sandbox vs. production) for different emails without changing the application config.