### PR TITLE
Add AhaSend adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### ✨ Features
+
+- Add AhaSend adapter @Sameer1122 (#1177)
+
 ## 1.26.3
 
 ### 🔒 Security

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ included:
 | Lettermint                   | [Swoosh.Adapters.Lettermint](https://hexdocs.pm/swoosh/Swoosh.Adapters.Lettermint.html#content)                                 |                  |
 | Resend                       | [Swoosh.Adapters.Resend](https://hexdocs.pm/swoosh/Swoosh.Adapters.Resend.html#content)                                         |                  |
 | Azure Communication Services | [Swoosh.Adapters.AzureCommunicationServices](https://hexdocs.pm/swoosh/Swoosh.Adapters.AzureCommunicationServices.html#content) |                  |
+| AhaSend                      | [Swoosh.Adapters.AhaSend](https://hexdocs.pm/swoosh/Swoosh.Adapters.AhaSend.html#content)                                       |                  |
 | ------                       | **Below are not fully featured services**                                                                                       | ------           |
 | Loops                        | [Swoosh.Adapters.Loops](https://hexdocs.pm/swoosh/Swoosh.Adapters.Loops.html#content)                                           |                  |
 | PostUp                       | [Swoosh.Adapters.PostUp](https://hexdocs.pm/swoosh/Swoosh.Adapters.PostUp.html#content)                                         |                  |

--- a/lib/swoosh/adapters/aha_send.ex
+++ b/lib/swoosh/adapters/aha_send.ex
@@ -1,0 +1,321 @@
+defmodule Swoosh.Adapters.AhaSend do
+  @moduledoc ~S"""
+  An adapter that sends email using the AhaSend API.
+
+  For reference: [AhaSend API docs](https://ahasend.com/docs/api-reference)
+
+  **This adapter requires an API Client.** Swoosh comes with Hackney, Finch and Req out of the box.
+  See the [installation section](https://hexdocs.pm/swoosh/Swoosh.html#module-installation)
+  for details.
+
+  ## Example
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.AhaSend,
+        api_key: "aha-sk-my-api-key",
+        account_id: "my-account-id"
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample
+      end
+
+  ## Recipients
+
+  AhaSend exposes two send endpoints and this adapter picks the one that
+  preserves the semantics of the email you built:
+
+    * emails without `cc` or `bcc` are sent through `/messages`, which
+      delivers an individual message to each recipient. Recipients do not
+      see one another.
+
+    * emails with `cc` or `bcc` are sent through `/messages/conversation`,
+      which delivers a single message carrying the full `To`/`Cc`/`Bcc`
+      headers, the way a regular mail client would.
+
+  ## Delivering many emails
+
+  `deliver_many/2` sends each email in its own request, so a problem with one
+  email (an invalid recipient, say) never affects the others. Results are
+  returned in the same order as the emails passed in. Delivery stops at the
+  first failure and returns that error; emails already sent are not rolled
+  back.
+
+  ## Using with provider options
+
+      import Swoosh.Email
+
+      new()
+      |> from("nora@example.com")
+      |> to("shushu@example.com")
+      |> subject("Hello, Wally!")
+      |> text_body("Hello")
+      |> put_provider_option(:tags, ["welcome", "onboarding"])
+      |> put_provider_option(:tracking, %{open: true, click: false})
+      |> put_provider_option(:idempotency_key, "unique-key-123")
+
+  ## Provider Options
+
+    * `tags` (list of strings) - `tags`, categorize the message
+
+    * `substitutions` (map) - `substitutions`, template variables applied to
+      the subject and body
+
+    * `tracking` (map) - `tracking`, override the account open/click tracking
+      defaults, for example `%{open: true, click: false}`
+
+    * `retention` (map) - `retention`, override the account data retention
+      defaults, for example `%{metadata: 30, data: 7}`
+
+    * `schedule` (map) - `schedule`, defer delivery, for example
+      `%{first_attempt: "2026-01-01T00:00:00Z"}`
+
+    * `sandbox` (boolean) - `sandbox`, accept and validate the message
+      without delivering it
+
+    * `sandbox_result` (string) - `sandbox_result`, the outcome to simulate in
+      sandbox mode. One of `deliver`, `bounce`, `defer`, `fail`, `suppress`
+
+    * `idempotency_key` (string) - sent as the `Idempotency-Key` header so a
+      retried request cannot deliver the message twice
+
+  """
+
+  use Swoosh.Adapter, required_config: [:api_key, :account_id]
+
+  alias Swoosh.Email
+
+  @base_url "https://api.ahasend.com"
+
+  def deliver(%Email{} = email, config \\ []) do
+    headers = prepare_headers(config, email)
+    body = email |> prepare_payload() |> Swoosh.json_library().encode!()
+    url = [base_url(config), api_endpoint(config, email)]
+
+    url |> Swoosh.ApiClient.post(headers, body, email) |> handle_response()
+  end
+
+  def deliver_many(emails, config \\ [])
+
+  def deliver_many([], _config) do
+    {:ok, []}
+  end
+
+  def deliver_many(emails, config) when is_list(emails) do
+    case Enum.reduce_while(emails, [], &deliver_and_accumulate(&1, &2, config)) do
+      {:error, reason} -> {:error, reason}
+      results -> {:ok, Enum.reverse(results)}
+    end
+  end
+
+  defp deliver_and_accumulate(email, results, config) do
+    case deliver(email, config) do
+      {:ok, result} -> {:cont, [result | results]}
+      {:error, reason} -> {:halt, {:error, reason}}
+    end
+  end
+
+  defp base_url(config), do: config[:base_url] || @base_url
+
+  defp api_endpoint(config, email) do
+    suffix = if conversation?(email), do: "/conversation", else: ""
+    ["/v2/accounts/", to_string(config[:account_id]), "/messages", suffix]
+  end
+
+  defp conversation?(%{cc: [], bcc: []}), do: false
+  defp conversation?(_email), do: true
+
+  defp prepare_headers(config, email) do
+    base_headers = [
+      {"Accept", "application/json"},
+      {"Content-Type", "application/json"},
+      {"User-Agent", "swoosh/#{Swoosh.version()}"},
+      {"Authorization", "Bearer #{config[:api_key]}"}
+    ]
+
+    case email do
+      %{provider_options: %{idempotency_key: key}} -> [{"Idempotency-Key", key} | base_headers]
+      _ -> base_headers
+    end
+  end
+
+  defp prepare_payload(email) do
+    %{}
+    |> prepare_from(email)
+    |> prepare_recipients(email)
+    |> prepare_cc(email)
+    |> prepare_bcc(email)
+    |> prepare_reply_to(email)
+    |> prepare_subject(email)
+    |> prepare_text_content(email)
+    |> prepare_html_content(email)
+    |> prepare_email_headers(email)
+    |> prepare_attachments(email)
+    |> prepare_tags(email)
+    |> prepare_substitutions(email)
+    |> prepare_tracking(email)
+    |> prepare_retention(email)
+    |> prepare_schedule(email)
+    |> prepare_sandbox(email)
+    |> prepare_sandbox_result(email)
+  end
+
+  defp prepare_from(payload, %{from: from}), do: Map.put(payload, "from", format_address(from))
+
+  defp prepare_recipients(payload, %{to: to} = email) do
+    key = if conversation?(email), do: "to", else: "recipients"
+    Map.put(payload, key, Enum.map(to, &format_address/1))
+  end
+
+  defp prepare_cc(payload, %{cc: []}), do: payload
+  defp prepare_cc(payload, %{cc: cc}), do: Map.put(payload, "cc", Enum.map(cc, &format_address/1))
+
+  defp prepare_bcc(payload, %{bcc: []}), do: payload
+
+  defp prepare_bcc(payload, %{bcc: bcc}) do
+    Map.put(payload, "bcc", Enum.map(bcc, &format_address/1))
+  end
+
+  defp prepare_reply_to(payload, %{reply_to: nil}), do: payload
+
+  defp prepare_reply_to(payload, %{reply_to: reply_to}) do
+    Map.put(payload, "reply_to", format_address(reply_to))
+  end
+
+  defp prepare_subject(payload, %{subject: ""}), do: payload
+  defp prepare_subject(payload, %{subject: subject}), do: Map.put(payload, "subject", subject)
+
+  defp prepare_text_content(payload, %{text_body: nil}), do: payload
+
+  defp prepare_text_content(payload, %{text_body: text_body}) do
+    Map.put(payload, "text_content", text_body)
+  end
+
+  defp prepare_html_content(payload, %{html_body: nil}), do: payload
+
+  defp prepare_html_content(payload, %{html_body: html_body}) do
+    Map.put(payload, "html_content", html_body)
+  end
+
+  defp prepare_email_headers(payload, %{headers: headers}) when map_size(headers) == 0,
+    do: payload
+
+  defp prepare_email_headers(payload, %{headers: headers}),
+    do: Map.put(payload, "headers", headers)
+
+  defp prepare_attachments(payload, %{attachments: []}), do: payload
+
+  defp prepare_attachments(payload, %{attachments: attachments}) do
+    Map.put(payload, "attachments", Enum.map(attachments, &prepare_attachment/1))
+  end
+
+  defp prepare_attachment(attachment) do
+    prepared = %{
+      "file_name" => attachment.filename,
+      "content_type" => attachment.content_type,
+      "data" => Swoosh.Attachment.get_content(attachment, :base64),
+      "base64" => true
+    }
+
+    case attachment.type do
+      :attachment ->
+        prepared
+
+      :inline ->
+        Map.merge(prepared, %{"content_id" => attachment.cid, "content_disposition" => "inline"})
+    end
+  end
+
+  defp prepare_tags(payload, %{provider_options: %{tags: tags}}),
+    do: Map.put(payload, "tags", tags)
+
+  defp prepare_tags(payload, _email), do: payload
+
+  defp prepare_substitutions(payload, %{provider_options: %{substitutions: substitutions}}) do
+    Map.put(payload, "substitutions", substitutions)
+  end
+
+  defp prepare_substitutions(payload, _email), do: payload
+
+  defp prepare_tracking(payload, %{provider_options: %{tracking: tracking}}) do
+    Map.put(payload, "tracking", tracking)
+  end
+
+  defp prepare_tracking(payload, _email), do: payload
+
+  defp prepare_retention(payload, %{provider_options: %{retention: retention}}) do
+    Map.put(payload, "retention", retention)
+  end
+
+  defp prepare_retention(payload, _email), do: payload
+
+  defp prepare_schedule(payload, %{provider_options: %{schedule: schedule}}) do
+    Map.put(payload, "schedule", schedule)
+  end
+
+  defp prepare_schedule(payload, _email), do: payload
+
+  defp prepare_sandbox(payload, %{provider_options: %{sandbox: sandbox}}) do
+    Map.put(payload, "sandbox", sandbox)
+  end
+
+  defp prepare_sandbox(payload, _email), do: payload
+
+  defp prepare_sandbox_result(payload, %{provider_options: %{sandbox_result: result}}) do
+    Map.put(payload, "sandbox_result", result)
+  end
+
+  defp prepare_sandbox_result(payload, _email), do: payload
+
+  defp format_address({name, email}) when name in [nil, ""], do: %{"email" => email}
+  defp format_address({name, email}), do: %{"email" => email, "name" => name}
+  defp format_address(email) when is_binary(email), do: %{"email" => email}
+
+  defp handle_response({:ok, 202, _headers, body}) do
+    case Swoosh.json_library().decode(body) do
+      {:ok, %{"data" => [_ | _] = messages}} -> {:ok, format_delivery(messages)}
+      {:ok, response} -> {:ok, response}
+      {:error, _} -> {:error, {202, body}}
+    end
+  end
+
+  defp handle_response({:ok, code, _headers, body}) when code >= 400 do
+    case Swoosh.json_library().decode(body) do
+      {:ok, error} -> {:error, {code, error}}
+      {:error, _} -> {:error, {code, body}}
+    end
+  end
+
+  # Any other 2xx/3xx the API might return. The documented send response is
+  # 202, but this keeps an unexpected success code from crashing rather than
+  # being reported.
+  defp handle_response({:ok, _code, _headers, body}) do
+    case Swoosh.json_library().decode(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, _} -> {:ok, body}
+    end
+  end
+
+  defp handle_response({:error, reason}), do: {:error, reason}
+
+  # AhaSend answers with one entry per recipient. The first entry is surfaced
+  # as `id`/`status` to match the shape used by the other adapters, and the
+  # full list is kept under `messages` so nothing is lost.
+  defp format_delivery([first | _] = messages) do
+    %{
+      id: first["id"],
+      status: first["status"],
+      messages: Enum.map(messages, &format_message/1)
+    }
+  end
+
+  defp format_message(message) do
+    %{
+      id: message["id"],
+      status: message["status"],
+      recipient: get_in(message, ["recipient", "email"]),
+      error: message["error"]
+    }
+  end
+end

--- a/test/swoosh/adapters/aha_send_test.exs
+++ b/test/swoosh/adapters/aha_send_test.exs
@@ -1,0 +1,594 @@
+defmodule Swoosh.Adapters.AhaSendTest do
+  use Swoosh.AdapterCase, async: true
+
+  import Swoosh.Email
+  import Plug.Conn, only: [get_req_header: 2]
+  alias Swoosh.Adapters.AhaSend
+
+  @account_id "8b0c4f5e-1234-4a2b-9c3d-000000000000"
+  @example_message_id "<0192a1b2-c3d4-7e8f-a9b0-c1d2e3f4a5b6@example.com>"
+  @messages_path "/v2/accounts/#{@account_id}/messages"
+  @conversation_path "/v2/accounts/#{@account_id}/messages/conversation"
+
+  setup do
+    bypass = Bypass.open()
+
+    config = [
+      api_key: "aha-sk-test-key",
+      account_id: @account_id,
+      base_url: "http://localhost:#{bypass.port}"
+    ]
+
+    valid_email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+
+    {:ok, bypass: bypass, config: config, valid_email: valid_email}
+  end
+
+  defp make_response(conn, status \\ "queued") do
+    Plug.Conn.resp(conn, 202, """
+      {
+        "object": "list",
+        "data": [
+          {
+            "object": "message",
+            "id": "#{@example_message_id}",
+            "recipient": {"email": "steve.rogers@example.com"},
+            "status": "#{status}",
+            "error": null
+          }
+        ]
+      }
+    """)
+  end
+
+  defp recipient_response(conn, recipient) do
+    Plug.Conn.resp(conn, 202, """
+      {
+        "object": "list",
+        "data": [
+          {
+            "object": "message",
+            "id": "<msg-#{recipient}@example.com>",
+            "recipient": {"email": "#{recipient}"},
+            "status": "queued",
+            "error": null
+          }
+        ]
+      }
+    """)
+  end
+
+  defp success_result(status \\ "queued") do
+    {:ok,
+     %{
+       id: @example_message_id,
+       status: status,
+       messages: [
+         %{
+           id: @example_message_id,
+           status: status,
+           recipient: "steve.rogers@example.com",
+           error: nil
+         }
+       ]
+     }}
+  end
+
+  test "successful delivery returns :ok", %{
+    bypass: bypass,
+    config: config,
+    valid_email: email
+  } do
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => %{"email" => "tony.stark@example.com"},
+               "recipients" => [%{"email" => "steve.rogers@example.com"}],
+               "subject" => "Hello, Avengers!",
+               "html_content" => "<h1>Hello</h1>",
+               "text_content" => "Hello"
+             }
+
+      assert get_req_header(conn, "authorization") == ["Bearer aha-sk-test-key"]
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "delivery with a scheduled status", %{
+    bypass: bypass,
+    config: config,
+    valid_email: email
+  } do
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      make_response(conn, "scheduled")
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result("scheduled")
+  end
+
+  test "text-only delivery returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => %{"email" => "tony.stark@example.com"},
+               "recipients" => [%{"email" => "steve.rogers@example.com"}],
+               "subject" => "Hello, Avengers!",
+               "text_content" => "Hello"
+             }
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "html-only delivery returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => %{"email" => "tony.stark@example.com"},
+               "recipients" => [%{"email" => "steve.rogers@example.com"}],
+               "subject" => "Hello, Avengers!",
+               "html_content" => "<h1>Hello</h1>"
+             }
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with recipient names returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> reply_to({"Bruce Banner", "hulk.smash@example.com"})
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => %{"email" => "tony.stark@example.com", "name" => "T Stark"},
+               "recipients" => [
+                 %{"email" => "steve.rogers@example.com", "name" => "Steve Rogers"}
+               ],
+               "reply_to" => %{"email" => "hulk.smash@example.com", "name" => "Bruce Banner"},
+               "subject" => "Hello, Avengers!",
+               "text_content" => "Hello"
+             }
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with cc and bcc uses the conversation endpoint", %{
+    bypass: bypass,
+    config: config
+  } do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> cc("hulk.smash@example.com")
+      |> bcc({"Henry McCoy", "beast.avengers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @conversation_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => %{"email" => "tony.stark@example.com", "name" => "T Stark"},
+               "to" => [%{"email" => "steve.rogers@example.com", "name" => "Steve Rogers"}],
+               "cc" => [%{"email" => "hulk.smash@example.com"}],
+               "bcc" => [%{"email" => "beast.avengers@example.com", "name" => "Henry McCoy"}],
+               "subject" => "Hello, Avengers!",
+               "text_content" => "Hello"
+             }
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with multiple recipients returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> to({"Bruce Banner", "hulk.smash@example.com"})
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "recipients" => [
+                 %{"email" => "hulk.smash@example.com", "name" => "Bruce Banner"},
+                 %{"email" => "steve.rogers@example.com"}
+               ]
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with custom headers", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> header("X-Custom-Header", "custom-value")
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{"headers" => %{"X-Custom-Header" => "custom-value"}} = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with an attachment", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> attachment(
+        Swoosh.Attachment.new({:data, "Test content"},
+          filename: "test.txt",
+          content_type: "text/plain"
+        )
+      )
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "attachments" => [
+                 %{
+                   "file_name" => "test.txt",
+                   "content_type" => "text/plain",
+                   "data" => "VGVzdCBjb250ZW50",
+                   "base64" => true
+                 }
+               ]
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with an inline attachment", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> attachment(
+        Swoosh.Attachment.new({:data, "Test content"},
+          filename: "logo.png",
+          content_type: "image/png",
+          type: :inline,
+          cid: "logo"
+        )
+      )
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "attachments" => [
+                 %{
+                   "file_name" => "logo.png",
+                   "content_id" => "logo",
+                   "content_disposition" => "inline",
+                   "base64" => true
+                 }
+               ]
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with provider options", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> put_provider_option(:tags, ["welcome", "onboarding"])
+      |> put_provider_option(:tracking, %{open: true, click: false})
+      |> put_provider_option(:sandbox, true)
+      |> put_provider_option(:sandbox_result, "deliver")
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "tags" => ["welcome", "onboarding"],
+               "tracking" => %{"open" => true, "click" => false},
+               "sandbox" => true,
+               "sandbox_result" => "deliver"
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with substitutions and retention", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, {{ first_name }}!")
+      |> text_body("Hello")
+      |> put_provider_option(:substitutions, %{first_name: "Steve"})
+      |> put_provider_option(:retention, %{metadata: 30, data: 7})
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "substitutions" => %{"first_name" => "Steve"},
+               "retention" => %{"metadata" => 30, "data" => 7}
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with a schedule", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> put_provider_option(:schedule, %{first_attempt: "2030-01-01T00:00:00Z"})
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{"schedule" => %{"first_attempt" => "2030-01-01T00:00:00Z"}} = conn.body_params
+
+      make_response(conn, "scheduled")
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result("scheduled")
+  end
+
+  test "deliver/1 with an idempotency key", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> put_provider_option(:idempotency_key, "unique-key-123")
+
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+
+      assert get_req_header(conn, "idempotency-key") == ["unique-key-123"]
+
+      make_response(conn)
+    end)
+
+    assert AhaSend.deliver(email, config) == success_result()
+  end
+
+  test "deliver_many/2 with an empty list returns :ok", %{config: config} do
+    assert AhaSend.deliver_many([], config) == {:ok, []}
+  end
+
+  test "deliver_many/2 sends each email in its own request", %{bypass: bypass, config: config} do
+    emails =
+      for recipient <- ["steve.rogers@example.com", "hulk.smash@example.com"] do
+        new()
+        |> from("tony.stark@example.com")
+        |> to(recipient)
+        |> subject("Hello, Avengers!")
+        |> text_body("Hello")
+      end
+
+    test_pid = self()
+
+    Bypass.expect(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+      [%{"email" => recipient}] = conn.body_params["recipients"]
+      send(test_pid, {:recipient, recipient})
+
+      recipient_response(conn, recipient)
+    end)
+
+    {:ok, results} = AhaSend.deliver_many(emails, config)
+
+    assert length(results) == 2
+    assert_received {:recipient, "steve.rogers@example.com"}
+    assert_received {:recipient, "hulk.smash@example.com"}
+  end
+
+  test "deliver_many/2 returns results in the order the emails were given", %{
+    bypass: bypass,
+    config: config
+  } do
+    emails =
+      for recipient <- ["first@example.com", "second@example.com", "third@example.com"] do
+        new()
+        |> from("tony.stark@example.com")
+        |> to(recipient)
+        |> subject("Hello, Avengers!")
+        |> text_body("Hello")
+      end
+
+    Bypass.expect(bypass, "POST", @messages_path, fn conn ->
+      conn = parse(conn)
+      [%{"email" => recipient}] = conn.body_params["recipients"]
+
+      recipient_response(conn, recipient)
+    end)
+
+    {:ok, results} = AhaSend.deliver_many(emails, config)
+
+    assert Enum.map(results, &(&1.messages |> hd() |> Map.get(:recipient))) ==
+             ["first@example.com", "second@example.com", "third@example.com"]
+  end
+
+  test "deliver_many/2 delivers cc/bcc emails via the conversation endpoint", %{
+    bypass: bypass,
+    config: config
+  } do
+    emails = [
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> cc("hulk.smash@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello"),
+      new()
+      |> from("tony.stark@example.com")
+      |> to("thor.odinson@example.com")
+      |> cc("hulk.smash@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+    ]
+
+    test_pid = self()
+
+    Bypass.expect(bypass, "POST", @conversation_path, fn conn ->
+      conn = parse(conn)
+      send(test_pid, {:conversation, conn.body_params["to"]})
+
+      make_response(conn)
+    end)
+
+    {:ok, results} = AhaSend.deliver_many(emails, config)
+
+    assert length(results) == 2
+    assert_received {:conversation, _}
+    assert_received {:conversation, _}
+  end
+
+  test "deliver_many/2 stops at the first failure", %{bypass: bypass, config: config} do
+    emails =
+      for subject <- ["First", "Second"] do
+        new()
+        |> from("tony.stark@example.com")
+        |> to("steve.rogers@example.com")
+        |> subject(subject)
+        |> text_body("Hello")
+      end
+
+    Bypass.expect(bypass, "POST", @messages_path, fn conn ->
+      Plug.Conn.resp(conn, 422, ~s/{"message": "Validation failed"}/)
+    end)
+
+    assert AhaSend.deliver_many(emails, config) ==
+             {:error, {422, %{"message" => "Validation failed"}}}
+  end
+
+  test "deliver/1 with 400 response", %{bypass: bypass, config: config, valid_email: email} do
+    error = ~s/{"message": "Invalid request parameters"}/
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 400, error))
+
+    assert AhaSend.deliver(email, config) ==
+             {:error, {400, %{"message" => "Invalid request parameters"}}}
+  end
+
+  test "deliver/1 with 401 response", %{bypass: bypass, config: config, valid_email: email} do
+    error = ~s/{"message": "Unauthorized"}/
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 401, error))
+
+    assert AhaSend.deliver(email, config) == {:error, {401, %{"message" => "Unauthorized"}}}
+  end
+
+  test "deliver/1 with 422 response", %{bypass: bypass, config: config, valid_email: email} do
+    error = ~s/{"message": "Validation failed", "errors": {"from": ["is required"]}}/
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 422, error))
+
+    response =
+      {:error,
+       {422, %{"message" => "Validation failed", "errors" => %{"from" => ["is required"]}}}}
+
+    assert AhaSend.deliver(email, config) == response
+  end
+
+  test "deliver/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect_once(bypass, "POST", @messages_path, fn conn ->
+      assert @messages_path == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 500, "")
+    end)
+
+    assert AhaSend.deliver(email, config) == {:error, {500, ""}}
+  end
+
+  test "validate_config/1 with valid config", %{config: config} do
+    assert AhaSend.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise(
+      ArgumentError,
+      """
+      expected [:account_id, :api_key] to be set, got: []
+      """,
+      fn ->
+        AhaSend.validate_config([])
+      end
+    )
+  end
+end


### PR DESCRIPTION
Adds an adapter for [AhaSend](https://ahasend.com), sending through their HTTP API (`POST /v2/accounts/{account_id}/messages`).

### Features

- `deliver/2` and `deliver_many/2`
- Attachments, including inline (`content_id` + `inline` disposition)
- Provider options: `tags`, `substitutions`, `tracking`, `retention`, `schedule`, `sandbox`, `sandbox_result`, `idempotency_key`
- Typed error tuples for non-2xx responses

### `deliver_many/2`

Sends each email as its own request so one invalid recipient can't affect the others — AhaSend validates the whole recipients array up front and rejects the entire request on a single bad address. Results are returned in input order; delivery halts on the first failure.

### Notes

- Config requires `:api_key` and `:account_id` (the account is in the URL path).
- Emails with `cc`/`bcc` use the conversation endpoint; others use the standard send endpoint.
- Verified against the live AhaSend sandbox: `deliver`, attachments, cc/conversation, `deliver_many`, and the error paths.

25 tests, `mix format` clean.
