### PR TITLE
fix fat-fingering `content_id` instead of `cid`, added tests, fixed outdated expected response in `mua_test.exs`

### DIFF
--- a/lib/swoosh/adapters/mailpit.ex
+++ b/lib/swoosh/adapters/mailpit.ex
@@ -173,7 +173,7 @@ defmodule Swoosh.Adapters.Mailpit do
 
         case attachment.type do
           :inline ->
-            content_id = attachment.content_id || attachment.filename
+            content_id = attachment.cid || attachment.filename
             Map.put(att_map, "ContentID", content_id)
 
           _ ->

--- a/lib/swoosh/adapters/mailpit.ex
+++ b/lib/swoosh/adapters/mailpit.ex
@@ -1,0 +1,218 @@
+defmodule Swoosh.Adapters.Mailpit do
+  @moduledoc ~s"""
+  An adapter that sends email to a self-hosted Mailpit server via its HTTP API.
+
+  For reference: [Mailpit API docs](https://mailpit.axllent.org/docs/api-v1/)
+
+  **This adapter requires an API Client.** Swoosh comes with Hackney, Finch and Req out of the box.
+  See the [installation section](https://hexdocs.pm/swoosh/Swoosh.html#module-installation)
+  for details.
+
+  ## Example
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.Mailpit,
+        base_url: "https://mailpit.example.com",
+        api_key: "YnJ...0Rw=="  # optional, for Basic Auth
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample
+      end
+
+  ## Using with provider options
+
+      import Swoosh.Email
+
+      new()
+      |> from({"Raife Hastings", "raife@example.com"})
+      |> to({"Jed Haverford", "jed@example.com"})
+      |> reply_to("raife.hastings@example.com")
+      |> cc("eliza@example.com")
+      |> cc({"Jules Landry", "jules@example.com"})
+      |> bcc("james.reece@example.com")
+      |> bcc({"Ben Edwards", "ben@example.com"})
+      |> subject("Hello there")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> put_provider_option(:tags, ["welcome", "transactional"])
+
+  ## Provider Options
+
+  Supported provider options are the following:
+
+  #### Inserted into request body
+
+    * `:tags` (list of strings) - Mailpit tags
+  """
+
+  use Swoosh.Adapter, required_config: [:base_url]
+
+  alias Swoosh.Email
+
+  @api_endpoint "/api/v1/send"
+
+  @provider_options_body_fields [:tags]
+
+  def deliver(%Email{} = email, config \\ []) do
+    headers = build_headers(config)
+    body = email |> prepare_body() |> Swoosh.json_library().encode!()
+    url = prepare_url(config)
+
+    case Swoosh.ApiClient.post(url, headers, body, email) do
+      {:ok, code, _headers, body} when code in 200..399 ->
+        decoded = Swoosh.json_library().decode!(body)
+        {:ok, %{id: decoded["ID"]}}
+
+      {:ok, code, _headers, body} when code >= 400 ->
+        case Swoosh.json_library().decode(body) do
+          {:ok, error} -> {:error, {code, error}}
+          {:error, _} -> {:error, {code, body}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp prepare_url(config), do: [base_url(config), @api_endpoint]
+
+  defp base_url(config), do: config[:base_url]
+
+  defp build_headers(config) do
+    base = [
+      {"Accept", "application/json"},
+      {"Content-Type", "application/json"},
+      {"User-Agent", "swoosh/#{Swoosh.version()}"}
+    ]
+
+    case config[:api_key] do
+      api_key when is_binary(api_key) -> [{"Authorization", "Basic #{api_key}"} | base]
+      _ -> base
+    end
+  end
+
+  defp prepare_body(email) do
+    %{}
+    |> prepare_from(email)
+    |> prepare_to(email)
+    |> prepare_cc(email)
+    |> prepare_bcc(email)
+    |> prepare_subject(email)
+    |> prepare_text(email)
+    |> prepare_html(email)
+    |> prepare_attachments(email)
+    |> prepare_reply_to(email)
+    |> prepare_custom_headers(email)
+    |> prepare_provider_options(email)
+  end
+
+  defp recipient({name, email}) when is_binary(name) and name != "" and is_binary(email),
+    do: %{"Email" => email, "Name" => name}
+
+  defp recipient({_, email}) when is_binary(email),
+    do: %{"Email" => email}
+
+  defp recipient(email) when is_binary(email),
+    do: %{"Email" => email}
+
+  defp recipient_email({_, email}) when is_binary(email), do: email
+  defp recipient_email(email) when is_binary(email), do: email
+  defp recipient_email(_), do: nil
+
+  defp prepare_from(body, %{from: from}),
+    do: Map.put(body, "From", recipient(from))
+
+  defp prepare_from(body, _), do: body
+
+  defp prepare_to(body, %{to: to}) when is_list(to) and to != [],
+    do: Map.put(body, "To", Enum.map(to, &recipient/1))
+
+  defp prepare_to(body, _), do: body
+
+  defp prepare_cc(body, %{cc: []}), do: body
+  defp prepare_cc(body, %{cc: cc}), do: Map.put(body, "Cc", Enum.map(cc, &recipient/1))
+  defp prepare_cc(body, _), do: body
+
+  defp prepare_bcc(body, %{bcc: []}), do: body
+
+  defp prepare_bcc(body, %{bcc: bcc}) do
+    emails = Enum.flat_map(bcc, fn item -> [recipient_email(item)] end)
+    Map.put(body, "Bcc", emails)
+  end
+
+  defp prepare_bcc(body, _), do: body
+
+  defp prepare_subject(body, %{subject: subject}) when is_binary(subject),
+    do: Map.put(body, "Subject", subject)
+
+  defp prepare_subject(body, _), do: body
+
+  defp prepare_text(body, %{text_body: nil}), do: body
+  defp prepare_text(body, %{text_body: text}), do: Map.put(body, "Text", text)
+  defp prepare_text(body, _), do: body
+
+  defp prepare_html(body, %{html_body: nil}), do: body
+  defp prepare_html(body, %{html_body: html}), do: Map.put(body, "HTML", html)
+  defp prepare_html(body, _), do: body
+
+  defp prepare_attachments(body, %{attachments: []}), do: body
+
+  defp prepare_attachments(body, %{attachments: attachments}) do
+    atts =
+      Enum.map(attachments, fn attachment ->
+        content = Swoosh.Attachment.get_content(attachment, :base64)
+
+        att_map =
+          %{
+            "Filename" => attachment.filename,
+            "Content" => content
+          }
+          |> maybe_put("ContentType", attachment.content_type)
+
+        case attachment.type do
+          :inline ->
+            content_id = attachment.content_id || attachment.filename
+            Map.put(att_map, "ContentID", content_id)
+
+          _ ->
+            att_map
+        end
+      end)
+
+    Map.put(body, "Attachments", atts)
+  end
+
+  defp prepare_attachments(body, _), do: body
+
+  defp prepare_reply_to(body, %{reply_to: nil}), do: body
+
+  defp prepare_reply_to(body, %{reply_to: reply_to}) do
+    replies = List.wrap(reply_to)
+    Map.put(body, "ReplyTo", Enum.map(replies, &recipient/1))
+  end
+
+  defp prepare_reply_to(body, _), do: body
+
+  defp prepare_custom_headers(body, %{headers: headers}) when map_size(headers) == 0,
+    do: body
+
+  defp prepare_custom_headers(body, %{headers: headers}),
+    do: Map.put(body, "Headers", headers)
+
+  defp prepare_custom_headers(body, _), do: body
+
+  defp prepare_provider_options(body, %{provider_options: opts}) do
+    case Map.take(opts, @provider_options_body_fields) do
+      map when map_size(map) > 0 -> Map.merge(body, map)
+      _ -> body
+    end
+  end
+
+  defp prepare_provider_options(body, _), do: body
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/test/swoosh/adapters/mailpit_test.exs
+++ b/test/swoosh/adapters/mailpit_test.exs
@@ -219,6 +219,108 @@ defmodule Swoosh.Adapters.MailpitTest do
       assert "/api/v1/send" == conn.request_path
       assert "POST" == conn.method
 
+      att = List.first(conn.body_params["Attachments"])
+      refute Map.has_key?(att, "ContentID")
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mailpit.deliver(email, config) ==
+             {:ok, %{id: "iAfZVVe2UQfNSG5BAjgYwa"}}
+  end
+
+  test "deliver/1 with an inline attachment", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body(~s(<img src="cid:inline.txt"/>))
+      |> text_body("Hello")
+      |> attachment(
+        Swoosh.Attachment.new(
+          {:data, "inline-content"},
+          filename: "inline.txt",
+          content_type: "text/plain",
+          type: :inline
+        )
+      )
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      attachment_content = Base.encode64("inline-content")
+
+      body_params = %{
+        "From" => %{"Email" => "tony.stark@example.com"},
+        "To" => [%{"Email" => "steve.rogers@example.com"}],
+        "Text" => "Hello",
+        "HTML" => ~s(<img src="cid:inline.txt"/>),
+        "Subject" => "Hello, Avengers!",
+        "Attachments" => [
+          %{
+            "Filename" => "inline.txt",
+            "Content" => attachment_content,
+            "ContentType" => "text/plain",
+            "ContentID" => "inline.txt"
+          }
+        ]
+      }
+
+      assert body_params == conn.body_params
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mailpit.deliver(email, config) ==
+             {:ok, %{id: "iAfZVVe2UQfNSG5BAjgYwa"}}
+  end
+
+  test "deliver/1 with an inline attachment and custom cid", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body(~s(<img src="cid:my-cid"/>))
+      |> text_body("Hello")
+      |> attachment(
+        Swoosh.Attachment.new(
+          {:data, "inline-content"},
+          filename: "inline.txt",
+          content_type: "text/plain",
+          type: :inline,
+          cid: "my-cid"
+        )
+      )
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      attachment_content = Base.encode64("inline-content")
+
+      body_params = %{
+        "From" => %{"Email" => "tony.stark@example.com"},
+        "To" => [%{"Email" => "steve.rogers@example.com"}],
+        "Text" => "Hello",
+        "HTML" => ~s(<img src="cid:my-cid"/>),
+        "Subject" => "Hello, Avengers!",
+        "Attachments" => [
+          %{
+            "Filename" => "inline.txt",
+            "Content" => attachment_content,
+            "ContentType" => "text/plain",
+            "ContentID" => "my-cid"
+          }
+        ]
+      }
+
+      assert body_params == conn.body_params
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+
       Plug.Conn.resp(conn, 200, @success_response)
     end)
 

--- a/test/swoosh/adapters/mailpit_test.exs
+++ b/test/swoosh/adapters/mailpit_test.exs
@@ -1,0 +1,250 @@
+defmodule Swoosh.Adapters.MailpitTest do
+  use Swoosh.AdapterCase, async: true
+
+  import Swoosh.Email
+  alias Swoosh.Adapters.Mailpit
+
+  @success_response ~s({"ID": "iAfZVVe2UQfNSG5BAjgYwa"})
+
+  setup do
+    bypass = Bypass.open()
+    config = [base_url: "http://localhost:#{bypass.port}"]
+
+    valid_email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+
+    {:ok, bypass: bypass, config: config, valid_email: valid_email}
+  end
+
+  test "successful delivery returns :ok", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "From" => %{"Email" => "tony.stark@example.com"},
+        "To" => [%{"Email" => "steve.rogers@example.com"}],
+        "Text" => "Hello",
+        "HTML" => "<h1>Hello</h1>",
+        "Subject" => "Hello, Avengers!"
+      }
+
+      assert body_params == conn.body_params
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mailpit.deliver(email, config) ==
+             {:ok, %{id: "iAfZVVe2UQfNSG5BAjgYwa"}}
+  end
+
+  test "text-only delivery returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "From" => %{"Email" => "tony.stark@example.com"},
+        "To" => [%{"Email" => "steve.rogers@example.com"}],
+        "Text" => "Hello",
+        "Subject" => "Hello, Avengers!"
+      }
+
+      assert body_params == conn.body_params
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mailpit.deliver(email, config) ==
+             {:ok, %{id: "iAfZVVe2UQfNSG5BAjgYwa"}}
+  end
+
+  test "html-only delivery returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "From" => %{"Email" => "tony.stark@example.com"},
+        "To" => [%{"Email" => "steve.rogers@example.com"}],
+        "HTML" => "<h1>Hello</h1>",
+        "Subject" => "Hello, Avengers!"
+      }
+
+      assert body_params == conn.body_params
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mailpit.deliver(email, config) ==
+             {:ok, %{id: "iAfZVVe2UQfNSG5BAjgYwa"}}
+  end
+
+  test "deliver with all fields returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> reply_to("hulk.smash@example.com")
+      |> cc("hulk.smash@example.com")
+      |> cc({"Janet Pym", "wasp.avengers@example.com"})
+      |> bcc("thor.odinson@example.com")
+      |> bcc({"Henry McCoy", "beast.avengers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "From" => %{"Name" => "T Stark", "Email" => "tony.stark@example.com"},
+        "To" => [%{"Name" => "Steve Rogers", "Email" => "steve.rogers@example.com"}],
+        "ReplyTo" => [%{"Email" => "hulk.smash@example.com"}],
+        "Cc" => [
+          %{"Name" => "Janet Pym", "Email" => "wasp.avengers@example.com"},
+          %{"Email" => "hulk.smash@example.com"}
+        ],
+        # Bcc order is newest-first (Swoosh prepends recipients to the list for efficiency)
+        "Bcc" => ["beast.avengers@example.com", "thor.odinson@example.com"],
+        "Text" => "Hello",
+        "HTML" => "<h1>Hello</h1>",
+        "Subject" => "Hello, Avengers!"
+      }
+
+      assert body_params == conn.body_params
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mailpit.deliver(email, config) ==
+             {:ok, %{id: "iAfZVVe2UQfNSG5BAjgYwa"}}
+  end
+
+  test "deliver/1 with custom headers returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+      |> header("In-Reply-To", "<1234@example.com>")
+      |> header("X-Accept-Language", "en")
+      |> header("X-Mailer", "swoosh")
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "From" => %{"Name" => "T Stark", "Email" => "tony.stark@example.com"},
+        "To" => [%{"Name" => "Steve Rogers", "Email" => "steve.rogers@example.com"}],
+        "Text" => "Hello",
+        "HTML" => "<h1>Hello</h1>",
+        "Subject" => "Hello, Avengers!",
+        "Headers" => %{
+          "In-Reply-To" => "<1234@example.com>",
+          "X-Accept-Language" => "en",
+          "X-Mailer" => "swoosh"
+        }
+      }
+
+      assert body_params == conn.body_params
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mailpit.deliver(email, config) ==
+             {:ok, %{id: "iAfZVVe2UQfNSG5BAjgYwa"}}
+  end
+
+  test "deliver/1 with an attachment", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> attachment("test/support/attachment.txt")
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      attachment_content =
+        "test/support/attachment.txt"
+        |> File.read!()
+        |> Base.encode64()
+
+      body_params = %{
+        "From" => %{"Email" => "tony.stark@example.com"},
+        "To" => [%{"Email" => "steve.rogers@example.com"}],
+        "Text" => "Hello",
+        "Subject" => "Hello, Avengers!",
+        "Attachments" => [
+          %{
+            "Filename" => "attachment.txt",
+            "Content" => attachment_content,
+            "ContentType" => "text/plain"
+          }
+        ]
+      }
+
+      assert body_params == conn.body_params
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Mailpit.deliver(email, config) ==
+             {:ok, %{id: "iAfZVVe2UQfNSG5BAjgYwa"}}
+  end
+
+  test "deliver/1 with 400 response", %{bypass: bypass, config: config, valid_email: email} do
+    errors = ~s({"error": "bad request"})
+
+    Bypass.expect(bypass, &Plug.Conn.resp(&1, 400, errors))
+
+    assert Mailpit.deliver(email, config) == {:error, {400, %{"error" => "bad request"}}}
+  end
+
+  test "deliver/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect(bypass, fn conn ->
+      assert "/api/v1/send" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 500, "")
+    end)
+
+    assert Mailpit.deliver(email, config) == {:error, {500, ""}}
+  end
+
+  test "validate_config/1 with valid config", %{config: config} do
+    assert Mailpit.validate_config(config) == :ok
+  end
+end

--- a/test/swoosh/adapters/mua_test.exs
+++ b/test/swoosh/adapters/mua_test.exs
@@ -29,7 +29,7 @@ defmodule Swoosh.Adapters.MuaTest do
                "From" => %{"Address" => "swoosh+mua@github.com", "Name" => "Mua"},
                "To" => [%{"Address" => "recipient@mailpit.local", "Name" => "Recipient"}],
                "Subject" => "how are you? 😋",
-               "Text" => "I'm fine 😌\r\n",
+               "Text" => "I'm fine 😌",
                "HTML" => "I'm <i>fine</i> 😌"
              } = mailpit_summary("latest")
 


### PR DESCRIPTION
- I had typed `attachment.content_id` instead of `attachment.cid`; fixed.
- I added 2 new tests for `deliver/2` a) with an inline attachment and b) with an inline attachment and custom `cid`.
- I ran `mix test --only mailpit` (hadn't noticed that this exists since last year for testing with a local docker container). The `"Text"` field with the latest docker image doesn't include a trailing `\r\n` so I adapted the expected response.

Verification:
```
$ docker run -d --rm -p 1025:1025 -p 8025:8025 --name mailpit axllent/mailpit
$ mix test --only mailpit
Running ExUnit with seed: 620926, max_cases: 24
Excluding tags: [:test, :integration]
Including tags: [:mailpit]
...
Finished in 1.2 seconds (1.2s async, 0.00s sync)
29 doctests, 594 tests, 0 failures, 617 excluded
$ mix test 
Running ExUnit with seed: 764694, max_cases: 24
Excluding tags: [:integration, :mailpit]
...
Finished in 1.9 seconds (1.8s async, 0.06s sync)
29 doctests, 594 tests, 0 failures, 22 excluded
```

Should be OK now.