### PR TITLE
Return empty text for a missing XML node instead of crashing (#1185)

### DIFF
--- a/lib/swoosh/adapters/xml/helpers.ex
+++ b/lib/swoosh/adapters/xml/helpers.ex
@@ -32,6 +32,10 @@ defmodule Swoosh.Adapters.XML.Helpers do
   end
 
   @doc false
+  # A missing node (no xpath match, so `first/2` returned nil) has no text.
+  # Return an empty string instead of crashing in :xmerl_xpath.node_type/1.
+  def text(nil), do: ""
+
   def text(node) do
     "./text()"
     |> to_charlist

--- a/test/swoosh/adapters/xml/helpers_test.exs
+++ b/test/swoosh/adapters/xml/helpers_test.exs
@@ -54,4 +54,13 @@ defmodule Swoosh.Adapters.XML.HelpersTest do
 
     assert text == ""
   end
+
+  test "first_text returns blank when the path matches no node", %{xml_string: xml_string} do
+    text =
+      xml_string
+      |> XMLHelper.parse()
+      |> XMLHelper.first_text("//missing")
+
+    assert text == ""
+  end
 end


### PR DESCRIPTION
Fixes #1185.

### Problem

`Swoosh.Adapters.XML.Helpers.first/2` returns `nil` when its xpath matches no node, and `text/1` then passed that `nil` straight to `:xmerl_xpath.string/2`, raising:

```
** (FunctionClauseError) no function clause matching in :xmerl_xpath.node_type/1
    (xmerl) xmerl_xpath.erl: :xmerl_xpath.node_type/1
    (swoosh) lib/swoosh/adapters/xml/helpers.ex:38: Swoosh.Adapters.XML.Helpers.text/1
```

This crashes `AmazonSES.parse_error_response/1`, which runs on any HTTP status `> 399` and calls `first_text(node, "//Error/Code")` / `first_text(node, "//Message")`. Whenever the SES (or an intermediary) error body is valid XML that lacks those elements, delivering an email raises `FunctionClauseError` instead of returning a clean `{:error, ...}`.

### Fix

Add a `text(nil)` clause returning `""` — a missing node has no text. `parse_error_response/1` then returns `%{code: ..., message: ""}` instead of crashing.

### Test

Added a regression test in `test/swoosh/adapters/xml/helpers_test.exs`: `first_text` on a path that matches no node returns `""`. Red-green verified with `mix test`: before the fix the test raises the exact `FunctionClauseError` in `:xmerl_xpath.node_type/1` from the issue; after, it returns `""`. `mix format --check-formatted` is clean.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I verified the crash, ran the tests (red-green), and take responsibility for the contribution.
