### PR TITLE
Add MailKite adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### ✨ Features
+
+- Add MailKite adapter @bucabay
+
 ## 1.28.0
 
 ### ✨ Features

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ included:
 | Azure Communication Services | [Swoosh.Adapters.AzureCommunicationServices](https://hexdocs.pm/swoosh/Swoosh.Adapters.AzureCommunicationServices.html#content) |                  |
 | AhaSend                      | [Swoosh.Adapters.AhaSend](https://hexdocs.pm/swoosh/Swoosh.Adapters.AhaSend.html#content)                                       | EU               |
 | TurboSMTP                    | [Swoosh.Adapters.TurboSMTP](https://hexdocs.pm/swoosh/Swoosh.Adapters.TurboSMTP.html#content)                                   | EU               |
+| MailKite                     | [Swoosh.Adapters.MailKite](https://hexdocs.pm/swoosh/Swoosh.Adapters.MailKite.html#content)                                     |                  |
 | ------                       | **Below are not fully featured services**                                                                                       | ------           |
 | Loops                        | [Swoosh.Adapters.Loops](https://hexdocs.pm/swoosh/Swoosh.Adapters.Loops.html#content)                                           |                  |
 | PostUp                       | [Swoosh.Adapters.PostUp](https://hexdocs.pm/swoosh/Swoosh.Adapters.PostUp.html#content)                                         |                  |

--- a/lib/swoosh/adapters/mailkite.ex
+++ b/lib/swoosh/adapters/mailkite.ex
@@ -1,0 +1,230 @@
+defmodule Swoosh.Adapters.MailKite do
+  @moduledoc ~S"""
+  An adapter that sends email using the MailKite API.
+
+  For reference: [MailKite API docs](https://mailkite.dev/docs/api-reference)
+
+  **This adapter requires an API Client.** Swoosh comes with Hackney, Finch and Req out of the box.
+  See the [installation section](https://hexdocs.pm/swoosh/Swoosh.html#module-installation)
+  for details.
+
+  ## Example
+
+      # config/config.exs
+      config :sample, Sample.Mailer,
+        adapter: Swoosh.Adapters.MailKite,
+        api_key: "mk_live_my-api-key"
+
+      # lib/sample/mailer.ex
+      defmodule Sample.Mailer do
+        use Swoosh.Mailer, otp_app: :sample
+      end
+
+  The `from` address must belong to a domain verified in your MailKite account.
+
+  ## Attachments
+
+  Regular attachments are sent inline as base64. MailKite attachments carry no
+  `Content-ID`, so inline (`type: :inline`) attachments cannot be expressed and
+  `deliver/2` returns `{:error, :inline_attachments_not_supported}` rather than
+  silently sending them as regular attachments. Host the image and reference it
+  by URL in your HTML instead.
+
+  ## Using with provider options
+
+      import Swoosh.Email
+
+      new()
+      |> from("nora@example.com")
+      |> to("shushu@example.com")
+      |> subject("Hello, Wally!")
+      |> text_body("Hello")
+      |> put_provider_option(:metadata, %{order_id: "ord_8812"})
+      |> put_provider_option(:track_opens, true)
+      |> put_provider_option(:scheduled_at, "2030-01-01T00:00:00Z")
+
+  ## Provider Options
+
+    * `metadata` (map) - `metadata`, scalar key/value pairs stored server-side on
+      the message and echoed back on reads; never emitted as a MIME header
+
+    * `template_id` (string) - `templateId`, send from a saved MailKite template
+      (`tpl_…` or `base_…`); explicit subject/html/text override the template's
+
+    * `template_data` (map) - `templateData`, values substituted into the
+      template's `{{merge_tags}}`
+
+    * `in_reply_to` (string) - `inReplyTo`, the `Message-ID` this email replies
+      to, so MailKite sets the threading headers
+
+    * `scheduled_at` (string or integer) - `scheduledAt`, send later: an ISO 8601
+      timestamp or a millisecond epoch. The response then carries the scheduled
+      send id and `status: "scheduled"`
+
+    * `track_opens` (boolean) - `trackOpens`, override the sending domain's
+      open-tracking default for this email
+
+    * `track_clicks` (boolean) - `trackClicks`, override the sending domain's
+      click-tracking default for this email
+
+  """
+
+  use Swoosh.Adapter, required_config: [:api_key]
+
+  alias Swoosh.Email
+
+  @base_url "https://api.mailkite.dev"
+  @api_endpoint "/v1/send"
+
+  @provider_options %{
+    metadata: "metadata",
+    template_id: "templateId",
+    template_data: "templateData",
+    in_reply_to: "inReplyTo",
+    scheduled_at: "scheduledAt",
+    track_opens: "trackOpens",
+    track_clicks: "trackClicks"
+  }
+
+  def deliver(%Email{} = email, config \\ []) do
+    with {:ok, payload} <- prepare_payload(email) do
+      headers = prepare_headers(config)
+      body = Swoosh.json_library().encode!(payload)
+      url = [base_url(config), @api_endpoint]
+
+      url |> Swoosh.ApiClient.post(headers, body, email) |> handle_response()
+    end
+  end
+
+  defp base_url(config), do: config[:base_url] || @base_url
+
+  defp prepare_headers(config) do
+    [
+      {"Accept", "application/json"},
+      {"Content-Type", "application/json"},
+      {"User-Agent", "swoosh/#{Swoosh.version()}"},
+      {"Authorization", "Bearer #{config[:api_key]}"}
+    ]
+  end
+
+  defp prepare_payload(%{attachments: attachments} = email) do
+    if Enum.any?(attachments, &(&1.type == :inline)) do
+      {:error, :inline_attachments_not_supported}
+    else
+      payload =
+        %{}
+        |> prepare_from(email)
+        |> prepare_to(email)
+        |> prepare_cc(email)
+        |> prepare_bcc(email)
+        |> prepare_reply_to(email)
+        |> prepare_subject(email)
+        |> prepare_text_content(email)
+        |> prepare_html_content(email)
+        |> prepare_email_headers(email)
+        |> prepare_attachments(email)
+        |> prepare_provider_options(email)
+
+      {:ok, payload}
+    end
+  end
+
+  defp prepare_from(payload, %{from: from}), do: Map.put(payload, "from", format_address(from))
+
+  defp prepare_to(payload, %{to: to}), do: Map.put(payload, "to", Enum.map(to, &format_address/1))
+
+  defp prepare_cc(payload, %{cc: []}), do: payload
+  defp prepare_cc(payload, %{cc: cc}), do: Map.put(payload, "cc", Enum.map(cc, &format_address/1))
+
+  defp prepare_bcc(payload, %{bcc: []}), do: payload
+
+  defp prepare_bcc(payload, %{bcc: bcc}),
+    do: Map.put(payload, "bcc", Enum.map(bcc, &format_address/1))
+
+  # MailKite takes a single Reply-To address; a list is joined the way a mail
+  # client would render the header.
+  defp prepare_reply_to(payload, %{reply_to: nil}), do: payload
+
+  defp prepare_reply_to(payload, %{reply_to: reply_to}) when is_list(reply_to) do
+    Map.put(payload, "replyTo", Enum.map_join(reply_to, ", ", &format_address/1))
+  end
+
+  defp prepare_reply_to(payload, %{reply_to: reply_to}) do
+    Map.put(payload, "replyTo", format_address(reply_to))
+  end
+
+  defp prepare_subject(payload, %{subject: subject}) when subject in [nil, ""], do: payload
+  defp prepare_subject(payload, %{subject: subject}), do: Map.put(payload, "subject", subject)
+
+  defp prepare_text_content(payload, %{text_body: nil}), do: payload
+  defp prepare_text_content(payload, %{text_body: text}), do: Map.put(payload, "text", text)
+
+  defp prepare_html_content(payload, %{html_body: nil}), do: payload
+  defp prepare_html_content(payload, %{html_body: html}), do: Map.put(payload, "html", html)
+
+  defp prepare_email_headers(payload, %{headers: headers}) when map_size(headers) == 0,
+    do: payload
+
+  defp prepare_email_headers(payload, %{headers: headers}),
+    do: Map.put(payload, "headers", headers)
+
+  defp prepare_attachments(payload, %{attachments: []}), do: payload
+
+  defp prepare_attachments(payload, %{attachments: attachments}) do
+    Map.put(payload, "attachments", Enum.map(attachments, &prepare_attachment/1))
+  end
+
+  defp prepare_attachment(attachment) do
+    %{
+      "filename" => attachment.filename,
+      "contentType" => attachment.content_type,
+      "content" => Swoosh.Attachment.get_content(attachment, :base64)
+    }
+  end
+
+  defp prepare_provider_options(payload, %{provider_options: provider_options}) do
+    Enum.reduce(@provider_options, payload, fn {option, key}, acc ->
+      case Map.fetch(provider_options, option) do
+        {:ok, value} -> Map.put(acc, key, value)
+        :error -> acc
+      end
+    end)
+  end
+
+  # Display names are quoted unless they are a plain run of atom characters,
+  # matching how MailKite's other integrations render RFC 5322 mailboxes.
+  defp format_address({name, address}) when name in [nil, ""], do: address
+
+  defp format_address({name, address}) do
+    if Regex.match?(~r/\A[A-Za-z0-9 .'\-]+\z/, name) do
+      "#{name} <#{address}>"
+    else
+      escaped = String.replace(name, ~r/(["\\])/, "\\\\\\1")
+      "\"#{escaped}\" <#{address}>"
+    end
+  end
+
+  defp format_address(address) when is_binary(address), do: address
+
+  defp handle_response({:ok, code, _headers, body}) when code in 200..299 do
+    case Swoosh.json_library().decode(body) do
+      {:ok, %{"id" => id} = response} ->
+        {:ok, %{id: id, status: response["status"]}}
+
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, _} ->
+        {:error, {code, body}}
+    end
+  end
+
+  defp handle_response({:ok, code, _headers, body}) do
+    case Swoosh.json_library().decode(body) do
+      {:ok, error} -> {:error, {code, error}}
+      {:error, _} -> {:error, {code, body}}
+    end
+  end
+
+  defp handle_response({:error, reason}), do: {:error, reason}
+end

--- a/test/swoosh/adapters/mailkite_test.exs
+++ b/test/swoosh/adapters/mailkite_test.exs
@@ -1,0 +1,396 @@
+defmodule Swoosh.Adapters.MailKiteTest do
+  use Swoosh.AdapterCase, async: true
+
+  import Swoosh.Email
+  import Plug.Conn, only: [get_req_header: 2]
+  alias Swoosh.Adapters.MailKite
+
+  @send_path "/v1/send"
+  @message_id "msg_0f256de268de4c098e42403771deb3fa"
+  @success_response ~s({"id": "#{@message_id}", "status": "sent"})
+
+  setup do
+    bypass = Bypass.open()
+
+    config = [
+      api_key: "mk_live_test-key",
+      base_url: "http://localhost:#{bypass.port}"
+    ]
+
+    valid_email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+      |> text_body("Hello")
+
+    {:ok, bypass: bypass, config: config, valid_email: valid_email}
+  end
+
+  defp make_response(conn, body \\ @success_response), do: Plug.Conn.resp(conn, 202, body)
+
+  defp success_result, do: {:ok, %{id: @message_id, status: "sent"}}
+
+  test "successful delivery returns :ok", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => "tony.stark@example.com",
+               "to" => ["steve.rogers@example.com"],
+               "subject" => "Hello, Avengers!",
+               "html" => "<h1>Hello</h1>",
+               "text" => "Hello"
+             }
+
+      assert get_req_header(conn, "authorization") == ["Bearer mk_live_test-key"]
+      assert get_req_header(conn, "content-type") == ["application/json"]
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "text-only delivery returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => "tony.stark@example.com",
+               "to" => ["steve.rogers@example.com"],
+               "subject" => "Hello, Avengers!",
+               "text" => "Hello"
+             }
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "html-only delivery returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body("<h1>Hello</h1>")
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => "tony.stark@example.com",
+               "to" => ["steve.rogers@example.com"],
+               "subject" => "Hello, Avengers!",
+               "html" => "<h1>Hello</h1>"
+             }
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with recipient names returns :ok", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from({"T Stark", "tony.stark@example.com"})
+      |> to({"Steve Rogers", "steve.rogers@example.com"})
+      |> reply_to({"Bruce Banner", "hulk.smash@example.com"})
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => "T Stark <tony.stark@example.com>",
+               "to" => ["Steve Rogers <steve.rogers@example.com>"],
+               "replyTo" => "Bruce Banner <hulk.smash@example.com>",
+               "subject" => "Hello, Avengers!",
+               "text" => "Hello"
+             }
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 quotes display names that are not plain atoms", %{
+    bypass: bypass,
+    config: config
+  } do
+    email =
+      new()
+      |> from({"Stark, Tony", "tony.stark@example.com"})
+      |> to({~s(Steve "Cap" Rogers), "steve.rogers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "from" => ~s("Stark, Tony" <tony.stark@example.com>),
+               "to" => [~s("Steve \\"Cap\\" Rogers" <steve.rogers@example.com>)]
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with cc, bcc and multiple recipients returns :ok", %{
+    bypass: bypass,
+    config: config
+  } do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> to({"Bruce Banner", "hulk.smash@example.com"})
+      |> cc("thor.odinson@example.com")
+      |> bcc({"Henry McCoy", "beast.avengers@example.com"})
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "to" => ["Bruce Banner <hulk.smash@example.com>", "steve.rogers@example.com"],
+               "cc" => ["thor.odinson@example.com"],
+               "bcc" => ["Henry McCoy <beast.avengers@example.com>"]
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with several reply_to addresses joins them", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> reply_to([{"Pepper Potts", "pepper@example.com"}, "happy@example.com"])
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{"replyTo" => "Pepper Potts <pepper@example.com>, happy@example.com"} =
+               conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with custom headers", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> header("X-Entity-Ref-ID", "ord_8812")
+      |> header("List-Unsubscribe", "<mailto:unsub@example.com>")
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "headers" => %{
+                 "X-Entity-Ref-ID" => "ord_8812",
+                 "List-Unsubscribe" => "<mailto:unsub@example.com>"
+               }
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with an attachment", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> attachment(
+        Swoosh.Attachment.new({:data, "Test content"},
+          filename: "test.txt",
+          content_type: "text/plain"
+        )
+      )
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "attachments" => [
+                 %{
+                   "filename" => "test.txt",
+                   "contentType" => "text/plain",
+                   "content" => "VGVzdCBjb250ZW50"
+                 }
+               ]
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with an inline attachment returns an error without a request", %{
+    config: config
+  } do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> html_body(~s(<img src="cid:logo">))
+      |> attachment(
+        Swoosh.Attachment.new({:data, "Test content"},
+          filename: "logo.png",
+          content_type: "image/png",
+          type: :inline,
+          cid: "logo"
+        )
+      )
+
+    assert MailKite.deliver(email, config) == {:error, :inline_attachments_not_supported}
+  end
+
+  test "deliver/1 with provider options", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> subject("Hello, Avengers!")
+      |> text_body("Hello")
+      |> put_provider_option(:metadata, %{order_id: "ord_8812", tenant: "acme"})
+      |> put_provider_option(:in_reply_to, "<original@example.com>")
+      |> put_provider_option(:track_opens, true)
+      |> put_provider_option(:track_clicks, false)
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{
+               "metadata" => %{"order_id" => "ord_8812", "tenant" => "acme"},
+               "inReplyTo" => "<original@example.com>",
+               "trackOpens" => true,
+               "trackClicks" => false
+             } = conn.body_params
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with a template", %{bypass: bypass, config: config} do
+    email =
+      new()
+      |> from("tony.stark@example.com")
+      |> to("steve.rogers@example.com")
+      |> put_provider_option(:template_id, "tpl_welcome")
+      |> put_provider_option(:template_data, %{name: "Steve"})
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert conn.body_params == %{
+               "from" => "tony.stark@example.com",
+               "to" => ["steve.rogers@example.com"],
+               "templateId" => "tpl_welcome",
+               "templateData" => %{"name" => "Steve"}
+             }
+
+      make_response(conn)
+    end)
+
+    assert MailKite.deliver(email, config) == success_result()
+  end
+
+  test "deliver/1 with a scheduled send", %{bypass: bypass, config: config, valid_email: email} do
+    email = put_provider_option(email, :scheduled_at, "2030-01-01T00:00:00Z")
+
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      conn = parse(conn)
+
+      assert %{"scheduledAt" => "2030-01-01T00:00:00Z"} = conn.body_params
+
+      make_response(
+        conn,
+        ~s({"id": "ssnd_01hz", "status": "scheduled", "scheduledAt": 1893456000000})
+      )
+    end)
+
+    assert MailKite.deliver(email, config) == {:ok, %{id: "ssnd_01hz", status: "scheduled"}}
+  end
+
+  test "deliver/1 with 400 response", %{bypass: bypass, config: config, valid_email: email} do
+    error = ~s({"error": "from must be an address on a verified domain"})
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 400, error))
+
+    assert MailKite.deliver(email, config) ==
+             {:error, {400, %{"error" => "from must be an address on a verified domain"}}}
+  end
+
+  test "deliver/1 with 401 response", %{bypass: bypass, config: config, valid_email: email} do
+    error = ~s({"error": "invalid api key"})
+
+    Bypass.expect_once(bypass, &Plug.Conn.resp(&1, 401, error))
+
+    assert MailKite.deliver(email, config) == {:error, {401, %{"error" => "invalid api key"}}}
+  end
+
+  test "deliver/1 with 5xx response", %{bypass: bypass, config: config, valid_email: email} do
+    Bypass.expect_once(bypass, "POST", @send_path, fn conn ->
+      assert @send_path == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 500, "")
+    end)
+
+    assert MailKite.deliver(email, config) == {:error, {500, ""}}
+  end
+
+  test "validate_config/1 with valid config", %{config: config} do
+    assert MailKite.validate_config(config) == :ok
+  end
+
+  test "validate_config/1 with invalid config" do
+    assert_raise(
+      ArgumentError,
+      """
+      expected [:api_key] to be set, got: []
+      """,
+      fn ->
+        MailKite.validate_config([])
+      end
+    )
+  end
+end


### PR DESCRIPTION
Adds an adapter for the [MailKite](https://mailkite.dev) API.

I work on MailKite, so this is a vendor contribution and I'll maintain the adapter going forward (API changes, bug reports, provider options).

```elixir
config :sample, Sample.Mailer,
  adapter: Swoosh.Adapters.MailKite,
  api_key: "mk_live_..."
```

`POST https://api.mailkite.dev/v1/send`, Bearer key, JSON body. Same shape as the Lettermint / AhaSend adapters: `from`/`to`/`cc`/`bcc`/`reply_to`/`subject`/`text_body`/`html_body`/`headers`/attachments map onto the documented request fields, `base_url` is overridable for tests, and the response is normalised to `{:ok, %{id: "msg_…", status: "sent"}}`. The API accepts RFC 5322 mailboxes, so `{name, address}` tuples are rendered as `Name <address>` (quoted when the name is not a plain atom run — same rule as our nodemailer transport).

## Two API details the adapter absorbs

**Reply-To is a single field.** MailKite's `replyTo` is one string, while `Swoosh.Email.reply_to/2` also accepts a list. A list is joined with `", "` — the way a mail client would render the header — instead of dropping addresses or raising. Covered by a test.

**No inline (CID) attachments.** MailKite attachments carry no `Content-ID`, so an email with a `type: :inline` attachment cannot be expressed. Rather than silently sending it as a regular attachment (which would leave a broken `cid:` reference in the HTML), `deliver/2` returns `{:error, :inline_attachments_not_supported}` before any request is made, and the moduledoc says so. Regular attachments are sent base64-inline.

## Provider options

`metadata`, `template_id` / `template_data`, `in_reply_to`, `scheduled_at`, `track_opens`, `track_clicks` — each maps to the corresponding camelCase API field, documented in the moduledoc.

## Testing

- `test/swoosh/adapters/mailkite_test.exs`: 18 tests against Bypass (request shape for text/html/both, names + quoting, cc/bcc, multi reply-to, custom headers, attachment, inline-attachment error, provider options, template send, scheduled send, 400/401/5xx, `validate_config/1`).
- `mix test`: 666 passed, 0 failures on this branch (Elixir 1.20 / OTP 28).
- `mix compile --warnings-as-errors` and `mix format --check-formatted` clean.

README adapter table and CHANGELOG (Unreleased) updated. No changes outside the new adapter and its test.

Happy to adjust anything to match house style.
