### PR TITLE
Fix Postmark adapter not adding the Recipient's name to the Reply-To header

### DIFF
--- a/lib/swoosh/adapters/postmark.ex
+++ b/lib/swoosh/adapters/postmark.ex
@@ -253,8 +253,8 @@ defmodule Swoosh.Adapters.Postmark do
 
   defp prepare_reply_to(body, %{reply_to: nil}), do: body
 
-  defp prepare_reply_to(body, %{reply_to: {_name, address}}),
-    do: Map.put(body, "ReplyTo", address)
+  defp prepare_reply_to(body, %{reply_to: reply_to}),
+    do: Map.put(body, "ReplyTo", render_recipient(reply_to))
 
   defp prepare_subject(body, %{subject: ""}), do: body
   defp prepare_subject(body, %{subject: subject}), do: Map.put(body, "Subject", subject)

--- a/test/swoosh/adapters/postmark_test.exs
+++ b/test/swoosh/adapters/postmark_test.exs
@@ -645,4 +645,34 @@ defmodule Swoosh.Adapters.PostmarkTest do
                 }
               ]}
   end
+
+  test "deliver/1 includes recipient name in reply_to", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> reply_to({"Iron Man", "iron.man@example.com"})
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+
+    Bypass.expect(bypass, fn conn ->
+      conn = parse(conn)
+
+      body_params = %{
+        "To" => "\"Steve Rogers\" <steve.rogers@example.com>",
+        "From" => "\"T Stark\" <tony.stark@example.com>",
+        "ReplyTo" => "\"Iron Man\" <iron.man@example.com>",
+        "TextBody" => "Hello",
+        "HtmlBody" => "<h1>Hello</h1>"
+      }
+
+      assert body_params == conn.body_params
+      assert "/email" == conn.request_path
+      assert "POST" == conn.method
+
+      Plug.Conn.resp(conn, 200, @success_response)
+    end)
+
+    assert Postmark.deliver(email, config) == {:ok, %{id: "b7bc2f4a-e38e-4336-af7d-e6c392c2f817"}}
+  end
 end


### PR DESCRIPTION
As the title states, the Postmark adapter did not add the Recipient's name when calling `reply_to/2`. 

Before, calling `reply_to({"Victor", "victor@example.com"})` would result in the header: `Reply-To: victor@example.com`.

With this fix we now get: `Reply-To: Victor <victor@example.com>`
