### PR TITLE
Replace deprecated xref: [exclude:] with elixirc_options: [no_warn_undefined:]

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,9 +25,9 @@ defmodule Swoosh.Mixfile do
       homepage_url: @source_url,
       docs: &docs/0,
 
-      # Suppress warnings
-      xref: [
-        exclude: [
+      # Suppress warnings for optional dependencies
+      elixirc_options: [
+        no_warn_undefined: [
           :hackney,
           :gen_smtp_client,
           :mimemail,


### PR DESCRIPTION
Mix 1.20 deprecated `xref: [exclude: ...]` in favour of `elixirc_options: [no_warn_undefined: ...]`. This is a straight rename of the key/value — the list contents are identical.

Silences the compile warning:
```
warning: "xref: [exclude: ...]" in your mix.exs file is deprecated,
instead use: "elixirc_options: [no_warn_undefined: ...]"
```