### PR TITLE
Add TurboSMTP adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### ✨ Features
+
+- Add TurboSMTP adapter @NewtTheWolf
+
 ## 1.27.1
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ✨ Features
 
-- Add TurboSMTP adapter @NewtTheWolf
+- Add TurboSMTP adapter @NewtTheWolf (#1190)
 
 ## 1.27.1
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ included:
 | Resend                       | [Swoosh.Adapters.Resend](https://hexdocs.pm/swoosh/Swoosh.Adapters.Resend.html#content)                                         |                  |
 | Azure Communication Services | [Swoosh.Adapters.AzureCommunicationServices](https://hexdocs.pm/swoosh/Swoosh.Adapters.AzureCommunicationServices.html#content) |                  |
 | AhaSend                      | [Swoosh.Adapters.AhaSend](https://hexdocs.pm/swoosh/Swoosh.Adapters.AhaSend.html#content)                                       | EU               |
+| TurboSMTP                    | [Swoosh.Adapters.TurboSMTP](https://hexdocs.pm/swoosh/Swoosh.Adapters.TurboSMTP.html#content)                                   | EU               |
 | ------                       | **Below are not fully featured services**                                                                                       | ------           |
 | Loops                        | [Swoosh.Adapters.Loops](https://hexdocs.pm/swoosh/Swoosh.Adapters.Loops.html#content)                                           |                  |
 | PostUp                       | [Swoosh.Adapters.PostUp](https://hexdocs.pm/swoosh/Swoosh.Adapters.PostUp.html#content)                                         |                  |

--- a/lib/swoosh/adapters/turbo_smtp.ex
+++ b/lib/swoosh/adapters/turbo_smtp.ex
@@ -95,10 +95,10 @@ defmodule Swoosh.Adapters.TurboSMTP do
       url = [base_url(config), @api_endpoint]
 
       case Swoosh.ApiClient.post(url, headers, body, email) do
-        {:ok, 200, _headers, body} ->
-          handle_success(body)
+        {:ok, code, _headers, body} when code in 200..299 ->
+          handle_success(code, body)
 
-        {:ok, code, _headers, body} when code >= 400 ->
+        {:ok, code, _headers, body} ->
           {:error, {code, decode_body(body)}}
 
         {:error, reason} ->
@@ -107,11 +107,11 @@ defmodule Swoosh.Adapters.TurboSMTP do
     end
   end
 
-  defp handle_success(body) do
+  defp handle_success(code, body) do
     case Swoosh.json_library().decode(body) do
       {:ok, %{"mid" => mid}} -> {:ok, %{id: to_string(mid)}}
       {:ok, response} -> {:ok, response}
-      {:error, _} -> {:error, {200, body}}
+      {:error, _} -> {:error, {code, body}}
     end
   end
 

--- a/lib/swoosh/adapters/turbo_smtp.ex
+++ b/lib/swoosh/adapters/turbo_smtp.ex
@@ -108,7 +108,7 @@ defmodule Swoosh.Adapters.TurboSMTP do
   end
 
   defp handle_success(body) do
-    case Swoosh.json_library().decode(body) do
+    case decode_json(body) do
       {:ok, %{"mid" => mid}} -> {:ok, %{id: to_string(mid)}}
       {:ok, response} -> {:ok, response}
       {:error, _} -> {:error, {200, body}}
@@ -116,11 +116,13 @@ defmodule Swoosh.Adapters.TurboSMTP do
   end
 
   defp decode_body(body) do
-    case Swoosh.json_library().decode(body) do
+    case decode_json(body) do
       {:ok, decoded} -> decoded
       {:error, _} -> body
     end
   end
+
+  defp decode_json(body), do: Swoosh.json_library().decode(body)
 
   defp prepare_headers(config) do
     [
@@ -141,6 +143,8 @@ defmodule Swoosh.Adapters.TurboSMTP do
         |> prepare_content(email)
         |> prepare_custom_headers(email)
         |> prepare_attachments(email)
+        # qualify_inline_cids reads payload["attachments"], so it must run after
+        # prepare_attachments — otherwise cids are silently left unqualified.
         |> qualify_inline_cids(email)
         |> prepare_provider_options(email)
 
@@ -196,6 +200,10 @@ defmodule Swoosh.Adapters.TurboSMTP do
 
   defp custom_headers(%{headers: headers, reply_to: nil}), do: headers
 
+  defp custom_headers(%{headers: headers, reply_to: reply_to}) when is_list(reply_to) do
+    Map.put(headers, "Reply-To", Enum.map_join(reply_to, ",", &format_email/1))
+  end
+
   defp custom_headers(%{headers: headers, reply_to: reply_to}) do
     Map.put(headers, "Reply-To", format_email(reply_to))
   end
@@ -237,10 +245,15 @@ defmodule Swoosh.Adapters.TurboSMTP do
     attachments
     |> Enum.map(& &1["content_id"])
     |> Enum.reject(&(is_nil(&1) or String.contains?(&1, "@")))
-    |> Enum.reduce(html, fn cid, html ->
-      pattern = Regex.compile!("cid:#{Regex.escape(cid)}(?![\\w.@-])")
-      Regex.replace(pattern, html, "cid:#{cid}@#{domain}")
-    end)
+    |> case do
+      [] ->
+        html
+
+      cids ->
+        alternation = Enum.map_join(cids, "|", &Regex.escape/1)
+        pattern = Regex.compile!("cid:(#{alternation})(?![\\w.@-])")
+        Regex.replace(pattern, html, "cid:\\1@#{domain}")
+    end
   end
 
   defp sender_domain(from) do

--- a/lib/swoosh/adapters/turbo_smtp.ex
+++ b/lib/swoosh/adapters/turbo_smtp.ex
@@ -1,0 +1,274 @@
+defmodule Swoosh.Adapters.TurboSMTP do
+  @moduledoc ~S"""
+  An adapter that sends email using the TurboSMTP API.
+
+  For reference: [TurboSMTP API docs](https://serversmtp.com/turbo-api/)
+
+  **This adapter requires an API Client.** Swoosh comes with Hackney, Finch and Req out of the box.
+  See the [installation section](https://hexdocs.pm/swoosh/Swoosh.html#module-installation)
+  for details.
+
+  ## Example
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.TurboSMTP,
+        consumer_key: "my-consumer-key",
+        consumer_secret: "my-consumer-secret"
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample
+      end
+
+  ## Sending from the EU region
+
+  TurboSMTP serves the EU from a separate host. Point `base_url` at it:
+
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.TurboSMTP,
+        consumer_key: "my-consumer-key",
+        consumer_secret: "my-consumer-secret",
+        base_url: "https://api.eu.turbo-smtp.com/api/v2"
+
+  ## Inline images
+
+  Use Swoosh's usual inline attachments. The adapter takes care of a TurboSMTP
+  quirk on the way out: the API builds each inline part's Content-ID as
+  `<content_id@sender-domain>`, so a bare `cid:` reference never matches and the
+  image arrives as an ordinary attachment. References are qualified with the
+  sender's domain automatically, so this renders inline:
+
+      import Swoosh.Email
+
+      new()
+      |> from("nora@example.com")
+      |> to("shushu@example.com")
+      |> subject("Hello, Wally!")
+      |> html_body(~s|<img src="cid:logo.png">|)
+      |> attachment(Swoosh.Attachment.new("/data/logo.png", type: :inline))
+
+  A `cid` that already carries a domain is left alone.
+
+  ## Using with provider options
+
+      import Swoosh.Email
+
+      new()
+      |> from("nora@example.com")
+      |> to("shushu@example.com")
+      |> subject("Hello, Wally!")
+      |> text_body("Hello")
+      |> put_provider_option(:reference_id, "3a1f9d7e-0c4b-4f3a-9c1e-2b6d5a7f8e90")
+      |> put_provider_option(:campaign_id, "welcome-2024")
+
+  ## Provider Options
+
+    * `reference_id` (string) - `reference_id`, a UUID of your own that TurboSMTP
+      echoes back on delivery events
+    * `campaign_id` (string) - `X-campaign-ID`, groups sends in the dashboard
+    * `mime_raw` (string) - `mime_raw`, a complete MIME message to send verbatim
+
+  ## Display names in recipients
+
+  TurboSMTP splits `to`, `cc` and `bcc` on commas before it parses RFC 5322
+  quoted strings, so a comma inside a recipient's display name is torn apart and
+  the send is rejected. The adapter returns `{:error, {:invalid_recipient, name}}`
+  for that case rather than letting the API answer with a parse error naming a
+  fragment of the name. `from` and `reply_to` are not comma-split and accept it.
+  """
+
+  use Swoosh.Adapter, required_config: [:consumer_key, :consumer_secret]
+
+  alias Swoosh.Attachment
+  alias Swoosh.Email
+
+  @base_url "https://api.turbo-smtp.com/api/v2"
+  @api_endpoint "/mail/send"
+
+  defp base_url(config), do: config[:base_url] || @base_url
+
+  def deliver(%Email{} = email, config \\ []) do
+    with {:ok, payload} <- prepare_payload(email) do
+      headers = prepare_headers(config)
+      body = Swoosh.json_library().encode!(payload)
+      url = [base_url(config), @api_endpoint]
+
+      case Swoosh.ApiClient.post(url, headers, body, email) do
+        {:ok, 200, _headers, body} ->
+          handle_success(body)
+
+        {:ok, code, _headers, body} when code >= 400 ->
+          {:error, {code, decode_body(body)}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp handle_success(body) do
+    case Swoosh.json_library().decode(body) do
+      {:ok, %{"mid" => mid}} -> {:ok, %{id: to_string(mid)}}
+      {:ok, response} -> {:ok, response}
+      {:error, _} -> {:error, {200, body}}
+    end
+  end
+
+  defp decode_body(body) do
+    case Swoosh.json_library().decode(body) do
+      {:ok, decoded} -> decoded
+      {:error, _} -> body
+    end
+  end
+
+  defp prepare_headers(config) do
+    [
+      {"Accept", "application/json"},
+      {"Content-Type", "application/json"},
+      {"User-Agent", "swoosh/#{Swoosh.version()}"},
+      {"consumerKey", config[:consumer_key]},
+      {"consumerSecret", config[:consumer_secret]}
+    ]
+  end
+
+  defp prepare_payload(email) do
+    with {:ok, payload} <- prepare_recipients(%{}, email) do
+      payload =
+        payload
+        |> prepare_from(email)
+        |> prepare_subject(email)
+        |> prepare_content(email)
+        |> prepare_custom_headers(email)
+        |> prepare_attachments(email)
+        |> qualify_inline_cids(email)
+        |> prepare_provider_options(email)
+
+      {:ok, payload}
+    end
+  end
+
+  defp prepare_from(payload, %{from: from}), do: Map.put(payload, "from", format_email(from))
+
+  defp prepare_recipients(payload, email) do
+    fields = [{"to", email.to}, {"cc", email.cc}, {"bcc", email.bcc}]
+
+    Enum.reduce_while(fields, {:ok, payload}, fn
+      {_field, []}, acc ->
+        {:cont, acc}
+
+      {field, recipients}, {:ok, payload} ->
+        case join_recipients(recipients) do
+          {:ok, joined} -> {:cont, {:ok, Map.put(payload, field, joined)}}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+    end)
+  end
+
+  defp join_recipients(recipients) do
+    case Enum.find(recipients, &comma_in_display_name?/1) do
+      nil -> {:ok, Enum.map_join(recipients, ",", &format_email/1)}
+      {name, _address} -> {:error, {:invalid_recipient, name}}
+    end
+  end
+
+  defp comma_in_display_name?({name, _address}) when is_binary(name),
+    do: String.contains?(name, ",")
+
+  defp comma_in_display_name?(_recipient), do: false
+
+  defp prepare_subject(payload, %{subject: nil}), do: payload
+  defp prepare_subject(payload, %{subject: ""}), do: payload
+  defp prepare_subject(payload, %{subject: subject}), do: Map.put(payload, "subject", subject)
+
+  defp prepare_content(payload, email) do
+    payload
+    |> put_unless_nil("content", email.text_body)
+    |> put_unless_nil("html_content", email.html_body)
+  end
+
+  defp prepare_custom_headers(payload, email) do
+    case custom_headers(email) do
+      headers when map_size(headers) == 0 -> payload
+      headers -> Map.put(payload, "custom_headers", headers)
+    end
+  end
+
+  defp custom_headers(%{headers: headers, reply_to: nil}), do: headers
+
+  defp custom_headers(%{headers: headers, reply_to: reply_to}) do
+    Map.put(headers, "Reply-To", format_email(reply_to))
+  end
+
+  defp prepare_attachments(payload, %{attachments: []}), do: payload
+
+  defp prepare_attachments(payload, %{attachments: attachments}) do
+    Map.put(payload, "attachments", Enum.map(attachments, &prepare_attachment/1))
+  end
+
+  defp prepare_attachment(%Attachment{} = attachment) do
+    prepared = %{
+      "name" => attachment.filename,
+      "type" => attachment.content_type,
+      "content" => Attachment.get_content(attachment, :base64)
+    }
+
+    case attachment.type do
+      :inline -> Map.put(prepared, "content_id", attachment.cid || attachment.filename)
+      _ -> prepared
+    end
+  end
+
+  # Without this the send still succeeds and the image just arrives as an ordinary
+  # attachment, so the bug is invisible until someone opens the mail.
+  defp qualify_inline_cids(%{"html_content" => html} = payload, %{from: from})
+       when is_binary(html) do
+    case sender_domain(from) do
+      nil -> payload
+      domain -> Map.put(payload, "html_content", qualify(html, payload["attachments"], domain))
+    end
+  end
+
+  defp qualify_inline_cids(payload, _email), do: payload
+
+  defp qualify(html, nil, _domain), do: html
+
+  defp qualify(html, attachments, domain) do
+    attachments
+    |> Enum.map(& &1["content_id"])
+    |> Enum.reject(&(is_nil(&1) or String.contains?(&1, "@")))
+    |> Enum.reduce(html, fn cid, html ->
+      pattern = Regex.compile!("cid:#{Regex.escape(cid)}(?![\\w.@-])")
+      Regex.replace(pattern, html, "cid:#{cid}@#{domain}")
+    end)
+  end
+
+  defp sender_domain(from) do
+    {_name, address} = normalize_email(from)
+
+    case String.split(address, "@") do
+      [_local, domain] when domain != "" -> domain
+      _ -> nil
+    end
+  end
+
+  defp prepare_provider_options(payload, %{provider_options: options}) do
+    payload
+    |> put_unless_nil("reference_id", options[:reference_id])
+    |> put_unless_nil("X-campaign-ID", options[:campaign_id])
+    |> put_unless_nil("mime_raw", options[:mime_raw])
+  end
+
+  defp put_unless_nil(payload, _key, nil), do: payload
+  defp put_unless_nil(payload, key, value), do: Map.put(payload, key, value)
+
+  defp format_email(email) do
+    case normalize_email(email) do
+      {name, address} when name in [nil, ""] -> address
+      {name, address} -> "#{name} <#{address}>"
+    end
+  end
+
+  defp normalize_email({name, address}), do: {name, address}
+  defp normalize_email(address) when is_binary(address), do: {nil, address}
+end

--- a/lib/swoosh/adapters/turbo_smtp.ex
+++ b/lib/swoosh/adapters/turbo_smtp.ex
@@ -108,7 +108,7 @@ defmodule Swoosh.Adapters.TurboSMTP do
   end
 
   defp handle_success(body) do
-    case decode_json(body) do
+    case Swoosh.json_library().decode(body) do
       {:ok, %{"mid" => mid}} -> {:ok, %{id: to_string(mid)}}
       {:ok, response} -> {:ok, response}
       {:error, _} -> {:error, {200, body}}
@@ -116,13 +116,11 @@ defmodule Swoosh.Adapters.TurboSMTP do
   end
 
   defp decode_body(body) do
-    case decode_json(body) do
+    case Swoosh.json_library().decode(body) do
       {:ok, decoded} -> decoded
       {:error, _} -> body
     end
   end
-
-  defp decode_json(body), do: Swoosh.json_library().decode(body)
 
   defp prepare_headers(config) do
     [

--- a/test/swoosh/adapters/turbo_smtp_test.exs
+++ b/test/swoosh/adapters/turbo_smtp_test.exs
@@ -1,0 +1,295 @@
+defmodule Swoosh.Adapters.TurboSMTPTest do
+  use Swoosh.AdapterCase, async: true
+
+  import Swoosh.Email
+  import Plug.Conn, only: [get_req_header: 2]
+  alias Swoosh.Adapters.TurboSMTP
+  alias Swoosh.Attachment
+
+  # A real `mid` is a 64-bit snowflake.
+  @example_mid 1_785_432_109_876_543_210
+
+  setup do
+    bypass = Bypass.open()
+
+    config = [
+      consumer_key: "test-consumer-key",
+      consumer_secret: "test-consumer-secret",
+      base_url: "http://localhost:#{bypass.port}/api/v2"
+    ]
+
+    valid_email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    {:ok, bypass: bypass, config: config, valid_email: valid_email}
+  end
+
+  defp make_response(conn) do
+    Plug.Conn.resp(conn, 200, ~s|{"message": "OK", "mid": #{@example_mid}}|)
+  end
+
+  test "a sent email results in :ok", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => "tony.stark@example.com",
+               "to" => "steve.rogers@example.com",
+               "subject" => "Hello, Avengers!",
+               "content" => "Hello"
+             }
+
+      assert get_req_header(conn, "consumerkey") == ["test-consumer-key"]
+      assert get_req_header(conn, "consumersecret") == ["test-consumer-secret"]
+
+      make_response(conn)
+    end)
+
+    assert TurboSMTP.deliver(email, config) == {:ok, %{id: to_string(@example_mid)}}
+  end
+
+  test "the credentials never travel as an Authorization header", %{
+    bypass: bypass,
+    config: config,
+    valid_email: email
+  } do
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      assert get_req_header(conn, "authorization") == []
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
+  test "deliver/1 with all fields returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to([{"Steve Rogers", "steve.rogers@example.com"}, "bruce.banner@example.com"])
+      |> cc({"Bruce Banner", "hulk@example.com"})
+      |> bcc("nick.fury@example.com")
+      |> reply_to({"Pepper Potts", "pepper@example.com"})
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> html_body("<h1>Hello</h1>")
+      |> header("X-Custom-Header", "custom")
+
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => "T Stark <tony.stark@example.com>",
+               "to" => "Steve Rogers <steve.rogers@example.com>,bruce.banner@example.com",
+               "cc" => "Bruce Banner <hulk@example.com>",
+               "bcc" => "nick.fury@example.com",
+               "subject" => "Hello, Avengers!",
+               "content" => "Hello",
+               "html_content" => "<h1>Hello</h1>",
+               "custom_headers" => %{
+                 "X-Custom-Header" => "custom",
+                 "Reply-To" => "Pepper Potts <pepper@example.com>"
+               }
+             }
+
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
+  test "deliver/1 with provider options returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> put_provider_option(:reference_id, "3a1f9d7e-0c4b-4f3a-9c1e-2b6d5a7f8e90")
+      |> put_provider_option(:campaign_id, "welcome-2024")
+
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params["reference_id"] == "3a1f9d7e-0c4b-4f3a-9c1e-2b6d5a7f8e90"
+      assert conn.body_params["X-campaign-ID"] == "welcome-2024"
+
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
+  test "deliver/1 with an attachment returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> attachment(
+        Attachment.new({:data, "hello"}, filename: "hello.txt", content_type: "text/plain")
+      )
+
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params["attachments"] == [
+               %{
+                 "name" => "hello.txt",
+                 "type" => "text/plain",
+                 "content" => Base.encode64("hello")
+               }
+             ]
+
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
+  test "an inline attachment keeps a bare content_id and qualifies the HTML reference", %{
+    bypass: bypass,
+    config: config
+  } do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body(~s|<img src="cid:logo.png"> and <img src="cid:logo.png.bak">|)
+      |> attachment(
+        Attachment.new({:data, "img"},
+          filename: "logo.png",
+          content_type: "image/png",
+          type: :inline
+        )
+      )
+
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params["attachments"] == [
+               %{
+                 "name" => "logo.png",
+                 "type" => "image/png",
+                 "content" => Base.encode64("img"),
+                 "content_id" => "logo.png"
+               }
+             ]
+
+      # The unrelated `logo.png.bak` reference must not be caught by the rewrite.
+      assert conn.body_params["html_content"] ==
+               ~s|<img src="cid:logo.png@example.com"> and <img src="cid:logo.png.bak">|
+
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
+  test "an inline content_id that already carries a domain is left alone", %{
+    bypass: bypass,
+    config: config
+  } do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body(~s|<img src="cid:logo@cdn.example.net">|)
+      |> attachment(
+        Attachment.new({:data, "img"},
+          filename: "logo.png",
+          content_type: "image/png",
+          type: :inline,
+          cid: "logo@cdn.example.net"
+        )
+      )
+
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params["html_content"] == ~s|<img src="cid:logo@cdn.example.net">|
+
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
+  # The API splits these fields on commas before it parses quoted display names.
+  test "a comma in a recipient display name is rejected before sending", %{config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to({"Rogers, Steve", "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    assert TurboSMTP.deliver(email, config) == {:error, {:invalid_recipient, "Rogers, Steve"}}
+  end
+
+  test "a comma in the sender display name is allowed", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"Stark, Tony", "tony.stark@example.com"})
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params["from"] == "Stark, Tony <tony.stark@example.com>"
+
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
+  test "deliver/1 with 4xx response", %{bypass: bypass, config: config, valid_email: email} do
+    error = ~s/{"message": "invalid request", "errors": ["missing recipients (to)"]}/
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 400, error))
+
+    assert TurboSMTP.deliver(email, config) ==
+             {:error,
+              {400, %{"message" => "invalid request", "errors" => ["missing recipients (to)"]}}}
+  end
+
+  test "deliver/1 with 401 response", %{bypass: bypass, config: config, valid_email: email} do
+    error = ~s/{"errorCode": 401, "message": "Wrong credentials"}/
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 401, error))
+
+    assert TurboSMTP.deliver(email, config) ==
+             {:error, {401, %{"errorCode" => 401, "message" => "Wrong credentials"}}}
+  end
+
+  test "deliver/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 500, ""))
+
+    assert TurboSMTP.deliver(email, config) == {:error, {500, ""}}
+  end
+
+  test "validate_config/1 with valid config", %{config: config} do
+    assert TurboSMTP.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise(
+      ArgumentError,
+      """
+      expected [:consumer_secret, :consumer_key] to be set, got: []
+      """,
+      fn ->
+        TurboSMTP.validate_config([])
+      end
+    )
+  end
+end

--- a/test/swoosh/adapters/turbo_smtp_test.exs
+++ b/test/swoosh/adapters/turbo_smtp_test.exs
@@ -101,6 +101,31 @@ defmodule Swoosh.Adapters.TurboSMTPTest do
     assert {:ok, _} = TurboSMTP.deliver(email, config)
   end
 
+  test "multiple reply_to addresses are joined into a single header", %{
+    bypass: bypass,
+    config: config
+  } do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> reply_to([{"Pepper Potts", "pepper@example.com"}, "happy@example.com"])
+
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params["custom_headers"] == %{
+               "Reply-To" => "Pepper Potts <pepper@example.com>,happy@example.com"
+             }
+
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
   test "deliver/1 with provider options returns :ok", %{bypass: bypass, config: config} do
     email =
       new()
@@ -184,6 +209,43 @@ defmodule Swoosh.Adapters.TurboSMTPTest do
       # The unrelated `logo.png.bak` reference must not be caught by the rewrite.
       assert conn.body_params["html_content"] ==
                ~s|<img src="cid:logo.png@example.com"> and <img src="cid:logo.png.bak">|
+
+      make_response(conn)
+    end)
+
+    assert {:ok, _} = TurboSMTP.deliver(email, config)
+  end
+
+  test "multiple inline attachments are all qualified", %{
+    bypass: bypass,
+    config: config
+  } do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body(~s|<img src="cid:logo.png"> and <img src="cid:banner.png">|)
+      |> attachment(
+        Attachment.new({:data, "img1"},
+          filename: "logo.png",
+          content_type: "image/png",
+          type: :inline
+        )
+      )
+      |> attachment(
+        Attachment.new({:data, "img2"},
+          filename: "banner.png",
+          content_type: "image/png",
+          type: :inline
+        )
+      )
+
+    Bypass.expect_once(bypass, "POST", "/api/v2/mail/send", fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params["html_content"] ==
+               ~s|<img src="cid:logo.png@example.com"> and <img src="cid:banner.png@example.com">|
 
       make_response(conn)
     end)

--- a/test/swoosh/adapters/turbo_smtp_test.exs
+++ b/test/swoosh/adapters/turbo_smtp_test.exs
@@ -333,6 +333,26 @@ defmodule Swoosh.Adapters.TurboSMTPTest do
              {:error, {401, %{"errorCode" => 401, "message" => "Wrong credentials"}}}
   end
 
+  test "an unexpected status is an error tuple, never a raise", %{
+    bypass: bypass,
+    config: config,
+    valid_email: email
+  } do
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 302, "moved"))
+
+    assert TurboSMTP.deliver(email, config) == {:error, {302, "moved"}}
+  end
+
+  test "a 2xx body that is not JSON reports its own status", %{
+    bypass: bypass,
+    config: config,
+    valid_email: email
+  } do
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 202, "queued"))
+
+    assert TurboSMTP.deliver(email, config) == {:error, {202, "queued"}}
+  end
+
   test "deliver/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
     Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 500, ""))
 


### PR DESCRIPTION
Adds an adapter for the [TurboSMTP](https://serversmtp.com) API.

I am contributing this on behalf of TurboSMTP, so the provider-specific behaviour below is verified against the live API rather than read off the docs.

```elixir
config :sample, Sample.Mailer,
  adapter: Swoosh.Adapters.TurboSMTP,
  consumer_key: "my-consumer-key",
  consumer_secret: "my-consumer-secret"
```

`POST /api/v2/mail/send`, credentials as `consumerKey` / `consumerSecret` headers. TurboSMTP has exactly two regions; the EU one is reached by pointing `base_url` at `https://api.eu.turbo-smtp.com/api/v2`, which follows what Brevo, Scaleway and Lettermint already do rather than adding a new config key.

## Two provider quirks the adapter absorbs

**Inline images.** TurboSMTP composes each inline part's Content-ID as `<content_id@sender-domain>` while `content_id` travels bare, so Swoosh's documented `<img src="cid:file.png">` never matches and the image is delivered as an ordinary attachment. The send returns 200 either way, which is what makes it hard to spot. The adapter qualifies `cid:` references with the sender's domain and leaves a `cid` that already carries one alone.

Verified end to end against the live API with two otherwise identical mails. Only the qualification differs:

| | HTML reference | Thunderbird reports |
|---|---|---|
| through the adapter | `cid:swoosh.png@sender-domain` | 1 embedded image, rendered in the body |
| bare `cid:` | `cid:swoosh.png` | 1 file attached, body gap |

**Commas in recipient display names.** `to`, `cc` and `bcc` are split on commas before RFC 5322 quoted strings are parsed, so `{"Doe, John", "j@example.com"}` is torn apart. The live API answers:

```
400 {"message":"error","errors":[["'\"Doe' 'to' email not valid"]]}
```

That names a fragment of the display name, so the adapter returns `{:error, {:invalid_recipient, name}}` before sending instead. `from` and `reply_to` are not comma-split and keep accepting it.

## Verification

`mix test`, `mix format --check-formatted` and `mix deps.unlock --check-unused` are green on Elixir 1.20, and the suite also passes on 1.18. 14 adapter tests cover the payload mapping, both quirks, provider options, and the 4xx/5xx paths.

Live sends against `api.turbo-smtp.com`, all returning real message ids: plain text, HTML with Reply-To and a custom header, an inline image, and one through the EU host.
